### PR TITLE
feat(bulletin): add structured error hierarchy

### DIFF
--- a/product-sdk/packages/bulletin/src/authorization.ts
+++ b/product-sdk/packages/bulletin/src/authorization.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@parity/product-sdk-logger";
 import { Enum } from "polkadot-api";
 
+import { BulletinAuthorizationError } from "./errors.js";
 import type { AuthorizationStatus, BulletinApi } from "./types.js";
 
 const log = createLogger("bulletin");
@@ -54,7 +55,7 @@ export async function checkAuthorization(
         );
     } catch (error) {
         log.error("checkAuthorization: query failed", { address, error });
-        throw new Error(`Failed to check authorization for ${address}`, { cause: error });
+        throw new BulletinAuthorizationError(address, error);
     }
 
     if (!auth) {
@@ -150,7 +151,7 @@ if (import.meta.vitest) {
             expect(status.expiration).toBe(12345);
         });
 
-        test("throws with contextual error when query fails", async () => {
+        test("throws BulletinAuthorizationError when query fails", async () => {
             const api = {
                 query: {
                     TransactionStorage: {
@@ -162,9 +163,9 @@ if (import.meta.vitest) {
             } as unknown as BulletinApi;
 
             const err = await checkAuthorization(api, "5GrwvaEF...").catch((e: unknown) => e);
-            expect(err).toBeInstanceOf(Error);
-            const error = err as Error;
-            expect(error.message).toBe("Failed to check authorization for 5GrwvaEF...");
+            expect(err).toBeInstanceOf(BulletinAuthorizationError);
+            const error = err as BulletinAuthorizationError;
+            expect(error.address).toBe("5GrwvaEF...");
             expect(error.cause).toBeInstanceOf(Error);
             expect((error.cause as Error).message).toBe("RPC connection lost");
         });

--- a/product-sdk/packages/bulletin/src/cid.ts
+++ b/product-sdk/packages/bulletin/src/cid.ts
@@ -3,6 +3,8 @@ import { createLogger } from "@parity/product-sdk-logger";
 import { CID } from "multiformats/cid";
 import * as Digest from "multiformats/hashes/digest";
 
+import { BulletinCidError } from "./errors.js";
+
 const log = createLogger("bulletin");
 
 /**
@@ -67,12 +69,13 @@ export function computeCid(data: Uint8Array): string {
 export function cidToPreimageKey(cid: string): `0x${string}` {
     const parsed = CID.parse(cid);
     if (parsed.version !== 1) {
-        throw new Error(`Expected CIDv1, got CIDv${parsed.version}`);
+        throw new BulletinCidError(`Expected CIDv1, got CIDv${parsed.version}`, cid);
     }
     if (!SUPPORTED_HASH_CODES.has(parsed.multihash.code)) {
-        throw new Error(
+        throw new BulletinCidError(
             `Unsupported hash algorithm 0x${parsed.multihash.code.toString(16)}; ` +
                 `expected one of: ${[...SUPPORTED_HASH_CODES].map((c) => `0x${c.toString(16)}`).join(", ")}`,
+            cid,
         );
     }
     return `0x${bytesToHex(parsed.multihash.digest)}`;
@@ -125,19 +128,19 @@ export function hashToCid(
     codec: CidCodec = CidCodec.Raw,
 ): string {
     if (hexHash.length !== EXPECTED_HEX_LENGTH) {
-        throw new Error(
+        throw new BulletinCidError(
             `Expected a 0x-prefixed 32-byte hex hash (${EXPECTED_HEX_LENGTH} chars), ` +
                 `got ${hexHash.length} chars`,
         );
     }
     if (!SUPPORTED_HASH_CODES.has(hashCode)) {
-        throw new Error(
+        throw new BulletinCidError(
             `Unsupported hash algorithm 0x${hashCode.toString(16)}; ` +
                 `expected one of: ${[...SUPPORTED_HASH_CODES].map((c) => `0x${c.toString(16)}`).join(", ")}`,
         );
     }
     if (!SUPPORTED_CODEC_CODES.has(codec)) {
-        throw new Error(
+        throw new BulletinCidError(
             `Unsupported CID codec 0x${codec.toString(16)}; ` +
                 `expected one of: ${[...SUPPORTED_CODEC_CODES].map((c) => `0x${c.toString(16)}`).join(", ")}`,
         );
@@ -222,17 +225,17 @@ if (import.meta.vitest) {
             expect(key).toBe(`0x${bytesToHex(hash)}`);
         });
 
-        test("throws for CIDv0 input", () => {
+        test("throws BulletinCidError for CIDv0 input", () => {
             const hash = new Uint8Array(32).fill(0xab);
             const cidV0 = CID.create(0, 0x70, Digest.create(HashAlgorithm.Sha2_256, hash));
-            expect(() => cidToPreimageKey(cidV0.toString())).toThrow("Expected CIDv1");
+            expect(() => cidToPreimageKey(cidV0.toString())).toThrow(BulletinCidError);
         });
 
-        test("throws for CIDv1 with unsupported hash algorithm", () => {
+        test("throws BulletinCidError for CIDv1 with unsupported hash algorithm", () => {
             const unsupportedCode = 0x99;
             const hash = new Uint8Array(32).fill(0xab);
             const cidV1 = CID.createV1(CidCodec.Raw, Digest.create(unsupportedCode, hash));
-            expect(() => cidToPreimageKey(cidV1.toString())).toThrow("Unsupported hash algorithm");
+            expect(() => cidToPreimageKey(cidV1.toString())).toThrow(BulletinCidError);
         });
     });
 
@@ -306,13 +309,13 @@ if (import.meta.vitest) {
             expect(CID.parse(cid).code).toBe(CidCodec.DagCbor);
         });
 
-        test("throws for hex that is too short", () => {
-            expect(() => hashToCid("0xabcd" as `0x${string}`)).toThrow("66 chars");
+        test("throws BulletinCidError for hex that is too short", () => {
+            expect(() => hashToCid("0xabcd" as `0x${string}`)).toThrow(BulletinCidError);
         });
 
-        test("throws for hex that is too long", () => {
+        test("throws BulletinCidError for hex that is too long", () => {
             const tooLong = `0x${"aa".repeat(33)}` as `0x${string}`;
-            expect(() => hashToCid(tooLong)).toThrow("66 chars");
+            expect(() => hashToCid(tooLong)).toThrow(BulletinCidError);
         });
 
         test("throws for non-hex characters", () => {
@@ -320,17 +323,15 @@ if (import.meta.vitest) {
             expect(() => hashToCid(bad)).toThrow();
         });
 
-        test("throws for unsupported hash algorithm", () => {
+        test("throws BulletinCidError for unsupported hash algorithm", () => {
             const hex = `0x${"ab".repeat(32)}` as `0x${string}`;
-            expect(() => hashToCid(hex, 0x99 as HashAlgorithm)).toThrow(
-                "Unsupported hash algorithm",
-            );
+            expect(() => hashToCid(hex, 0x99 as HashAlgorithm)).toThrow(BulletinCidError);
         });
 
-        test("throws for unsupported codec", () => {
+        test("throws BulletinCidError for unsupported codec", () => {
             const hex = `0x${"ab".repeat(32)}` as `0x${string}`;
             expect(() => hashToCid(hex, HashAlgorithm.Blake2b256, 0x99 as CidCodec)).toThrow(
-                "Unsupported CID codec",
+                BulletinCidError,
             );
         });
     });

--- a/product-sdk/packages/bulletin/src/errors.ts
+++ b/product-sdk/packages/bulletin/src/errors.ts
@@ -1,0 +1,235 @@
+/**
+ * Base class for all Bulletin Chain errors.
+ *
+ * Use `instanceof BulletinError` to catch any bulletin-related error.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await bulletin.upload(data);
+ * } catch (e) {
+ *   if (e instanceof BulletinError) {
+ *     console.error("Bulletin operation failed:", e.message);
+ *   }
+ * }
+ * ```
+ */
+export class BulletinError extends Error {
+    constructor(message: string, options?: ErrorOptions) {
+        super(message, options);
+        this.name = "BulletinError";
+    }
+}
+
+/**
+ * The host preimage API is unavailable.
+ *
+ * Thrown when bulletin operations require the host container but it's not available.
+ * This typically means the SDK is running outside of Polkadot Browser/Desktop.
+ */
+export class BulletinHostUnavailableError extends BulletinError {
+    constructor(operation: "upload" | "query") {
+        super(
+            `Host preimage API unavailable for ${operation}. Ensure you are running inside a host container (Polkadot Browser / Desktop).`,
+        );
+        this.name = "BulletinHostUnavailableError";
+    }
+}
+
+/**
+ * The host preimage lookup timed out.
+ *
+ * The host was unable to retrieve the requested content within the timeout period.
+ * The content may still become available later.
+ */
+export class BulletinLookupTimeoutError extends BulletinError {
+    /** The CID that was being looked up. */
+    readonly cid: string;
+    /** The timeout duration in milliseconds. */
+    readonly timeoutMs: number;
+
+    constructor(cid: string, timeoutMs: number) {
+        super(`Host preimage lookup timed out after ${timeoutMs}ms for CID: ${cid}`);
+        this.name = "BulletinLookupTimeoutError";
+        this.cid = cid;
+        this.timeoutMs = timeoutMs;
+    }
+}
+
+/**
+ * The host interrupted the preimage lookup.
+ *
+ * The host terminated the lookup subscription, typically after repeated failures
+ * or when the host determines the content is unavailable.
+ */
+export class BulletinLookupInterruptedError extends BulletinError {
+    /** The CID that was being looked up. */
+    readonly cid: string;
+
+    constructor(cid: string) {
+        super(`Host preimage lookup was interrupted for CID: ${cid}`);
+        this.name = "BulletinLookupInterruptedError";
+        this.cid = cid;
+    }
+}
+
+/**
+ * Failed to check authorization status for an account.
+ *
+ * Wraps RPC or query errors that occur when checking if an account
+ * is authorized to store data on the Bulletin Chain.
+ */
+export class BulletinAuthorizationError extends BulletinError {
+    /** The address that was being checked. */
+    readonly address: string;
+
+    constructor(address: string, cause?: unknown) {
+        super(`Failed to check authorization for ${address}`, { cause });
+        this.name = "BulletinAuthorizationError";
+        this.address = address;
+    }
+}
+
+/**
+ * The IPFS gateway for the specified environment is not available.
+ *
+ * Thrown when attempting to use gateway features for a network that
+ * doesn't have a live bulletin gateway yet.
+ */
+export class BulletinGatewayUnavailableError extends BulletinError {
+    /** The environment that was requested. */
+    readonly environment: string;
+
+    constructor(environment: string) {
+        super(`Bulletin gateway for "${environment}" is not yet available`);
+        this.name = "BulletinGatewayUnavailableError";
+        this.environment = environment;
+    }
+}
+
+/**
+ * An IPFS gateway request failed.
+ *
+ * Thrown when a fetch to the IPFS gateway returns a non-OK response.
+ */
+export class BulletinGatewayFetchError extends BulletinError {
+    /** The CID that was being fetched. */
+    readonly cid: string;
+    /** The HTTP status code returned by the gateway. */
+    readonly status: number;
+    /** The HTTP status text returned by the gateway. */
+    readonly statusText: string;
+
+    constructor(cid: string, status: number, statusText: string) {
+        super(`Gateway fetch failed for ${cid}: ${status} ${statusText}`);
+        this.name = "BulletinGatewayFetchError";
+        this.cid = cid;
+        this.status = status;
+        this.statusText = statusText;
+    }
+}
+
+/**
+ * Invalid CID format or version.
+ *
+ * Thrown when a CID string cannot be parsed or has an unexpected version/codec.
+ */
+export class BulletinCidError extends BulletinError {
+    /** The invalid CID string, if available. */
+    readonly cid?: string;
+
+    constructor(message: string, cid?: string) {
+        super(message);
+        this.name = "BulletinCidError";
+        this.cid = cid;
+    }
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    describe("BulletinError hierarchy", () => {
+        test("BulletinError is instanceof Error", () => {
+            const err = new BulletinError("test");
+            expect(err).toBeInstanceOf(Error);
+            expect(err).toBeInstanceOf(BulletinError);
+            expect(err.name).toBe("BulletinError");
+        });
+
+        test("BulletinHostUnavailableError", () => {
+            const err = new BulletinHostUnavailableError("upload");
+            expect(err).toBeInstanceOf(BulletinError);
+            expect(err.name).toBe("BulletinHostUnavailableError");
+            expect(err.message).toContain("upload");
+            expect(err.message).toContain("Host preimage API unavailable");
+        });
+
+        test("BulletinLookupTimeoutError", () => {
+            const err = new BulletinLookupTimeoutError("bafyabc123", 30000);
+            expect(err).toBeInstanceOf(BulletinError);
+            expect(err.name).toBe("BulletinLookupTimeoutError");
+            expect(err.cid).toBe("bafyabc123");
+            expect(err.timeoutMs).toBe(30000);
+            expect(err.message).toContain("30000ms");
+            expect(err.message).toContain("bafyabc123");
+        });
+
+        test("BulletinLookupInterruptedError", () => {
+            const err = new BulletinLookupInterruptedError("bafyabc123");
+            expect(err).toBeInstanceOf(BulletinError);
+            expect(err.name).toBe("BulletinLookupInterruptedError");
+            expect(err.cid).toBe("bafyabc123");
+            expect(err.message).toContain("interrupted");
+        });
+
+        test("BulletinAuthorizationError with cause", () => {
+            const cause = new Error("RPC timeout");
+            const err = new BulletinAuthorizationError("5GrwvaEF...", cause);
+            expect(err).toBeInstanceOf(BulletinError);
+            expect(err.name).toBe("BulletinAuthorizationError");
+            expect(err.address).toBe("5GrwvaEF...");
+            expect(err.cause).toBe(cause);
+        });
+
+        test("BulletinGatewayUnavailableError", () => {
+            const err = new BulletinGatewayUnavailableError("polkadot");
+            expect(err).toBeInstanceOf(BulletinError);
+            expect(err.name).toBe("BulletinGatewayUnavailableError");
+            expect(err.environment).toBe("polkadot");
+            expect(err.message).toContain("polkadot");
+        });
+
+        test("BulletinGatewayFetchError", () => {
+            const err = new BulletinGatewayFetchError("bafyabc", 404, "Not Found");
+            expect(err).toBeInstanceOf(BulletinError);
+            expect(err.name).toBe("BulletinGatewayFetchError");
+            expect(err.cid).toBe("bafyabc");
+            expect(err.status).toBe(404);
+            expect(err.statusText).toBe("Not Found");
+            expect(err.message).toContain("404");
+        });
+
+        test("BulletinCidError", () => {
+            const err = new BulletinCidError("Expected CIDv1, got CIDv0", "Qmabc");
+            expect(err).toBeInstanceOf(BulletinError);
+            expect(err.name).toBe("BulletinCidError");
+            expect(err.cid).toBe("Qmabc");
+        });
+
+        test("all errors can be caught with BulletinError", () => {
+            const errors = [
+                new BulletinHostUnavailableError("query"),
+                new BulletinLookupTimeoutError("cid", 1000),
+                new BulletinLookupInterruptedError("cid"),
+                new BulletinAuthorizationError("addr"),
+                new BulletinGatewayUnavailableError("env"),
+                new BulletinGatewayFetchError("cid", 500, "Error"),
+                new BulletinCidError("bad cid"),
+            ];
+
+            for (const err of errors) {
+                expect(err).toBeInstanceOf(BulletinError);
+            }
+        });
+    });
+}

--- a/product-sdk/packages/bulletin/src/gateway.ts
+++ b/product-sdk/packages/bulletin/src/gateway.ts
@@ -1,3 +1,4 @@
+import { BulletinGatewayFetchError, BulletinGatewayUnavailableError } from "./errors.js";
 import type { Environment, FetchOptions } from "./types.js";
 
 /** Add entries here as bulletin gateways go live on each network. */
@@ -7,11 +8,14 @@ const GATEWAYS: Partial<Record<Environment, string>> = {
 
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 
-/** Get the IPFS gateway URL for an environment. Throws if the network is not yet available. */
+/**
+ * Get the IPFS gateway URL for an environment.
+ * @throws {BulletinGatewayUnavailableError} If the network doesn't have a live gateway yet.
+ */
 export function getGateway(env: Environment): string {
     const gw = GATEWAYS[env];
     if (!gw) {
-        throw new Error(`Bulletin gateway for "${env}" is not yet available`);
+        throw new BulletinGatewayUnavailableError(env);
     }
     return gw;
 }
@@ -43,7 +47,10 @@ export async function cidExists(
     }
 }
 
-/** Fetch raw bytes from the gateway. */
+/**
+ * Fetch raw bytes from the gateway.
+ * @throws {BulletinGatewayFetchError} If the gateway returns a non-OK response.
+ */
 export async function fetchBytes(
     cid: string,
     gateway: string,
@@ -56,7 +63,7 @@ export async function fetchBytes(
     try {
         const response = await fetch(gatewayUrl(cid, gateway), { signal: controller.signal });
         if (!response.ok) {
-            throw new Error(`Gateway returned ${response.status}: ${response.statusText}`);
+            throw new BulletinGatewayFetchError(cid, response.status, response.statusText);
         }
         return new Uint8Array(await response.arrayBuffer());
     } finally {
@@ -88,9 +95,9 @@ if (import.meta.vitest) {
             expect(gw).toMatch(/\/ipfs\/$/);
         });
 
-        test("throws for environments without a live gateway", () => {
-            expect(() => getGateway("polkadot")).toThrow("not yet available");
-            expect(() => getGateway("kusama")).toThrow("not yet available");
+        test("throws BulletinGatewayUnavailableError for environments without a live gateway", () => {
+            expect(() => getGateway("polkadot")).toThrow(BulletinGatewayUnavailableError);
+            expect(() => getGateway("kusama")).toThrow(BulletinGatewayUnavailableError);
         });
     });
 
@@ -148,7 +155,7 @@ if (import.meta.vitest) {
             expect(result).toEqual(payload);
         });
 
-        test("throws on non-ok response", async () => {
+        test("throws BulletinGatewayFetchError on non-ok response", async () => {
             vi.stubGlobal(
                 "fetch",
                 vi.fn().mockResolvedValue({
@@ -157,7 +164,10 @@ if (import.meta.vitest) {
                     statusText: "Internal Server Error",
                 }),
             );
-            await expect(fetchBytes("bafyabc", "https://gw/ipfs/")).rejects.toThrow("500");
+            const err = await fetchBytes("bafyabc", "https://gw/ipfs/").catch((e) => e);
+            expect(err).toBeInstanceOf(BulletinGatewayFetchError);
+            expect(err.cid).toBe("bafyabc");
+            expect(err.status).toBe(500);
         });
 
         test("throws on timeout", async () => {

--- a/product-sdk/packages/bulletin/src/index.ts
+++ b/product-sdk/packages/bulletin/src/index.ts
@@ -7,6 +7,16 @@ export {
     HashAlgorithm,
     CidCodec,
 } from "./cid.js";
+export {
+    BulletinError,
+    BulletinHostUnavailableError,
+    BulletinLookupTimeoutError,
+    BulletinLookupInterruptedError,
+    BulletinAuthorizationError,
+    BulletinGatewayUnavailableError,
+    BulletinGatewayFetchError,
+    BulletinCidError,
+} from "./errors.js";
 export { getGateway, gatewayUrl, cidExists, fetchBytes, fetchJson } from "./gateway.js";
 export { resolveQueryStrategy } from "./resolve-query.js";
 export { queryBytes, queryJson } from "./query.js";

--- a/product-sdk/packages/bulletin/src/resolve-query.ts
+++ b/product-sdk/packages/bulletin/src/resolve-query.ts
@@ -2,6 +2,11 @@ import { getPreimageManager, type PreimageManager } from "@parity/product-sdk-ho
 import { createLogger } from "@parity/product-sdk-logger";
 
 import { cidToPreimageKey, computeCid } from "./cid.js";
+import {
+    BulletinHostUnavailableError,
+    BulletinLookupInterruptedError,
+    BulletinLookupTimeoutError,
+} from "./errors.js";
 
 const log = createLogger("bulletin");
 
@@ -25,7 +30,7 @@ export interface QueryStrategy {
  * IPFS polling automatically.
  *
  * @returns The resolved query strategy.
- * @throws {Error} If the host preimage manager is unavailable.
+ * @throws {BulletinHostUnavailableError} If the host preimage manager is unavailable.
  */
 export async function resolveQueryStrategy(): Promise<QueryStrategy> {
     const preimageManager = await getPreimageManager();
@@ -37,9 +42,7 @@ export async function resolveQueryStrategy(): Promise<QueryStrategy> {
         };
     }
 
-    throw new Error(
-        "Host preimage API unavailable. Ensure you are running inside a host container (Polkadot Browser / Desktop).",
-    );
+    throw new BulletinHostUnavailableError("query");
 }
 
 /**
@@ -77,7 +80,7 @@ export function lookupViaHost(
 
         let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
             settle(() => {
-                reject(new Error(`Host preimage lookup timed out after ${timeoutMs}ms for ${key}`));
+                reject(new BulletinLookupTimeoutError(cid, timeoutMs));
             });
         }, timeoutMs);
 
@@ -90,7 +93,7 @@ export function lookupViaHost(
 
         const cancelInterrupt = sub.onInterrupt(() => {
             settle(() => {
-                reject(new Error(`Host preimage lookup interrupted for ${key}`));
+                reject(new BulletinLookupInterruptedError(cid));
             });
         });
     });
@@ -149,14 +152,21 @@ if (import.meta.vitest) {
             expect(result).toEqual(new Uint8Array([10, 20, 30]));
         });
 
-        test("rejects on timeout", async () => {
+        test("rejects with BulletinLookupTimeoutError on timeout", async () => {
+            const { BulletinLookupTimeoutError } = await import("./errors.js");
             const manager = createMockManager("hang");
-            await expect(lookupViaHost(manager, testCid, 50)).rejects.toThrow("timed out");
+            const err = await lookupViaHost(manager, testCid, 50).catch((e) => e);
+            expect(err).toBeInstanceOf(BulletinLookupTimeoutError);
+            expect(err.cid).toBe(testCid);
+            expect(err.timeoutMs).toBe(50);
         });
 
-        test("rejects on interrupt", async () => {
+        test("rejects with BulletinLookupInterruptedError on interrupt", async () => {
+            const { BulletinLookupInterruptedError } = await import("./errors.js");
             const manager = createMockManager("interrupt");
-            await expect(lookupViaHost(manager, testCid)).rejects.toThrow("interrupted");
+            const err = await lookupViaHost(manager, testCid).catch((e) => e);
+            expect(err).toBeInstanceOf(BulletinLookupInterruptedError);
+            expect(err.cid).toBe(testCid);
         });
 
         test("calls unsubscribe and cancelInterrupt on resolution", async () => {
@@ -168,7 +178,7 @@ if (import.meta.vitest) {
 
         test("calls unsubscribe on interrupt", async () => {
             const manager = createMockManager("interrupt");
-            await expect(lookupViaHost(manager, testCid)).rejects.toThrow("interrupted");
+            await lookupViaHost(manager, testCid).catch(() => {});
             expect(manager.unsubscribe).toHaveBeenCalledOnce();
         });
 

--- a/product-sdk/packages/bulletin/src/resolve-signer.ts
+++ b/product-sdk/packages/bulletin/src/resolve-signer.ts
@@ -2,6 +2,8 @@ import { getPreimageManager } from "@parity/product-sdk-host";
 import { createLogger } from "@parity/product-sdk-logger";
 import type { PolkadotSigner } from "polkadot-api";
 
+import { BulletinHostUnavailableError } from "./errors.js";
+
 const log = createLogger("bulletin");
 
 /**
@@ -41,10 +43,7 @@ export async function resolveUploadStrategy(
         return { kind: "preimage", submit: (data) => preimageManager.submit(data) };
     }
 
-    throw new Error(
-        "Host preimage API unavailable. Ensure you are running inside a host container (Polkadot Browser / Desktop), " +
-            "or provide an explicit signer.",
-    );
+    throw new BulletinHostUnavailableError("upload");
 }
 
 if (import.meta.vitest) {


### PR DESCRIPTION
  Introduce BulletinError base class and specific error types for better
  error handling and debugging:

  - BulletinHostUnavailableError - host preimage API not available
  - BulletinLookupTimeoutError - host lookup timed out (includes cid, timeoutMs)
  - BulletinLookupInterruptedError - host interrupted lookup (includes cid)
  - BulletinAuthorizationError - authorization check failed (includes address, cause)
  - BulletinGatewayUnavailableError - gateway not available (includes environment)
  - BulletinGatewayFetchError - gateway fetch failed (includes cid, status)
  - BulletinCidError - invalid CID format (includes cid)