### PR TITLE
docs: write @packageDocumentation and TSDoc across SDK packages

### DIFF
--- a/docs/scripts/lib/render-symbol.ts
+++ b/docs/scripts/lib/render-symbol.ts
@@ -40,16 +40,15 @@ function collapseWhitespace(s: string): string {
   return s.replace(/\s+/g, " ").trim();
 }
 
-function renderParamsTable(parameters: Parameter[]): string {
-  if (parameters.length === 0) return "_No parameters._";
-  const rows = parameters.map((p) => {
-    const type = collapseWhitespace(typeToString(p.type)).replace(/\|/g, "\\|");
-    const optional = p.flags?.isOptional ? " _(optional)_" : "";
-    const def = p.defaultValue ? ` = \`${p.defaultValue}\`` : "";
-    const desc = collapseWhitespace(renderSummary(p.comment)) || "—";
-    return `| \`${p.name}\`${optional} | \`${type}\`${def} | ${mdEscape(desc)} |`;
-  });
-  return ["| Parameter | Type | Description |", "| --- | --- | --- |", ...rows].join("\n");
+// Render only parameters that carry a description — types and names are already
+// visible in the signature line above. Returns an empty string when none qualify,
+// signalling the caller to skip the whole "Parameters" section.
+function renderParamsList(parameters: Parameter[]): string {
+  const items = parameters
+    .map((p) => ({ name: p.name, desc: collapseWhitespace(renderSummary(p.comment)) }))
+    .filter((p) => p.desc);
+  if (items.length === 0) return "";
+  return items.map((p) => `- \`${p.name}\`: ${mdEscape(p.desc)}`).join("\n");
 }
 
 interface SignatureOpts {
@@ -82,21 +81,22 @@ function renderSignatureDetails(
     out.push(remarks);
   }
 
-  out.push("");
-  out.push(h(opts.subLevel, "Parameters"));
-  out.push("");
-  out.push(renderParamsTable(sig.parameters ?? []));
+  const paramsList = renderParamsList(sig.parameters ?? []);
+  if (paramsList) {
+    out.push("");
+    out.push(h(opts.subLevel, "Parameters"));
+    out.push("");
+    out.push(paramsList);
+  }
 
   if (!opts.hideReturns) {
-    const ret = typeToString(sig.type);
-    if (ret && ret !== "void" && ret !== "undefined") {
-      const returns = (sig.comment?.blockTags ?? []).find((t) => t.tag === "@returns");
-      const retDesc = returns ? renderCommentText(returns.content).trim() : "";
-      const body = `\`${ret}\`${retDesc ? " — " + retDesc : ""}`;
+    const returns = (sig.comment?.blockTags ?? []).find((t) => t.tag === "@returns");
+    const retDesc = returns ? renderCommentText(returns.content).trim() : "";
+    if (retDesc) {
       out.push("");
       out.push(h(opts.subLevel, "Returns"));
       out.push("");
-      out.push(body);
+      out.push(retDesc);
     }
   }
 

--- a/product-sdk/packages/address/src/index.ts
+++ b/product-sdk/packages/address/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * @parity/product-sdk-address — Address handling for accounts that live on both Substrate (SS58) and EVM (H160) chains.
+ *
+ * Convert between formats, validate, normalize SS58 prefixes, and shorten
+ * addresses for display.
+ *
+ * @packageDocumentation
+ */
 export {
     isValidSs58,
     ss58Decode,
@@ -19,4 +27,15 @@ export {
 
 export { truncateAddress, addressesEqual } from "./display.js";
 
-export type { SS58String, HexString } from "@polkadot-api/substrate-bindings";
+/**
+ * An SS58-encoded Substrate address (e.g. `5GrwvaEF...`). The brand marks strings
+ * the SDK has validated, so APIs accepting `SS58String` can skip re-checking.
+ * Construct one via {@link normalizeSs58} or {@link ss58Encode}.
+ */
+export type { SS58String } from "@polkadot-api/substrate-bindings";
+
+/**
+ * A `0x`-prefixed hex string (e.g. `0xdeadbeef`). The SDK uses it for raw byte
+ * values like public keys and EVM addresses.
+ */
+export type { HexString } from "@polkadot-api/substrate-bindings";

--- a/product-sdk/packages/bulletin/src/index.ts
+++ b/product-sdk/packages/bulletin/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * @parity/product-sdk-bulletin — Upload and retrieve content on the Polkadot Bulletin Chain.
+ *
+ * `BulletinClient` covers the common case end-to-end: it picks an upload strategy
+ * (host preimage API or signer-driven `TransactionStorage.store`), computes the
+ * CID locally, submits, and returns the CID alongside a Bulletin gateway URL for
+ * later retrieval. `checkAuthorization` is exposed separately as a pre-flight
+ * helper, and the lower-level CID, gateway, and upload/query primitives are
+ * available for consumers that need to compose those steps themselves.
+ *
+ * @packageDocumentation
+ */
 export { BulletinClient } from "./client.js";
 export { checkAuthorization } from "./authorization.js";
 export {

--- a/product-sdk/packages/chain-client/src/index.ts
+++ b/product-sdk/packages/chain-client/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * @parity/product-sdk-chain-client — Typed, multi-chain Polkadot API client.
+ *
+ * Pick the entry point that fits how much you want to wire up yourself:
+ * `getChainAPI` is the zero-config path with built-in descriptors and RPC endpoints
+ * (Paseo is live today; Polkadot and Kusama are reserved but not yet enabled), and
+ * `createChainClient` is the bring-your-own-descriptors path for custom or
+ * pre-release chains.
+ *
+ * @packageDocumentation
+ */
+
 // Core BYOD API — zero descriptor overhead
 export { createChainClient, destroyAll, getClient, isConnected } from "./clients.js";
 

--- a/product-sdk/packages/contracts/src/index.ts
+++ b/product-sdk/packages/contracts/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * @parity/product-sdk-contracts — Typed contract interactions on Polkadot Asset Hub.
+ *
+ * Drives queries and transactions against deployed contracts from a Contract
+ * Description Metadata (CDM) JSON file. `ContractManager` is the runtime entry
+ * point; `generateContractTypes` produces the typed bindings at build time so
+ * call sites get full inference for parameters and return values.
+ *
+ * @packageDocumentation
+ */
 export { ContractManager, createContract, createContractFromClient } from "./manager.js";
 export { generateContractTypes } from "./codegen.js";
 export {

--- a/product-sdk/packages/contracts/src/types.ts
+++ b/product-sdk/packages/contracts/src/types.ts
@@ -9,11 +9,13 @@ export type { TxResult, SubmitOptions } from "@parity/product-sdk-tx";
 // cdm.json schema
 // ---------------------------------------------------------------------------
 
+/** Pins a target to specific asset-hub and Bulletin chain hashes in `cdm.json`. */
 export interface CdmJsonTarget {
     "asset-hub": string;
     bulletin: string;
 }
 
+/** A deployed contract's on-chain address, ABI, and metadata CID. */
 export interface CdmJsonContract {
     version: number;
     address: HexString;
@@ -21,6 +23,7 @@ export interface CdmJsonContract {
     metadataCid: string;
 }
 
+/** A project's `cdm.json` manifest: declared targets, runtime dependencies, and per-target contract deployments. */
 export interface CdmJson {
     targets: Record<string, CdmJsonTarget>;
     dependencies: Record<string, Record<string, number | string>>;
@@ -31,12 +34,14 @@ export interface CdmJson {
 // ABI types (Solidity-compatible, used by both Ink!/PolkaVM and Solidity)
 // ---------------------------------------------------------------------------
 
+/** An ABI parameter or return value, with support for nested tuple and struct types. */
 export interface AbiParam {
     name: string;
     type: string;
     components?: AbiParam[];
 }
 
+/** One function, constructor, or event in a contract's ABI. */
 export interface AbiEntry {
     type: string;
     name?: string;

--- a/product-sdk/packages/crypto/src/nacl.ts
+++ b/product-sdk/packages/crypto/src/nacl.ts
@@ -1,5 +1,11 @@
 import nacl from "tweetnacl";
 
+/**
+ * Re-export of the upstream `tweetnacl` module — the primitive library that
+ * backs the box helpers in this package. Reach for it directly when you need
+ * raw NaCl operations the SDK doesn't wrap, such as `nacl.box.keyPair()`,
+ * `nacl.randomBytes(n)`, or `nacl.sign(...)`.
+ */
 export { default as nacl } from "tweetnacl";
 
 const PUBKEY_LEN = 32;

--- a/product-sdk/packages/host/src/chains.ts
+++ b/product-sdk/packages/host/src/chains.ts
@@ -3,14 +3,18 @@
  * chain-specific endpoints used by multiple packages.
  */
 
-/** Bulletin chain RPC endpoints by environment. */
+/**
+ * Bulletin Chain RPC endpoints per network environment. Only `paseo` is
+ * populated today; `polkadot` and `kusama` are reserved for when those
+ * Bulletin deployments go live.
+ */
 export const BULLETIN_RPCS = {
     paseo: ["wss://paseo-bulletin-rpc.polkadot.io"],
     polkadot: [] as string[],
     kusama: [] as string[],
 } as const;
 
-/** Default bulletin endpoint (first paseo endpoint). */
+/** Default Bulletin Chain endpoint — the first entry under {@link BULLETIN_RPCS}.paseo. */
 export const DEFAULT_BULLETIN_ENDPOINT: string = BULLETIN_RPCS.paseo[0];
 
 if (import.meta.vitest) {

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * @parity/product-sdk-host — Detect and talk to the Polkadot Desktop/Mobile host container.
+ *
+ * Use `isInsideContainer` to branch behavior when running embedded vs. standalone,
+ * and `getHostLocalStorage`, `getHostProvider`, and `getStatementStore` to reach
+ * the storage, signer, and statement-store APIs the host injects.
+ *
+ * @packageDocumentation
+ */
 export {
     isInsideContainer,
     isInsideContainerSync,

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -61,6 +61,7 @@ export {
     fromHex,
 } from "@novasamatech/host-api";
 
+/** A `0x`-prefixed hex string (the template literal type ``\`0x${string}\``) used by the host API surface for raw byte payloads. Re-exported from `@novasamatech/host-api` so consumers bridging between host APIs and SDK code can reach the host-side type without an additional dependency. */
 export type { HexString } from "@novasamatech/host-api";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -202,7 +203,10 @@ export async function getAccountsProvider(): Promise<AccountsProvider | null> {
 }
 
 /**
- * Account from the host wallet.
+ * One of the user's existing wallet accounts, surfaced through the host and
+ * identified by its public key and an optional name. Contrast with
+ * {@link ProductAccount}, which is also user-controlled but derived by the
+ * host for a specific app rather than picked from the user's existing keys.
  */
 export interface HostAccount {
     publicKey: Uint8Array;

--- a/product-sdk/packages/host/src/types.ts
+++ b/product-sdk/packages/host/src/types.ts
@@ -1,4 +1,9 @@
-/** Subset of product-sdk's hostLocalStorage that the KV store uses. */
+/**
+ * Persistent string and JSON storage exposed by the host container. Most
+ * apps reach it indirectly through the Storage package's `KvStore`; reach for
+ * it directly via {@link getHostLocalStorage} when you need raw host storage
+ * without the KV abstraction.
+ */
 export interface HostLocalStorage {
     readString(key: string): Promise<string | null>;
     writeString(key: string, value: string): Promise<void>;
@@ -11,14 +16,24 @@ export interface HostLocalStorage {
     clear(key: string): Promise<void>;
 }
 
-/** Proof types returned from createProof (matches product-sdk SCALE-decoded types). */
+/**
+ * Cryptographic proof attached to a statement before submission, returned by
+ * {@link HostStatementStore.createProof}. Variants cover the supported
+ * signature schemes — `Sr25519`, `Ed25519`, `Secp256k1Ecdsa`, and
+ * `EcdsaRecoverable`.
+ */
 export type StatementProof =
     | { tag: "Sr25519"; value: { signature: Uint8Array; signer: Uint8Array } }
     | { tag: "Ed25519"; value: { signature: Uint8Array; signer: Uint8Array } }
     | { tag: "Secp256k1Ecdsa"; value: { signature: Uint8Array; signer: Uint8Array } }
     | { tag: "EcdsaRecoverable"; value: { signature: Uint8Array } };
 
-/** The statement store interface provided by the host API via product-sdk. */
+/**
+ * Statement Store handle exposed by the host container. Provides
+ * `subscribe`, `createProof`, and `submit` operations that go through the
+ * host's native binary protocol; the `statement-store` package layers a
+ * higher-level client on top.
+ */
 export interface HostStatementStore {
     /**
      * Subscribe to statements matching the given topics.

--- a/product-sdk/packages/keys/src/index.ts
+++ b/product-sdk/packages/keys/src/index.ts
@@ -1,3 +1,16 @@
+/**
+ * @parity/product-sdk-keys — Derive application keys from a user's account without touching their seed phrase.
+ *
+ * `KeyManager` holds a master key (typically derived from a one-time signature)
+ * and produces deterministic child keys via HKDF-SHA256, so an app can scope its
+ * own keys without ever asking for the user's mnemonic. `SessionKeyManager` is a
+ * separate, storage-backed mechanism: it generates a fresh BIP39 mnemonic, keeps
+ * it in a {@link KvStore}, and derives an sr25519 account from it — useful for
+ * persistent session signers. `seedToAccount` is the dev/test escape hatch that
+ * turns a mnemonic and derivation path into a ready-to-use signer.
+ *
+ * @packageDocumentation
+ */
 export { KeyManager } from "./key-manager.js";
 export { SessionKeyManager } from "./session-key-manager.js";
 export { seedToAccount } from "./seed-to-account.js";

--- a/product-sdk/packages/logger/src/configure.ts
+++ b/product-sdk/packages/logger/src/configure.ts
@@ -1,6 +1,11 @@
 import { state } from "./state.js";
 import type { LoggerConfig } from "./types.js";
 
+/**
+ * Apply global logger configuration. Merges into prior settings — passed fields
+ * replace, omitted fields are left alone — and takes effect immediately for
+ * every {@link Logger}, present and future.
+ */
 export function configure(config: LoggerConfig): void {
     if (config.level !== undefined) {
         state.level = config.level;

--- a/product-sdk/packages/logger/src/create-logger.ts
+++ b/product-sdk/packages/logger/src/create-logger.ts
@@ -34,6 +34,13 @@ function emit(level: LogLevel, namespace: string, message: string, data?: unknow
     }
 }
 
+/**
+ * Create a {@link Logger} bound to a namespace.
+ *
+ * The namespace is attached to every {@link LogEntry} the logger emits and is
+ * what {@link LoggerConfig.namespaces} matches against. Convention is
+ * `package:area` — e.g. `"signer:dev"`, `"chain-client"`.
+ */
 export function createLogger(namespace: string): Logger {
     return {
         error: (message: string, data?: unknown) => emit("error", namespace, message, data),

--- a/product-sdk/packages/logger/src/index.ts
+++ b/product-sdk/packages/logger/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * @parity/product-sdk-logger — Structured, namespace-filtered logging for the SDK.
+ *
+ * Each package calls `createLogger(namespace)` to emit structured `LogEntry`
+ * records; the host application calls `configure` once to set the log level,
+ * decide which namespaces are enabled, and route entries into its own
+ * observability stack via a custom `LogHandler`.
+ *
+ * @packageDocumentation
+ */
 export { configure } from "./configure.js";
 export { createLogger } from "./create-logger.js";
 export type { LogLevel, LogEntry, LogHandler, LoggerConfig, Logger } from "./types.js";

--- a/product-sdk/packages/logger/src/types.ts
+++ b/product-sdk/packages/logger/src/types.ts
@@ -1,5 +1,7 @@
+/** Severity ranking — `"error"` is the highest, then `"warn"`, `"info"`, `"debug"`. The configured level is the lowest severity that gets emitted; less-severe entries are dropped. */
 export type LogLevel = "error" | "warn" | "info" | "debug";
 
+/** A structured record emitted by a {@link Logger}. */
 export interface LogEntry {
     level: LogLevel;
     namespace: string;
@@ -8,8 +10,10 @@ export interface LogEntry {
     timestamp: number;
 }
 
+/** Custom sink for log records. When set via {@link configure} it replaces the default `console.*` output and receives every {@link LogEntry} that passes the level filter. */
 export type LogHandler = (entry: LogEntry) => void;
 
+/** Global configuration for the logger system, applied via {@link configure}. */
 export interface LoggerConfig {
     /** Minimum log level. Default: "warn" */
     level?: LogLevel;
@@ -19,6 +23,7 @@ export interface LoggerConfig {
     handler?: LogHandler;
 }
 
+/** A namespaced logger. Each method emits a {@link LogEntry} at the matching {@link LogLevel}, or no-ops when filtered out by the current configuration. */
 export interface Logger {
     error(message: string, data?: unknown): void;
     warn(message: string, data?: unknown): void;

--- a/product-sdk/packages/signer/src/index.ts
+++ b/product-sdk/packages/signer/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * @parity/product-sdk-signer — Account connection and signing, decoupled from where the keys actually live.
+ *
+ * `SignerManager` wraps one or more `SignerProvider` implementations behind a
+ * `Result`-typed API for connecting, listing accounts, and reacting to status or
+ * account changes. The two built-in providers — `HostProvider` (Polkadot
+ * Desktop/Mobile) and `DevProvider` (the well-known Alice/Bob accounts) — let
+ * the same call sites work in production and in tests.
+ *
+ * @packageDocumentation
+ */
+
 // Core manager
 export { SignerManager } from "./signer-manager.js";
 

--- a/product-sdk/packages/signer/src/providers/dev.ts
+++ b/product-sdk/packages/signer/src/providers/dev.ts
@@ -14,6 +14,7 @@ const DEV_PHRASE = "bottom drive obey lake curtain smoke basket hold race lonely
 /** Standard Substrate dev account names. */
 const DEFAULT_DEV_NAMES = ["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie"] as const;
 
+/** A well-known Substrate development account name (Alice, Bob, …) used to derive deterministic dev accounts from the standard Substrate dev mnemonic. */
 export type DevAccountName = (typeof DEFAULT_DEV_NAMES)[number];
 
 /** Supported key types for dev account derivation. */

--- a/product-sdk/packages/statement-store/src/index.ts
+++ b/product-sdk/packages/statement-store/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * @parity/product-sdk-statement-store — Publish/subscribe over the Polkadot Statement Store.
+ *
+ * `StatementStoreClient` submits signed statements and subscribes to topics via
+ * the Host API's native binary protocol — the SDK runs only inside a host
+ * container (Polkadot Browser / Desktop). `ChannelStore` layers a channel
+ * abstraction on top for apps that want stable, two-party message streams
+ * instead of raw topics.
+ *
+ * @packageDocumentation
+ */
+
 // Client
 export { StatementStoreClient } from "./client.js";
 export { ChannelStore } from "./channels.js";

--- a/product-sdk/packages/statement-store/src/types.ts
+++ b/product-sdk/packages/statement-store/src/types.ts
@@ -1,12 +1,22 @@
 // Re-export statement types from @novasamatech/sdk-statement
-export type {
-    Statement,
-    SignedStatement,
-    UnsignedStatement,
-    Proof,
-    SubmitResult,
-    TopicFilter as SdkTopicFilter,
-} from "@novasamatech/sdk-statement";
+
+/** A record published to the Statement Store. Every field is optional: a `data` payload, `topics` for routing, a `channel` for last-write-wins, an `expiry`, and a `proof` once signed. */
+export type { Statement } from "@novasamatech/sdk-statement";
+
+/** A {@link Statement} with its `proof` attached and ready for submission — the only field the submission path actually requires. */
+export type { SignedStatement } from "@novasamatech/sdk-statement";
+
+/** A {@link Statement} before signing — the same optional fields, minus `proof`. */
+export type { UnsignedStatement } from "@novasamatech/sdk-statement";
+
+/** Signature attached to a statement — `sr25519`/`ed25519`/`ecdsa` plus public key, or an on-chain witness referencing a block event. */
+export type { Proof } from "@novasamatech/sdk-statement";
+
+/** Outcome of a submission — new, already-known, known-expired, rejected, invalid, or internal-error. */
+export type { SubmitResult } from "@novasamatech/sdk-statement";
+
+/** Upstream topic filter shape — same `"any"` / `matchAll` / `matchAny` structure as {@link TopicFilter}, but carries topics as 32-byte hex strings (`SizedHex<32>`) rather than the SDK's `Uint8Array`-based {@link TopicHash}. Reach for this when working with a {@link StatementTransport} directly. */
+export type { TopicFilter as SdkTopicFilter } from "@novasamatech/sdk-statement";
 
 import type {
     Statement,

--- a/product-sdk/packages/storage/src/index.ts
+++ b/product-sdk/packages/storage/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * @parity/product-sdk-storage — One key-value API across the host container and the browser.
+ *
+ * `createKvStore` returns a `KvStore` that uses the host-provided
+ * `HostLocalStorage` when running inside a Polkadot host container and falls back
+ * to browser `localStorage` otherwise, so app code reads and writes the same way
+ * on desktop, mobile, and web.
+ *
+ * @packageDocumentation
+ */
 export { createKvStore } from "./kv-store.js";
 export type { KvStore, KvStoreOptions } from "./types.js";
 export type { HostLocalStorage } from "@parity/product-sdk-host";

--- a/product-sdk/packages/storage/src/types.ts
+++ b/product-sdk/packages/storage/src/types.ts
@@ -1,5 +1,6 @@
 import type { HostLocalStorage } from "@parity/product-sdk-host";
 
+/** Async string key-value store, with `getJSON`/`setJSON` for structured values. Returned by {@link createKvStore}. */
 export interface KvStore {
     get(key: string): Promise<string | null>;
     set(key: string, value: string): Promise<void>;
@@ -8,6 +9,7 @@ export interface KvStore {
     setJSON(key: string, value: unknown): Promise<void>;
 }
 
+/** Optional configuration for {@link createKvStore}: a key prefix to namespace entries, or an explicit host-storage handle that overrides auto-detection. */
 export interface KvStoreOptions {
     /** Key prefix to namespace storage keys (e.g. "myapp" → keys become "myapp:theme"). */
     prefix?: string;

--- a/product-sdk/packages/tx/src/index.ts
+++ b/product-sdk/packages/tx/src/index.ts
@@ -1,3 +1,15 @@
+/**
+ * @parity/product-sdk-tx — Submit Polkadot transactions and follow them to finality.
+ *
+ * `submitAndWatch` signs, broadcasts, and tracks a single extrinsic through its
+ * lifecycle; `batchSubmitAndWatch` does the same for a list of calls. The package
+ * also bundles the things you almost always reach for next to a real submission:
+ * dry-run helpers, Asset Hub account mapping, retry primitives, dev signers, and
+ * a typed error hierarchy with formatters that turn dispatch errors into readable
+ * messages.
+ *
+ * @packageDocumentation
+ */
 export { submitAndWatch } from "./submit.js";
 export { batchSubmitAndWatch } from "./batch.js";
 export { withRetry, calculateDelay } from "./retry.js";


### PR DESCRIPTION
## Summary

- Adds `@packageDocumentation` blocks to the 11 packages that were missing one, so the API reference overview table reads as peers rather than a mix of described and undescribed packages.
- Documents type aliases and interfaces that were previously missing descriptions across `address`, `contracts`, `statement-store`, `storage`, `signer`, `logger`, `crypto`, and `host`.
- Tightens the docs generator: function pages now only render the **Parameters** and **Returns** sections when there's a description to show, and parameters render as a bullet list (`- name: description`) instead of a table that mostly duplicated the signature line.