### PR TITLE
feat(bench): add bundle-size benchmark + CI gate

### DIFF
--- a/.github/workflows/product-sdk-bundle-size.yml
+++ b/.github/workflows/product-sdk-bundle-size.yml
@@ -36,19 +36,20 @@ jobs:
 
       - name: Measure
         # If the bench script doesn't exist on base yet, emit an empty
-        # report so the diff shows everything as "new".
+        # report so the diff shows everything as "new". Stage the file at
+        # the repo root so the artifact has it at its root, not nested.
         run: |
-          if [ -f scripts/bench-bundle.mjs ]; then
-            node scripts/bench-bundle.mjs measure --out bundle-size.base.json
+          if [ -f product-sdk/scripts/bench-bundle.mjs ]; then
+            (cd product-sdk && node scripts/bench-bundle.mjs measure --out bundle-size.base.json)
+            mv product-sdk/bundle-size.base.json ./bundle-size.base.json
           else
             echo '{"version":1,"packages":{},"generatedAt":"base","node":"n/a","esbuild":"n/a"}' > bundle-size.base.json
           fi
-        working-directory: product-sdk
 
       - uses: actions/upload-artifact@v4
         with:
           name: bundle-size-base
-          path: product-sdk/bundle-size.base.json
+          path: bundle-size.base.json
           retention-days: 1
 
   measure-head:
@@ -76,13 +77,15 @@ jobs:
         working-directory: product-sdk
 
       - name: Measure
-        run: node scripts/bench-bundle.mjs measure --out bundle-size.head.json
-        working-directory: product-sdk
+        # Stage the JSON at the repo root so the artifact has it at its root.
+        run: |
+          (cd product-sdk && node scripts/bench-bundle.mjs measure --out bundle-size.head.json)
+          mv product-sdk/bundle-size.head.json ./bundle-size.head.json
 
       - uses: actions/upload-artifact@v4
         with:
           name: bundle-size-head
-          path: product-sdk/bundle-size.head.json
+          path: bundle-size.head.json
           retention-days: 1
 
   compare:
@@ -118,8 +121,28 @@ jobs:
             --head bundle-size.head.json \
             --md bundle-size.diff.md \
             --strict
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          # Make sure a comment body always exists, even if the script crashed
+          # before writing one. Otherwise the sticky-comment action errors with
+          # "Either message or path input is required".
+          if [ ! -s bundle-size.diff.md ]; then
+            {
+              echo "<!-- product-sdk-bundle-size -->"
+              echo "## 📦 Bundle size impact"
+              echo
+              echo "Bench compare step failed to produce a report (exit $code). See workflow logs."
+            } > bundle-size.diff.md
+          fi
         working-directory: product-sdk
+
+      - name: Debug — show diff file
+        if: always()
+        run: |
+          echo "--- ls product-sdk ---"
+          ls -la product-sdk/ | grep bundle-size || true
+          echo "--- diff.md head ---"
+          head -40 product-sdk/bundle-size.diff.md || echo "(missing)"
 
       - name: Post sticky PR comment
         if: always()

--- a/.github/workflows/product-sdk-bundle-size.yml
+++ b/.github/workflows/product-sdk-bundle-size.yml
@@ -1,0 +1,135 @@
+name: "product-sdk: Bundle Size"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "product-sdk/**"
+      - ".github/workflows/product-sdk-bundle-size.yml"
+
+jobs:
+  measure-base:
+    name: "Measure base"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: product-sdk/pnpm-lock.yaml
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+        working-directory: product-sdk
+
+      - name: Build
+        run: pnpm build
+        working-directory: product-sdk
+
+      - name: Measure
+        # If the bench script doesn't exist on base yet, emit an empty
+        # report so the diff shows everything as "new".
+        run: |
+          if [ -f scripts/bench-bundle.mjs ]; then
+            node scripts/bench-bundle.mjs measure --out bundle-size.base.json
+          else
+            echo '{"version":1,"packages":{},"generatedAt":"base","node":"n/a","esbuild":"n/a"}' > bundle-size.base.json
+          fi
+        working-directory: product-sdk
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle-size-base
+          path: product-sdk/bundle-size.base.json
+          retention-days: 1
+
+  measure-head:
+    name: "Measure head"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: product-sdk/pnpm-lock.yaml
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+        working-directory: product-sdk
+
+      - name: Build
+        run: pnpm build
+        working-directory: product-sdk
+
+      - name: Measure
+        run: node scripts/bench-bundle.mjs measure --out bundle-size.head.json
+        working-directory: product-sdk
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle-size-head
+          path: product-sdk/bundle-size.head.json
+          retention-days: 1
+
+  compare:
+    name: "Compare & comment"
+    runs-on: ubuntu-latest
+    needs: [measure-base, measure-head]
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bundle-size-base
+          path: product-sdk
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bundle-size-head
+          path: product-sdk
+
+      - name: Compare
+        id: compare
+        continue-on-error: true
+        run: |
+          set +e
+          node scripts/bench-bundle.mjs compare \
+            --base bundle-size.base.json \
+            --head bundle-size.head.json \
+            --md bundle-size.diff.md \
+            --strict
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+        working-directory: product-sdk
+
+      - name: Post sticky PR comment
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: product-sdk-bundle-size
+          path: product-sdk/bundle-size.diff.md
+
+      - name: Fail on regression
+        if: steps.compare.outputs.exit_code != '0'
+        run: |
+          echo "Bundle size regression exceeds fail threshold."
+          exit 1

--- a/.github/workflows/product-sdk-bundle-size.yml
+++ b/.github/workflows/product-sdk-bundle-size.yml
@@ -101,19 +101,50 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Debug — env after checkout
+        run: |
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          echo "PWD=$(pwd)"
+          echo "--- repo root ---"
+          ls -la
+          echo "--- product-sdk/ exists? ---"
+          ls -la product-sdk/ 2>&1 | head -20 || echo "MISSING"
+
+      # Download both artifacts to the repo root (artifacts contain the JSON
+      # files at their root since we staged them flat in the measure jobs).
       - uses: actions/download-artifact@v4
         with:
           name: bundle-size-base
-          path: product-sdk
+          path: .
 
       - uses: actions/download-artifact@v4
         with:
           name: bundle-size-head
-          path: product-sdk
+          path: .
+
+      - name: Debug — env after downloads
+        run: |
+          echo "--- repo root ---"
+          ls -la
+          echo "--- bundle-size files ---"
+          ls -la bundle-size.*.json 2>&1 || echo "no bundle-size files"
+          echo "--- product-sdk/scripts ---"
+          ls -la product-sdk/scripts/ 2>&1 | head || echo "MISSING"
+
+      # Run compare from the repo root. The script resolves paths against
+      # WORKSPACE_ROOT (= product-sdk/) internally, so we need to either:
+      #   a) cd into product-sdk/ and reference ../bundle-size.*.json, or
+      #   b) move the artifacts into product-sdk/.
+      # We do (b) — simpler, and bundle-size.diff.md ends up where the
+      # sticky-comment step expects it.
+      - name: Stage artifacts into product-sdk/
+        run: |
+          mv bundle-size.base.json product-sdk/bundle-size.base.json
+          mv bundle-size.head.json product-sdk/bundle-size.head.json
+          ls -la product-sdk/bundle-size.*.json
 
       - name: Compare
         id: compare
-        continue-on-error: true
         run: |
           set +e
           node scripts/bench-bundle.mjs compare \
@@ -122,10 +153,9 @@ jobs:
             --md bundle-size.diff.md \
             --strict
           code=$?
-          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
-          # Make sure a comment body always exists, even if the script crashed
-          # before writing one. Otherwise the sticky-comment action errors with
-          # "Either message or path input is required".
+          echo "compare-exit=$code" >> "$GITHUB_OUTPUT"
+          # Always emit a comment body so the sticky-comment action has input
+          # even if the script crashed before writing one.
           if [ ! -s bundle-size.diff.md ]; then
             {
               echo "<!-- product-sdk-bundle-size -->"
@@ -134,12 +164,15 @@ jobs:
               echo "Bench compare step failed to produce a report (exit $code). See workflow logs."
             } > bundle-size.diff.md
           fi
+          # Don't fail this step — let the sticky-comment post first, then
+          # fail the dedicated 'Fail on regression' step at the end.
+          exit 0
         working-directory: product-sdk
 
       - name: Debug — show diff file
         if: always()
         run: |
-          echo "--- ls product-sdk ---"
+          echo "--- product-sdk/ contents ---"
           ls -la product-sdk/ | grep bundle-size || true
           echo "--- diff.md head ---"
           head -40 product-sdk/bundle-size.diff.md || echo "(missing)"
@@ -152,7 +185,7 @@ jobs:
           path: product-sdk/bundle-size.diff.md
 
       - name: Fail on regression
-        if: steps.compare.outputs.exit_code != '0'
+        if: steps.compare.outputs.compare-exit != '0'
         run: |
-          echo "Bundle size regression exceeds fail threshold."
+          echo "Bundle size regression exceeds fail threshold (script exit ${{ steps.compare.outputs.compare-exit }})."
           exit 1

--- a/.github/workflows/product-sdk-bundle-size.yml
+++ b/.github/workflows/product-sdk-bundle-size.yml
@@ -93,6 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [measure-base, measure-head]
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/product-sdk-bundle-size.yml
+++ b/.github/workflows/product-sdk-bundle-size.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: product-sdk/pnpm-lock.yaml
 
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: product-sdk/pnpm-lock.yaml
 
@@ -100,7 +100,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Debug — env after checkout
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ yarn.lock
 
 #local docs
 local-docs
+
+# Bundle bench: ephemeral outputs, baseline JSON is committed.
+product-sdk/bundle-size.md
+product-sdk/bundle-size.base.json
+product-sdk/bundle-size.head.json
+product-sdk/bundle-size.diff.md

--- a/product-sdk/BUNDLE_SIZE.md
+++ b/product-sdk/BUNDLE_SIZE.md
@@ -51,6 +51,8 @@ pnpm bench:compare
 
 The committed `bundle-size.json` represents the SDK's current measured size. **Update it** when you intentionally land a change that grows or shrinks bundles — adding a feature, swapping a dep, ripping out dead code.
 
+Regenerate using **Node 24** to match CI — V8/zlib output can shift slightly across Node majors, so a baseline captured on a different version will show phantom drift in PR comparisons run on `main`.
+
 ```bash
 pnpm build
 pnpm bench

--- a/product-sdk/BUNDLE_SIZE.md
+++ b/product-sdk/BUNDLE_SIZE.md
@@ -1,0 +1,97 @@
+# Bundle Size
+
+Every PR that touches `product-sdk/**` runs the bundle-size benchmark and posts a sticky comment with the impact per package. The goal is to keep the SDK small and to catch tree-shaking regressions early.
+
+## What gets measured
+
+For every `@parity/product-sdk-*` package and every subpath export of `@parity/product-sdk` and `@parity/product-sdk-descriptors`, three numbers are recorded:
+
+| Metric | How it's measured | What it tells you |
+|---|---|---|
+| **Ship** | Raw + gzip + brotli of `dist/<entry>.js` | What npm sends per file |
+| **Bundled** | esbuild bundle of `import * as M from "<pkg>"` | Consumer ceiling — full cost when every export is reachable |
+| **Shaken** | esbuild bundle of `import { firstExport } from "<pkg>"` | Tree-shaken cost of importing one symbol |
+
+The ratio `shaken / bundled` is the **tree-shake ratio**. A low ratio is good — most of the package falls away when consumers only use one symbol. A ratio near 100% means tree-shaking is broken (top-level side effects, eager class instantiation, or `sideEffects: true`).
+
+## CI behaviour
+
+`product-sdk-bundle-size.yml` runs on every PR that touches `product-sdk/`:
+
+1. Builds the **base** branch and measures.
+2. Builds the **PR head** and measures.
+3. Diffs the two reports and posts a sticky comment.
+4. Fails the job if any package's bundled size grows beyond the fail threshold.
+
+Thresholds (deliberately loose for v1, will tighten with data):
+
+| Severity | Bundled growth | Notes |
+|---|---|---|
+| 🟢 ok | <10% and <5 KB | |
+| 🟡 warn | ≥10% or ≥5 KB | Comment shows yellow row, job still passes |
+| 🔴 fail | ≥20% or ≥15 KB | Job fails |
+
+For deps-dominated entries (>100 KB baseline), only the percentage applies — a +5 KB swing in a 1 MB bundle is noise. For small entries (<100 KB), absolute byte budgets kick in to catch slow drift.
+
+## Local commands
+
+```bash
+# Measure once and write bundle-size.json + bundle-size.md
+pnpm bench
+
+# Compare current vs an earlier snapshot (used by CI)
+pnpm bench:compare
+```
+
+`pnpm bench` writes:
+- `bundle-size.json` — committed baseline, the source of truth for the SDK's current size.
+- `bundle-size.md` — gitignored markdown table for human eyes.
+
+## When to update the baseline
+
+The committed `bundle-size.json` represents the SDK's current measured size. **Update it** when you intentionally land a change that grows or shrinks bundles — adding a feature, swapping a dep, ripping out dead code.
+
+```bash
+pnpm build
+pnpm bench
+git add product-sdk/bundle-size.json
+git commit -m "chore: refresh bundle-size baseline"
+```
+
+The CI compare uses `<base-branch>` vs `<PR-head>` directly, so the committed baseline isn't used to gate PRs. It exists so we can track the SDK's size on `main` over time and answer "did this release get bigger?"
+
+## Debugging a regression
+
+If your PR comment shows a 🟡 or 🔴 entry:
+
+1. **Check the `Bundled` column** — that's the consumer-cost number. If it grew, something you imported pulled in more code.
+2. **Check the `Shake ratio`** — if it jumped (e.g. 5% → 95%), you accidentally introduced a side effect that defeats tree-shaking. Common causes:
+   - A new top-level statement with effects (`const x = doSomething()` outside a function).
+   - A package marked `sideEffects: true` somewhere in the dep chain.
+   - A barrel that re-exports an entire module via `import "x"` (no binding pulled).
+3. **Inspect locally** with esbuild's metafile:
+   ```bash
+   cd product-sdk
+   pnpm build
+   node -e '
+     import("esbuild").then(async ({ build }) => {
+       const r = await build({
+         stdin: { contents: `import { Thing } from "@parity/product-sdk-foo"; globalThis.x = Thing;`, resolveDir: "scripts/bench-consumer" },
+         bundle: true, format: "esm", platform: "browser", target: "es2022",
+         minify: true, write: false, metafile: true,
+       });
+       require("fs").writeFileSync("meta.json", JSON.stringify(r.metafile));
+     });
+   '
+   ```
+   Then drop `meta.json` into <https://esbuild.github.io/analyze/> to see who pulled what.
+
+## How the script works
+
+`scripts/bench-bundle.mjs` discovers every workspace package whose name starts with `@parity/product-sdk` and walks its `exports` map. For each entry, it:
+
+1. Reads the dist file directly → ship/gzip/brotli.
+2. Synthesises an entry `import * as M from "<pkg>"; globalThis.__pin = M;` and runs esbuild against `scripts/bench-consumer/` (a workspace package that depends on every SDK package, so esbuild can resolve bare imports through pnpm's per-package linking).
+3. Repeats with a single named import for the shaken measurement.
+
+The `bench-consumer` is a private workspace package that exists solely to give esbuild a `node_modules` to resolve through. It is never published.

--- a/product-sdk/README.md
+++ b/product-sdk/README.md
@@ -78,6 +78,15 @@ pnpm --filter "@parity/product-sdk-signer-demo" test:e2e
 pnpm --filter "@parity/product-sdk-signer-demo" test:e2e:ui
 ```
 
+## Bundle Size
+
+Every PR runs a bundle-size benchmark across all SDK packages and posts a diff comment. See [BUNDLE_SIZE.md](./BUNDLE_SIZE.md) for what's measured and how to debug regressions.
+
+```bash
+pnpm bench           # measure current sizes locally
+pnpm bench:compare   # compare against a saved snapshot (CI uses this)
+```
+
 ## License
 
 Apache-2.0

--- a/product-sdk/bundle-size.json
+++ b/product-sdk/bundle-size.json
@@ -1,0 +1,657 @@
+{
+  "version": 1,
+  "generatedAt": "2026-04-29T15:31:32.236Z",
+  "node": "v24.11.0",
+  "esbuild": "0.25.12",
+  "packages": {
+    "@parity/product-sdk": {
+      "entries": {
+        ".": {
+          "file": "packages/sdk/dist/index.js",
+          "ship": {
+            "raw": 705,
+            "gzip": 307,
+            "brotli": 278
+          },
+          "bundled": {
+            "raw": 4476259,
+            "gzip": 1468511,
+            "brotli": 675888
+          },
+          "shaken": {
+            "raw": 4346714,
+            "gzip": 1426165,
+            "brotli": 647087
+          },
+          "shakeRatio": 0.9711
+        },
+        "./address": {
+          "file": "packages/sdk/dist/address/index.js",
+          "ship": {
+            "raw": 102,
+            "gzip": 112,
+            "brotli": 88
+          },
+          "bundled": {
+            "raw": 20821,
+            "gzip": 8077,
+            "brotli": 7228
+          },
+          "shaken": {
+            "raw": 15727,
+            "gzip": 6197,
+            "brotli": 5554
+          },
+          "shakeRatio": 0.7553
+        },
+        "./bulletin": {
+          "file": "packages/sdk/dist/bulletin/index.js",
+          "ship": {
+            "raw": 104,
+            "gzip": 114,
+            "brotli": 91
+          },
+          "bundled": {
+            "raw": 4346183,
+            "gzip": 1427968,
+            "brotli": 649911
+          },
+          "shaken": {
+            "raw": 12668,
+            "gzip": 4739,
+            "brotli": 4336
+          },
+          "shakeRatio": 0.0029
+        },
+        "./chain": {
+          "file": "packages/sdk/dist/chain/index.js",
+          "ship": {
+            "raw": 105,
+            "gzip": 118,
+            "brotli": 90
+          },
+          "bundled": {
+            "raw": 4254377,
+            "gzip": 1395798,
+            "brotli": 621908
+          },
+          "shaken": {
+            "raw": 218474,
+            "gzip": 73966,
+            "brotli": 62627
+          },
+          "shakeRatio": 0.0514
+        },
+        "./contracts": {
+          "file": "packages/sdk/dist/contracts/index.js",
+          "ship": {
+            "raw": 106,
+            "gzip": 115,
+            "brotli": 91
+          },
+          "bundled": {
+            "raw": 2391712,
+            "gzip": 756617,
+            "brotli": 412187
+          },
+          "shaken": {
+            "raw": 160700,
+            "gzip": 57482,
+            "brotli": 41396
+          },
+          "shakeRatio": 0.0672
+        },
+        "./core": {
+          "file": "packages/sdk/dist/core/index.js",
+          "ship": {
+            "raw": 206,
+            "gzip": 151,
+            "brotli": 116
+          },
+          "bundled": {
+            "raw": 4476098,
+            "gzip": 1468434,
+            "brotli": 675729
+          },
+          "shaken": {
+            "raw": 634,
+            "gzip": 367,
+            "brotli": 316
+          },
+          "shakeRatio": 0.0001
+        },
+        "./crypto": {
+          "file": "packages/sdk/dist/crypto/index.js",
+          "ship": {
+            "raw": 100,
+            "gzip": 110,
+            "brotli": 94
+          },
+          "bundled": {
+            "raw": 73480,
+            "gzip": 25373,
+            "brotli": 20354
+          },
+          "shaken": {
+            "raw": 43080,
+            "gzip": 15325,
+            "brotli": 12056
+          },
+          "shakeRatio": 0.5863
+        },
+        "./host": {
+          "file": "packages/sdk/dist/host/index.js",
+          "ship": {
+            "raw": 96,
+            "gzip": 109,
+            "brotli": 91
+          },
+          "bundled": {
+            "raw": 99646,
+            "gzip": 33158,
+            "brotli": 27013
+          },
+          "shaken": {
+            "raw": 26117,
+            "gzip": 9523,
+            "brotli": 8578
+          },
+          "shakeRatio": 0.2621
+        },
+        "./identity": {
+          "file": "packages/sdk/dist/identity/index.js",
+          "ship": {
+            "raw": 3731,
+            "gzip": 1171,
+            "brotli": 995
+          },
+          "bundled": {
+            "raw": 51343,
+            "gzip": 18067,
+            "brotli": 14455
+          },
+          "shaken": {
+            "raw": 1158,
+            "gzip": 641,
+            "brotli": 540
+          },
+          "shakeRatio": 0.0226
+        },
+        "./react": {
+          "file": "packages/sdk/dist/react/index.js",
+          "ship": {
+            "raw": 5462,
+            "gzip": 1414,
+            "brotli": 1236
+          },
+          "bundled": {
+            "raw": 4486640,
+            "gzip": 1472018,
+            "brotli": 679095
+          },
+          "shaken": {
+            "raw": 8451,
+            "gzip": 3143,
+            "brotli": 2781
+          },
+          "shakeRatio": 0.0019
+        },
+        "./storage": {
+          "file": "packages/sdk/dist/storage/index.js",
+          "ship": {
+            "raw": 102,
+            "gzip": 111,
+            "brotli": 90
+          },
+          "bundled": {
+            "raw": 99156,
+            "gzip": 33070,
+            "brotli": 27033
+          },
+          "shaken": {
+            "raw": 99116,
+            "gzip": 33061,
+            "brotli": 26894
+          },
+          "shakeRatio": 0.9996
+        },
+        "./wallet": {
+          "file": "packages/sdk/dist/wallet/index.js",
+          "ship": {
+            "raw": 100,
+            "gzip": 115,
+            "brotli": 94
+          },
+          "bundled": {
+            "raw": 260460,
+            "gzip": 85596,
+            "brotli": 63422
+          },
+          "shaken": {
+            "raw": 1206,
+            "gzip": 633,
+            "brotli": 550
+          },
+          "shakeRatio": 0.0046
+        }
+      }
+    },
+    "@parity/product-sdk-address": {
+      "entries": {
+        ".": {
+          "file": "packages/address/dist/index.js",
+          "ship": {
+            "raw": 12913,
+            "gzip": 2996,
+            "brotli": 2687
+          },
+          "bundled": {
+            "raw": 20821,
+            "gzip": 8077,
+            "brotli": 7228
+          },
+          "shaken": {
+            "raw": 15727,
+            "gzip": 6197,
+            "brotli": 5554
+          },
+          "shakeRatio": 0.7553
+        }
+      }
+    },
+    "@parity/product-sdk-bulletin": {
+      "entries": {
+        ".": {
+          "file": "packages/bulletin/dist/index.js",
+          "ship": {
+            "raw": 48906,
+            "gzip": 9709,
+            "brotli": 8462
+          },
+          "bundled": {
+            "raw": 4346183,
+            "gzip": 1427968,
+            "brotli": 649911
+          },
+          "shaken": {
+            "raw": 12668,
+            "gzip": 4739,
+            "brotli": 4336
+          },
+          "shakeRatio": 0.0029
+        }
+      }
+    },
+    "@parity/product-sdk-chain-client": {
+      "entries": {
+        ".": {
+          "file": "packages/chain-client/dist/index.js",
+          "ship": {
+            "raw": 15079,
+            "gzip": 3917,
+            "brotli": 3398
+          },
+          "bundled": {
+            "raw": 4254377,
+            "gzip": 1395798,
+            "brotli": 621908
+          },
+          "shaken": {
+            "raw": 218474,
+            "gzip": 73966,
+            "brotli": 62627
+          },
+          "shakeRatio": 0.0514
+        }
+      }
+    },
+    "@parity/product-sdk-contracts": {
+      "entries": {
+        ".": {
+          "file": "packages/contracts/dist/index.js",
+          "ship": {
+            "raw": 14598,
+            "gzip": 3734,
+            "brotli": 3300
+          },
+          "bundled": {
+            "raw": 2391712,
+            "gzip": 756617,
+            "brotli": 412187
+          },
+          "shaken": {
+            "raw": 160700,
+            "gzip": 57482,
+            "brotli": 41396
+          },
+          "shakeRatio": 0.0672
+        },
+        "./codegen": {
+          "file": "packages/contracts/dist/codegen.js",
+          "ship": {
+            "raw": 134,
+            "gzip": 124,
+            "brotli": 108
+          },
+          "bundled": {
+            "raw": 1587,
+            "gzip": 826,
+            "brotli": 710
+          },
+          "shaken": {
+            "raw": 1453,
+            "gzip": 741,
+            "brotli": 638
+          },
+          "shakeRatio": 0.9156
+        }
+      }
+    },
+    "@parity/product-sdk-crypto": {
+      "entries": {
+        ".": {
+          "file": "packages/crypto/dist/index.js",
+          "ship": {
+            "raw": 20352,
+            "gzip": 3450,
+            "brotli": 3075
+          },
+          "bundled": {
+            "raw": 73480,
+            "gzip": 25373,
+            "brotli": 20354
+          },
+          "shaken": {
+            "raw": 43080,
+            "gzip": 15325,
+            "brotli": 12056
+          },
+          "shakeRatio": 0.5863
+        }
+      }
+    },
+    "@parity/product-sdk-descriptors": {
+      "entries": {
+        "./bulletin": {
+          "file": "packages/descriptors/chains/bulletin/generated/dist/index.mjs",
+          "ship": {
+            "raw": 5055,
+            "gzip": 1635,
+            "brotli": 1449
+          },
+          "bundled": {
+            "raw": 274013,
+            "gzip": 96116,
+            "brotli": 76657
+          },
+          "shaken": {
+            "raw": 50691,
+            "gzip": 20285,
+            "brotli": 17969
+          },
+          "shakeRatio": 0.185
+        },
+        "./individuality": {
+          "file": "packages/descriptors/chains/individuality/generated/dist/index.mjs",
+          "ship": {
+            "raw": 5080,
+            "gzip": 1650,
+            "brotli": 1460
+          },
+          "bundled": {
+            "raw": 625492,
+            "gzip": 211151,
+            "brotli": 160019
+          },
+          "shaken": {
+            "raw": 117618,
+            "gzip": 44965,
+            "brotli": 38141
+          },
+          "shakeRatio": 0.188
+        },
+        "./kusama-asset-hub": {
+          "file": "packages/descriptors/chains/kusama-asset-hub/generated/dist/index.mjs",
+          "ship": {
+            "raw": 6849,
+            "gzip": 2041,
+            "brotli": 1809
+          },
+          "bundled": {
+            "raw": 1084214,
+            "gzip": 350575,
+            "brotli": 254364
+          },
+          "shaken": {
+            "raw": 182095,
+            "gzip": 67972,
+            "brotli": 54644
+          },
+          "shakeRatio": 0.168
+        },
+        "./paseo-asset-hub": {
+          "file": "packages/descriptors/chains/paseo-asset-hub/generated/dist/index.mjs",
+          "ship": {
+            "raw": 6892,
+            "gzip": 2054,
+            "brotli": 1819
+          },
+          "bundled": {
+            "raw": 1026121,
+            "gzip": 331947,
+            "brotli": 239630
+          },
+          "shaken": {
+            "raw": 172854,
+            "gzip": 64460,
+            "brotli": 52146
+          },
+          "shakeRatio": 0.1685
+        },
+        "./polkadot-asset-hub": {
+          "file": "packages/descriptors/chains/polkadot-asset-hub/generated/dist/index.mjs",
+          "ship": {
+            "raw": 6913,
+            "gzip": 2056,
+            "brotli": 1829
+          },
+          "bundled": {
+            "raw": 1022953,
+            "gzip": 330917,
+            "brotli": 238954
+          },
+          "shaken": {
+            "raw": 172227,
+            "gzip": 64297,
+            "brotli": 51856
+          },
+          "shakeRatio": 0.1684
+        }
+      }
+    },
+    "@parity/product-sdk-host": {
+      "entries": {
+        ".": {
+          "file": "packages/host/dist/index.js",
+          "ship": {
+            "raw": 6449,
+            "gzip": 1581,
+            "brotli": 1402
+          },
+          "bundled": {
+            "raw": 99646,
+            "gzip": 33158,
+            "brotli": 27013
+          },
+          "shaken": {
+            "raw": 26117,
+            "gzip": 9523,
+            "brotli": 8578
+          },
+          "shakeRatio": 0.2621
+        }
+      }
+    },
+    "@parity/product-sdk-keys": {
+      "entries": {
+        ".": {
+          "file": "packages/keys/dist/index.js",
+          "ship": {
+            "raw": 21790,
+            "gzip": 4425,
+            "brotli": 3950
+          },
+          "bundled": {
+            "raw": 196371,
+            "gzip": 69422,
+            "brotli": 49626
+          },
+          "shaken": {
+            "raw": 145128,
+            "gzip": 52089,
+            "brotli": 38661
+          },
+          "shakeRatio": 0.7391
+        }
+      }
+    },
+    "@parity/product-sdk-logger": {
+      "entries": {
+        ".": {
+          "file": "packages/logger/dist/index.js",
+          "ship": {
+            "raw": 9600,
+            "gzip": 2272,
+            "brotli": 1973
+          },
+          "bundled": {
+            "raw": 1257,
+            "gzip": 645,
+            "brotli": 569
+          },
+          "shaken": {
+            "raw": 634,
+            "gzip": 367,
+            "brotli": 315
+          },
+          "shakeRatio": 0.5044
+        }
+      }
+    },
+    "@parity/product-sdk-signer": {
+      "entries": {
+        ".": {
+          "file": "packages/signer/dist/index.js",
+          "ship": {
+            "raw": 53071,
+            "gzip": 10087,
+            "brotli": 8866
+          },
+          "bundled": {
+            "raw": 260460,
+            "gzip": 85596,
+            "brotli": 63422
+          },
+          "shaken": {
+            "raw": 1206,
+            "gzip": 633,
+            "brotli": 550
+          },
+          "shakeRatio": 0.0046
+        }
+      }
+    },
+    "@parity/product-sdk-statement-store": {
+      "entries": {
+        ".": {
+          "file": "packages/statement-store/dist/index.js",
+          "ship": {
+            "raw": 35491,
+            "gzip": 8222,
+            "brotli": 7184
+          },
+          "bundled": {
+            "raw": 118344,
+            "gzip": 37534,
+            "brotli": 31079
+          },
+          "shaken": {
+            "raw": 10049,
+            "gzip": 4034,
+            "brotli": 3562
+          },
+          "shakeRatio": 0.0849
+        }
+      }
+    },
+    "@parity/product-sdk-storage": {
+      "entries": {
+        ".": {
+          "file": "packages/storage/dist/index.js",
+          "ship": {
+            "raw": 6549,
+            "gzip": 1449,
+            "brotli": 1255
+          },
+          "bundled": {
+            "raw": 99156,
+            "gzip": 33070,
+            "brotli": 27033
+          },
+          "shaken": {
+            "raw": 99116,
+            "gzip": 33061,
+            "brotli": 26894
+          },
+          "shakeRatio": 0.9996
+        }
+      }
+    },
+    "@parity/product-sdk-tx": {
+      "entries": {
+        ".": {
+          "file": "packages/tx/dist/index.js",
+          "ship": {
+            "raw": 56508,
+            "gzip": 10032,
+            "brotli": 8617
+          },
+          "bundled": {
+            "raw": 166390,
+            "gzip": 60790,
+            "brotli": 42855
+          },
+          "shaken": {
+            "raw": 30847,
+            "gzip": 13206,
+            "brotli": 11589
+          },
+          "shakeRatio": 0.1854
+        }
+      }
+    },
+    "@parity/product-sdk-utils": {
+      "entries": {
+        ".": {
+          "file": "packages/utils/dist/index.js",
+          "ship": {
+            "raw": 15285,
+            "gzip": 3414,
+            "brotli": 3034
+          },
+          "bundled": {
+            "raw": 18195,
+            "gzip": 7294,
+            "brotli": 6330
+          },
+          "shaken": {
+            "raw": 8399,
+            "gzip": 3417,
+            "brotli": 3004
+          },
+          "shakeRatio": 0.4616
+        }
+      }
+    }
+  }
+}

--- a/product-sdk/package.json
+++ b/product-sdk/package.json
@@ -12,11 +12,15 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "lint:biome": "biome lint .",
-    "check": "biome check ."
+    "check": "biome check .",
+    "bench": "node scripts/bench-bundle.mjs measure --out bundle-size.json --md bundle-size.md",
+    "bench:update": "node scripts/bench-bundle.mjs measure --out bundle-size.json --md bundle-size.md",
+    "bench:compare": "node scripts/bench-bundle.mjs compare --base bundle-size.base.json --head bundle-size.json --md bundle-size.diff.md --strict"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@changesets/cli": "^2.28.1",
+    "esbuild": "^0.25.0",
     "tsup": "^8.4.0",
     "typescript": "^5.7.0"
   },

--- a/product-sdk/packages/descriptors/package.json
+++ b/product-sdk/packages/descriptors/package.json
@@ -4,6 +4,7 @@
     "description": "PAPI-generated chain descriptors for Polkadot ecosystem",
     "license": "Apache-2.0",
     "type": "module",
+    "sideEffects": false,
     "exports": {
         "./bulletin": {
             "types": "./chains/bulletin/generated/dist/index.d.ts",

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.28.1
         version: 2.31.0(@types/node@25.6.0)
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       tsup:
         specifier: ^8.4.0
         version: 8.5.0(postcss@8.5.10)(typescript@5.9.3)
@@ -740,6 +743,54 @@ importers:
       vitest:
         specifier: ^3.1.2
         version: 3.2.4(@types/node@25.6.0)
+
+  scripts/bench-consumer:
+    dependencies:
+      '@parity/product-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@parity/product-sdk-address':
+        specifier: workspace:*
+        version: link:../../packages/address
+      '@parity/product-sdk-bulletin':
+        specifier: workspace:*
+        version: link:../../packages/bulletin
+      '@parity/product-sdk-chain-client':
+        specifier: workspace:*
+        version: link:../../packages/chain-client
+      '@parity/product-sdk-contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
+      '@parity/product-sdk-crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
+      '@parity/product-sdk-descriptors':
+        specifier: workspace:*
+        version: link:../../packages/descriptors
+      '@parity/product-sdk-host':
+        specifier: workspace:*
+        version: link:../../packages/host
+      '@parity/product-sdk-keys':
+        specifier: workspace:*
+        version: link:../../packages/keys
+      '@parity/product-sdk-logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
+      '@parity/product-sdk-signer':
+        specifier: workspace:*
+        version: link:../../packages/signer
+      '@parity/product-sdk-statement-store':
+        specifier: workspace:*
+        version: link:../../packages/statement-store
+      '@parity/product-sdk-storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
+      '@parity/product-sdk-tx':
+        specifier: workspace:*
+        version: link:../../packages/tx
+      '@parity/product-sdk-utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
 
 packages:
 

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "examples/*"
+  - "scripts/bench-consumer"
 
 catalog:
   polkadot-api: ^1.23.3

--- a/product-sdk/scripts/bench-bundle.mjs
+++ b/product-sdk/scripts/bench-bundle.mjs
@@ -1,0 +1,496 @@
+#!/usr/bin/env node
+// Bundle-size benchmark for @parity/product-sdk-* packages.
+//
+// Modes:
+//   measure  — build the workspace, measure each package, write JSON + markdown
+//   compare  — diff two JSON reports, print markdown table, exit non-zero on regression
+//
+// Usage:
+//   node scripts/bench-bundle.mjs measure --out bundle-size.json [--md report.md]
+//   node scripts/bench-bundle.mjs compare --base before.json --head after.json [--md diff.md] [--strict]
+
+import { readFile, writeFile, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync, brotliCompressSync, constants as zlibConstants } from "node:zlib";
+
+// esbuild is only needed in `measure` mode. Loaded lazily so `compare` can
+// run in CI environments without installing workspace dependencies.
+let esbuild;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = resolve(__dirname, "..");
+const PACKAGES_DIR = join(WORKSPACE_ROOT, "packages");
+// Disposable workspace consumer that depends on every @parity/product-sdk-*
+// package. esbuild resolves bare imports relative to this directory so
+// pnpm's per-package node_modules linking works.
+const BENCH_CONSUMER_DIR = join(WORKSPACE_ROOT, "scripts", "bench-consumer");
+
+// Regression thresholds (looser for v1; tighten once we have data).
+// For deps-dominated entries (>100 KB baseline) only the percentage applies.
+// For small entries (<100 KB) absolute byte budgets also kick in.
+const THRESHOLDS = {
+    fail: { pct: 20, bytes: 15 * 1024 },
+    warn: { pct: 10, bytes: 5 * 1024 },
+};
+
+// ---------------------------------------------------------------------------
+// Package discovery
+// ---------------------------------------------------------------------------
+
+async function discoverPackages() {
+    const dirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => join(PACKAGES_DIR, d.name));
+
+    const packages = [];
+    for (const dir of dirs) {
+        const pkgPath = join(dir, "package.json");
+        if (!existsSync(pkgPath)) continue;
+        const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
+        if (!pkg.name?.startsWith("@parity/product-sdk")) continue;
+        packages.push({ dir, pkg });
+    }
+    return packages.sort((a, b) => a.pkg.name.localeCompare(b.pkg.name));
+}
+
+// Resolve every entry point a consumer could import: "." plus any subpath
+// exports that point at a real .js / .mjs file we can bundle.
+function entryPointsFor(pkg, dir) {
+    const entries = [];
+    const exp = pkg.exports;
+    if (!exp || typeof exp === "string") {
+        entries.push({ subpath: ".", file: resolveExportFile(pkg.main ?? "./dist/index.js", dir) });
+        return entries.filter((e) => e.file && existsSync(e.file));
+    }
+    for (const [subpath, value] of Object.entries(exp)) {
+        const file = resolveExportFile(typeof value === "string" ? value : (value.import ?? value.default), dir);
+        if (file && existsSync(file)) entries.push({ subpath, file });
+    }
+    return entries;
+}
+
+function resolveExportFile(rel, dir) {
+    if (!rel) return null;
+    return resolve(dir, rel);
+}
+
+// ---------------------------------------------------------------------------
+// Measurements
+// ---------------------------------------------------------------------------
+
+function rawSizes(file) {
+    const buf = readFileSync(file);
+    return {
+        raw: buf.byteLength,
+        gzip: gzipSync(buf, { level: 9 }).byteLength,
+        brotli: brotliCompressSync(buf, {
+            params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 11 },
+        }).byteLength,
+    };
+}
+
+async function bundleSize({ entryPath, packageName, treeShake }) {
+    // Build a tiny in-memory entry that imports the package by name and pins
+    // the import to a global side-effect so esbuild can't DCE the whole thing.
+    //
+    // - treeShake=false: `import * as M` + pin M — every export is reachable,
+    //   measures the consumer ceiling for "I use everything".
+    // - treeShake=true:  `import { firstExport }` + pin that one binding —
+    //   measures the tree-shaken cost of one symbol. Comparing the two ratios
+    //   tells us whether tree-shaking is actually working.
+    //
+    // We use stdin with resolveDir = workspace root so esbuild resolves bare
+    // imports against the workspace's node_modules instead of /tmp.
+    let contents;
+    if (treeShake) {
+        const firstExport = await detectFirstExport(entryPath);
+        if (!firstExport) return { raw: null, gzip: null, brotli: null, error: "no exports detected" };
+        contents = `import { ${firstExport} } from ${JSON.stringify(packageName)}; globalThis.__pin = ${firstExport};`;
+    } else {
+        contents = `import * as M from ${JSON.stringify(packageName)}; globalThis.__pin = M;`;
+    }
+
+    const tmp = await mkdtemp(join(tmpdir(), "bench-"));
+    const outFile = join(tmp, "out.mjs");
+
+    try {
+        await esbuild.build({
+            stdin: {
+                contents,
+                resolveDir: BENCH_CONSUMER_DIR,
+                sourcefile: "bench-entry.mjs",
+                loader: "js",
+            },
+            outfile: outFile,
+            bundle: true,
+            format: "esm",
+            platform: "browser",
+            target: "es2022",
+            minify: true,
+            treeShaking: true,
+            absWorkingDir: WORKSPACE_ROOT,
+            logLevel: "silent",
+            external: ["node:*"],
+        });
+        return rawSizes(outFile);
+    } catch (err) {
+        return { raw: null, gzip: null, brotli: null, error: err.message };
+    } finally {
+        await rm(tmp, { recursive: true, force: true });
+    }
+}
+
+async function detectFirstExport(distFile, seen = new Set()) {
+    if (seen.has(distFile)) return null;
+    seen.add(distFile);
+    const content = await readFile(distFile, "utf8");
+
+    // tsup emits `export { Foo, Bar };` and `export { Foo as default };` patterns.
+    const blockMatch = content.match(/export\s*\{([^}]+)\}/);
+    if (blockMatch) {
+        const first = blockMatch[1]
+            .split(",")
+            .map((s) => s.trim())
+            .map((s) => s.split(/\s+as\s+/i).pop())
+            .find((name) => name && name !== "default" && /^[A-Za-z_$][\w$]*$/.test(name));
+        if (first) return first;
+    }
+    const named = content.match(/export\s+(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/);
+    if (named) return named[1];
+
+    // Re-export shim: `export * from "<spec>"` — chase the target.
+    const reExports = [...content.matchAll(/export\s*\*\s*from\s*["']([^"']+)["']/g)].map(
+        (m) => m[1],
+    );
+    for (const spec of reExports) {
+        const target = await resolveReExportTarget(spec);
+        if (target) {
+            const found = await detectFirstExport(target, seen);
+            if (found) return found;
+        }
+    }
+    return null;
+}
+
+async function resolveReExportTarget(spec) {
+    // Bare specifier — resolve against bench-consumer's node_modules.
+    if (!spec.startsWith(".") && !spec.startsWith("/")) {
+        const slash = spec.indexOf("/", spec.startsWith("@") ? spec.indexOf("/") + 1 : 0);
+        const pkgName = slash === -1 ? spec : spec.slice(0, slash);
+        const subpath = slash === -1 ? "." : `./${spec.slice(slash + 1)}`;
+        const pkgJsonPath = join(BENCH_CONSUMER_DIR, "node_modules", pkgName, "package.json");
+        if (!existsSync(pkgJsonPath)) return null;
+        const pkg = JSON.parse(await readFile(pkgJsonPath, "utf8"));
+        const entry = pickExport(pkg.exports, subpath) ?? pkg.module ?? pkg.main ?? "./dist/index.js";
+        return resolve(dirname(pkgJsonPath), entry);
+    }
+    return null;
+}
+
+function pickExport(exp, subpath) {
+    if (!exp || typeof exp === "string") return typeof exp === "string" ? exp : null;
+    const e = exp[subpath];
+    if (!e) return null;
+    if (typeof e === "string") return e;
+    return e.import ?? e.default ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Measure command
+// ---------------------------------------------------------------------------
+
+async function cmdMeasure(args) {
+    esbuild = await import("esbuild");
+    const outPath = resolve(WORKSPACE_ROOT, args.out ?? "bundle-size.json");
+    const mdPath = args.md ? resolve(WORKSPACE_ROOT, args.md) : null;
+
+    const packages = await discoverPackages();
+    const report = {
+        version: 1,
+        generatedAt: new Date().toISOString(),
+        node: process.version,
+        esbuild: esbuild.version ?? esbuild.default?.version ?? "unknown",
+        packages: {},
+    };
+
+    for (const { dir, pkg } of packages) {
+        const entries = entryPointsFor(pkg, dir);
+        if (entries.length === 0) {
+            console.warn(`skip ${pkg.name}: no resolvable entry points`);
+            continue;
+        }
+
+        const pkgReport = { entries: {} };
+        for (const { subpath, file } of entries) {
+            const importSpecifier = subpath === "." ? pkg.name : `${pkg.name}/${subpath.replace(/^\.\//, "")}`;
+            const ship = rawSizes(file);
+            const bundledFull = await bundleSize({
+                entryPath: file,
+                packageName: importSpecifier,
+                treeShake: false,
+            });
+            const bundledShaken = await bundleSize({
+                entryPath: file,
+                packageName: importSpecifier,
+                treeShake: true,
+            });
+
+            pkgReport.entries[subpath] = {
+                file: file.replace(`${WORKSPACE_ROOT}/`, ""),
+                ship, // what npm sends per file
+                bundled: bundledFull, // import * — full consumer cost
+                shaken: bundledShaken, // single named import — tree-shaken cost
+                shakeRatio:
+                    bundledFull.raw && bundledShaken.raw
+                        ? +(bundledShaken.raw / bundledFull.raw).toFixed(4)
+                        : null,
+            };
+            console.log(
+                `${pkg.name} ${subpath}: ship ${fmt(ship.gzip)} gzip · bundled ${fmt(bundledFull.gzip)} · shaken ${fmt(bundledShaken.gzip)}`,
+            );
+        }
+        report.packages[pkg.name] = pkgReport;
+    }
+
+    await mkdir(dirname(outPath), { recursive: true });
+    await writeFile(outPath, `${JSON.stringify(report, null, 2)}\n`);
+    console.log(`\nWrote ${outPath}`);
+
+    if (mdPath) {
+        await writeFile(mdPath, renderReportMd(report));
+        console.log(`Wrote ${mdPath}`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compare command
+// ---------------------------------------------------------------------------
+
+async function cmdCompare(args) {
+    const basePath = resolve(WORKSPACE_ROOT, args.base);
+    const headPath = resolve(WORKSPACE_ROOT, args.head);
+    const mdPath = args.md ? resolve(WORKSPACE_ROOT, args.md) : null;
+    const strict = !!args.strict;
+
+    const base = JSON.parse(await readFile(basePath, "utf8"));
+    const head = JSON.parse(await readFile(headPath, "utf8"));
+
+    const rows = [];
+    let maxSeverity = "ok";
+
+    const allPkgs = new Set([...Object.keys(base.packages), ...Object.keys(head.packages)]);
+    for (const name of [...allPkgs].sort()) {
+        const basePkg = base.packages[name];
+        const headPkg = head.packages[name];
+        if (!headPkg) {
+            rows.push({ name, subpath: "—", severity: "warn", note: "removed" });
+            maxSeverity = worse(maxSeverity, "warn");
+            continue;
+        }
+        if (!basePkg) {
+            rows.push({ name, subpath: "—", severity: "ok", note: "new package" });
+            continue;
+        }
+        const subpaths = new Set([
+            ...Object.keys(basePkg.entries ?? {}),
+            ...Object.keys(headPkg.entries ?? {}),
+        ]);
+        for (const sub of [...subpaths].sort()) {
+            const b = basePkg.entries?.[sub];
+            const h = headPkg.entries?.[sub];
+            if (!h) {
+                rows.push({ name, subpath: sub, severity: "warn", note: "entry removed" });
+                maxSeverity = worse(maxSeverity, "warn");
+                continue;
+            }
+            if (!b) {
+                rows.push({ name, subpath: sub, severity: "ok", note: "new entry" });
+                continue;
+            }
+            const beforeBundled = b.bundled?.raw ?? 0;
+            const afterBundled = h.bundled?.raw ?? 0;
+            const deltaB = afterBundled - beforeBundled;
+            const pct = beforeBundled > 0 ? (deltaB / beforeBundled) * 100 : 0;
+
+            const beforeShake = b.shakeRatio ?? null;
+            const afterShake = h.shakeRatio ?? null;
+
+            const severity = classify(pct, deltaB, beforeBundled);
+            maxSeverity = worse(maxSeverity, severity);
+
+            rows.push({
+                name,
+                subpath: sub,
+                severity,
+                bundledBefore: beforeBundled,
+                bundledAfter: afterBundled,
+                deltaBytes: deltaB,
+                deltaPct: pct,
+                shipGzipBefore: b.ship?.gzip ?? null,
+                shipGzipAfter: h.ship?.gzip ?? null,
+                shakeBefore: beforeShake,
+                shakeAfter: afterShake,
+            });
+        }
+    }
+
+    const md = renderDiffMd(rows, { base, head });
+    process.stdout.write(`${md}\n`);
+    if (mdPath) await writeFile(mdPath, md);
+
+    if (strict && maxSeverity === "fail") {
+        console.error("\nBundle size regression exceeds fail threshold.");
+        process.exit(1);
+    }
+}
+
+function classify(pct, bytes, baseBytes) {
+    if (bytes <= 0) return "ok";
+    // For deps-dominated entries (>100 KB baseline) a 5 KB swing is noise —
+    // gate on percentage only. Absolute thresholds apply to small entries
+    // where a 5 KB add is a meaningful regression.
+    const useAbsolute = baseBytes < 100 * 1024;
+    if (pct >= THRESHOLDS.fail.pct || (useAbsolute && bytes >= THRESHOLDS.fail.bytes)) return "fail";
+    if (pct >= THRESHOLDS.warn.pct || (useAbsolute && bytes >= THRESHOLDS.warn.bytes)) return "warn";
+    return "ok";
+}
+
+function worse(a, b) {
+    const order = { ok: 0, warn: 1, fail: 2 };
+    return order[b] > order[a] ? b : a;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function fmt(n) {
+    if (n == null) return "—";
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function fmtPct(p) {
+    if (!Number.isFinite(p)) return "—";
+    const sign = p > 0 ? "+" : "";
+    return `${sign}${p.toFixed(1)}%`;
+}
+
+function fmtDelta(b) {
+    if (b == null) return "—";
+    if (b === 0) return "0 B";
+    const sign = b > 0 ? "+" : "-";
+    return `${sign}${fmt(Math.abs(b))}`;
+}
+
+function severityIcon(s) {
+    return { ok: "🟢", warn: "🟡", fail: "🔴" }[s] ?? "⚪";
+}
+
+function renderReportMd(report) {
+    const lines = [];
+    lines.push(`# Bundle size report`);
+    lines.push(``);
+    lines.push(`Generated ${report.generatedAt} · node ${report.node} · esbuild ${report.esbuild}`);
+    lines.push(``);
+    lines.push(`| Package | Entry | Ship gzip | Bundled gzip | Shaken gzip | Shake ratio |`);
+    lines.push(`|---|---|---:|---:|---:|---:|`);
+    for (const [name, pkg] of Object.entries(report.packages)) {
+        for (const [sub, e] of Object.entries(pkg.entries)) {
+            lines.push(
+                `| \`${name}\` | \`${sub}\` | ${fmt(e.ship?.gzip)} | ${fmt(e.bundled?.gzip)} | ${fmt(e.shaken?.gzip)} | ${e.shakeRatio != null ? `${(e.shakeRatio * 100).toFixed(0)}%` : "—"} |`,
+            );
+        }
+    }
+    return `${lines.join("\n")}\n`;
+}
+
+function renderDiffMd(rows, ctx) {
+    const lines = [];
+    lines.push(`<!-- product-sdk-bundle-size -->`);
+    lines.push(`## 📦 Bundle size impact`);
+    lines.push(``);
+    lines.push(`Comparing \`${ctx.base.generatedAt}\` → \`${ctx.head.generatedAt}\``);
+    lines.push(``);
+
+    const changed = rows.filter(
+        (r) => r.severity !== "ok" || (r.deltaBytes != null && r.deltaBytes !== 0),
+    );
+
+    if (changed.length === 0) {
+        lines.push(`No size changes detected. 🟢`);
+        return `${lines.join("\n")}\n`;
+    }
+
+    lines.push(
+        `| | Package | Entry | Bundled before | Bundled after | Δ | Ship gzip Δ | Shake ratio |`,
+    );
+    lines.push(`|---|---|---|---:|---:|---:|---:|---:|`);
+    for (const r of changed) {
+        if (r.note) {
+            lines.push(
+                `| ${severityIcon(r.severity)} | \`${r.name}\` | \`${r.subpath}\` | — | — | ${r.note} | — | — |`,
+            );
+            continue;
+        }
+        const shipDelta =
+            r.shipGzipAfter != null && r.shipGzipBefore != null
+                ? r.shipGzipAfter - r.shipGzipBefore
+                : null;
+        const shake =
+            r.shakeAfter != null
+                ? `${(r.shakeAfter * 100).toFixed(0)}%${r.shakeBefore != null ? ` (was ${(r.shakeBefore * 100).toFixed(0)}%)` : ""}`
+                : "—";
+        lines.push(
+            `| ${severityIcon(r.severity)} | \`${r.name}\` | \`${r.subpath}\` | ${fmt(r.bundledBefore)} | ${fmt(r.bundledAfter)} | ${fmtDelta(r.deltaBytes)} (${fmtPct(r.deltaPct)}) | ${shipDelta != null ? fmtDelta(shipDelta) : "—"} | ${shake} |`,
+        );
+    }
+
+    lines.push(``);
+    lines.push(
+        `Thresholds — warn: ≥${THRESHOLDS.warn.pct}% or ≥${fmt(THRESHOLDS.warn.bytes)} · fail: ≥${THRESHOLDS.fail.pct}% or ≥${fmt(THRESHOLDS.fail.bytes)} (bundled).`,
+    );
+    return `${lines.join("\n")}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+    const [cmd, ...rest] = argv;
+    const args = { _: cmd };
+    for (let i = 0; i < rest.length; i++) {
+        const a = rest[i];
+        if (a.startsWith("--")) {
+            const key = a.slice(2);
+            const next = rest[i + 1];
+            if (next && !next.startsWith("--")) {
+                args[key] = next;
+                i++;
+            } else {
+                args[key] = true;
+            }
+        }
+    }
+    return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+switch (args._) {
+    case "measure":
+        await cmdMeasure(args);
+        break;
+    case "compare":
+        await cmdCompare(args);
+        break;
+    default:
+        console.error("Usage: bench-bundle.mjs <measure|compare> [options]");
+        console.error("  measure --out bundle-size.json [--md report.md]");
+        console.error("  compare --base before.json --head after.json [--md diff.md] [--strict]");
+        process.exit(2);
+}

--- a/product-sdk/scripts/bench-consumer/package.json
+++ b/product-sdk/scripts/bench-consumer/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@parity/product-sdk-bench-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@parity/product-sdk": "workspace:*",
+    "@parity/product-sdk-address": "workspace:*",
+    "@parity/product-sdk-bulletin": "workspace:*",
+    "@parity/product-sdk-chain-client": "workspace:*",
+    "@parity/product-sdk-contracts": "workspace:*",
+    "@parity/product-sdk-crypto": "workspace:*",
+    "@parity/product-sdk-descriptors": "workspace:*",
+    "@parity/product-sdk-host": "workspace:*",
+    "@parity/product-sdk-keys": "workspace:*",
+    "@parity/product-sdk-logger": "workspace:*",
+    "@parity/product-sdk-signer": "workspace:*",
+    "@parity/product-sdk-statement-store": "workspace:*",
+    "@parity/product-sdk-storage": "workspace:*",
+    "@parity/product-sdk-tx": "workspace:*",
+    "@parity/product-sdk-utils": "workspace:*"
+  }
+}


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                                    
  Adds a bundle-size benchmark that runs on every PR touching `product-sdk/` and posts a sticky comment with the size impact per package.                                                                                                           
                                                                                                                                                                                                                                                    
  For each `@parity/product-sdk-*` package and every umbrella subpath, we measure:                                                                                                                                                                  
  - **Ship**: raw + gzip + brotli of the dist file (what npm sends).
  - **Bundled**: esbuild bundle of `import * as M` (consumer ceiling).                                                                                                                                                                              
  - **Shaken**: esbuild bundle of one named import (tree-shaken cost).                                                                                                                                                                              
                                                                                                                                                                                                                                                    
  The shaken/bundled ratio surfaces tree-shake regressions directly. The first run already flags `@parity/product-sdk-storage` at 100% retention and a few others under 80% — follow-up work.                                                       
                                                                                                                                                                                                                                                    
  ## What's gated                                                                                                                                                                                                                                   
                                                            
  CI compares PR head vs base and fails the job on >20% or >15KB bundled growth. Warns at >10% / >5KB. Deps-dominated entries (>100KB baseline) gate on percentage only.