### PR TITLE
docs: fix local docs and remove stale extension references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,6 @@ The entire `content/api/` tree is generated from TSDoc comments in `product-sdk/
 
 ```bash
 pnpm docs:generate   # typedoc --json + custom MDX renderer
-pnpm docs:check      # regenerate and fail if content/api drifts (unused for now since content/api/ is gitignored)
 ```
 
 ### Generator internals

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Documentation site for `@parity/product-sdk`. Built with [Nextra 4](https://nextra.site) on Next.js 15 (static export), styled with `polkadot-design-system` tokens.
 
-Lives at the repo root (a sibling of `product-sdk/` and `repos/`) and runs as a standalone project. It is not part of the `product-sdk/` pnpm workspace.
+Lives at the repo root (a sibling of `product-sdk/`) and runs as a standalone project. It is not part of the `product-sdk/` pnpm workspace.
 
 ## Run locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,17 +9,21 @@ Lives at the repo root (a sibling of `product-sdk/` and `repos/`) and runs as a 
 ```bash
 cd docs
 pnpm install
+pnpm docs:generate   # required on first run — populates content/api/
 pnpm dev
 ```
 
 Open http://localhost:3000.
+
+> `pnpm dev` does not auto-regenerate the API reference. Re-run `pnpm docs:generate` after editing TSDoc comments in the SDK sources.
 
 > Search (Pagefind) is only populated by the production build. To test search locally, run `pnpm build && pnpm start` instead.
 
 ## Build
 
 ```bash
-pnpm build   # next build (static export to out/) + Pagefind postbuild
+pnpm docs:generate   # required — content/api/ is gitignored, must regenerate
+pnpm build           # next build (static export to out/) + Pagefind postbuild
 pnpm start  
 ```
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,8 +10,7 @@
     "start": "serve out",
     "docs:extract": "typedoc",
     "docs:render": "tsx scripts/generate-api.ts",
-    "docs:generate": "pnpm docs:extract && pnpm docs:render",
-    "docs:check": "pnpm docs:generate && git diff --exit-code content/api"
+    "docs:generate": "pnpm docs:extract && pnpm docs:render"
   },
   "dependencies": {
     "next": "^15.0.0",

--- a/product-sdk/README.md
+++ b/product-sdk/README.md
@@ -9,7 +9,7 @@ TypeScript SDK for building products in the Polkadot ecosystem. Provides typed A
 | `@parity/product-sdk` | Unified umbrella package — re-exports all modules |
 | `@parity/product-sdk-chain-client` | Multi-chain Polkadot API client with typed access to Asset Hub, Bulletin, and other chains |
 | `@parity/product-sdk-tx` | Transaction submission, lifecycle watching, and dev signers |
-| `@parity/product-sdk-signer` | Multi-provider signer manager — Host API, browser extensions, and dev accounts |
+| `@parity/product-sdk-signer` | Multi-provider signer manager — Host API and dev accounts |
 | `@parity/product-sdk-contracts` | Typed contract interactions on Polkadot Asset Hub |
 | `@parity/product-sdk-bulletin` | Upload and retrieve data on the Polkadot Bulletin Chain |
 | `@parity/product-sdk-statement-store` | Publish/subscribe client for the Polkadot Statement Store |

--- a/product-sdk/examples/signer-demo/README.md
+++ b/product-sdk/examples/signer-demo/README.md
@@ -10,9 +10,7 @@ E2E demo app for `@parity/product-sdk-signer`. Extends the [`tx-demo`](../tx-dem
 - Permission rejection via `testHost.setPermissionBehavior("reject-all")` / `revokePermission("TransactionSubmit")` — verifies the error surfaces cleanly through the `Result` type, not as a bare throw.
 - `disconnect()` + `connect()` lifecycle from a user click.
 
-Not covered (see [`tx-demo`](../tx-demo/README.md) caveats):
-
-- The browser extension / standalone path — the test SDK only simulates the host container.
+See [`tx-demo`](../tx-demo/README.md#caveats) for the shared test-SDK simulation caveats.
 
 ## Run locally
 

--- a/product-sdk/packages/sdk/src/core/types.ts
+++ b/product-sdk/packages/sdk/src/core/types.ts
@@ -147,7 +147,7 @@ export interface Account {
     address: string;
     /** Account name/label (if available) */
     name?: string;
-    /** Source of the account (extension name, host, etc.) */
+    /** Source of the account (host, dev signer, etc.) */
     source: string;
 }
 

--- a/product-sdk/packages/tx/src/batch.ts
+++ b/product-sdk/packages/tx/src/batch.ts
@@ -66,8 +66,8 @@ async function resolveDecodedCall(call: BatchableCall): Promise<unknown> {
  *   chain that has the Utility pallet — no chain-specific imports required.
  *   **All calls must target the same chain as this API.** Do not mix decoded calls
  *   from different chains (e.g., Asset Hub and Bulletin) in a single batch.
- * @param signer - The signer to use. Can come from a wallet extension, Host API
- *   (`getProductAccountSigner`), or {@link createDevSigner}.
+ * @param signer - The signer to use. Can come from the Host API
+ *   (`getProductAccountSigner`) or {@link createDevSigner}.
  * @param options - Optional {@link BatchSubmitOptions} (extends `SubmitOptions` with `mode`).
  * @returns The transaction result from the batch submission.
  *

--- a/product-sdk/packages/tx/src/submit.ts
+++ b/product-sdk/packages/tx/src/submit.ts
@@ -47,8 +47,8 @@ function buildTxResult(
  *
  * @param tx - A transaction object with `signSubmitAndWatch`. Works with raw PAPI
  *   transactions and Ink SDK `AsyncTransaction` wrappers (resolved automatically).
- * @param signer - The signer to use. Can come from a wallet extension, Host API
- *   (`getProductAccountSigner`), or {@link createDevSigner}.
+ * @param signer - The signer to use. Can come from the Host API
+ *   (`getProductAccountSigner`) or {@link createDevSigner}.
  * @param options - Submission options (waitFor, timeout, mortality, status callback).
  * @returns The transaction result once included/finalized.
  *

--- a/product-sdk/skills/product-sdk-app-builder/references/project-templates.md
+++ b/product-sdk/skills/product-sdk-app-builder/references/project-templates.md
@@ -143,7 +143,7 @@ import { formatBalance } from "@parity/product-sdk-utils";
 async function main() {
     const client = await getChainAPI("paseo");
 
-    // Connect to browser extension wallets
+    // Connect to host-provided accounts
     const signerManager = new SignerManager();
     await signerManager.connect();
 

--- a/product-sdk/skills/product-sdk-transactions/SKILL.md
+++ b/product-sdk/skills/product-sdk-transactions/SKILL.md
@@ -2,9 +2,8 @@
 name: product-sdk-transactions
 description: >
   Submit transactions, connect wallets, manage signers, and handle keys in product-sdk.
-  Use when: submitting transactions, connecting browser wallet extensions (Talisman, Polkadot.js,
-  SubWallet), integrating Host API signing (Polkadot Desktop/Mobile), managing multi-provider
-  wallet accounts, deriving keys, or creating dev signers for testnet.
+  Use when: submitting transactions, integrating Host API signing (Polkadot Desktop/Mobile),
+  managing multi-provider wallet accounts, deriving keys, or creating dev signers for testnet.
   Covers @parity/product-sdk-tx (submit/watch), @parity/product-sdk-signer (wallet connection, account
   management, multi-provider signing), and @parity/product-sdk-keys (key derivation, session keys).
 ---
@@ -176,7 +175,7 @@ const unsub = manager.subscribe((state) => {
   console.log(state.status, state.accounts, state.selectedAccount);
 });
 
-// Auto-detect: tries Host API (in container) or extensions (in browser)
+// Connect to the Host API (default). For testing, pass "dev": manager.connect("dev")
 const result = await manager.connect();
 
 if (result.ok) {

--- a/product-sdk/skills/product-sdk-transactions/references/signer-api.md
+++ b/product-sdk/skills/product-sdk-transactions/references/signer-api.md
@@ -4,7 +4,7 @@
 
 ## SignerManager
 
-Core orchestrator for signer management across multiple providers (Host API, browser extensions, dev accounts).
+Core orchestrator for signer management across the Host API and dev accounts.
 
 ```ts
 import { SignerManager } from "@parity/product-sdk-signer";
@@ -24,9 +24,8 @@ new SignerManager(options?: SignerManagerOptions)
 connect(providerType?: ProviderType): Promise<Result<SignerAccount[], SignerError>>
 ```
 
-Connect to a provider. If no provider type is specified, runs auto-detection:
-- Inside a container: Try Host API, fallback to extensions
-- Outside a container: Try extensions directly
+Connect to a provider. Defaults to the Host API; pass `"dev"` for dev accounts (testing).
+The SDK is designed for container-only usage — `connect()` with no argument always targets the Host API.
 
 #### selectAccount
 
@@ -80,17 +79,6 @@ import { DevProvider } from "@parity/product-sdk-signer";
 const provider = new DevProvider({ names: ["Alice", "Bob"] });
 ```
 
-### ExtensionProvider
-
-```ts
-import { ExtensionProvider } from "@parity/product-sdk-signer";
-
-const provider = new ExtensionProvider({
-  extensionName: "talisman",
-  dappName: "My App",
-});
-```
-
 ### HostProvider
 
 ```ts
@@ -111,8 +99,6 @@ All errors extend `SignerError`:
 - `HostUnavailableError`
 - `HostRejectedError`
 - `HostDisconnectedError`
-- `ExtensionNotFoundError`
-- `ExtensionRejectedError`
 - `SigningFailedError`
 - `NoAccountsError`
 - `TimeoutError`
@@ -123,7 +109,6 @@ All errors extend `SignerError`:
 
 ```ts
 function isHostError(e: SignerError): boolean
-function isExtensionError(e: SignerError): boolean
 ```
 
 ---
@@ -164,7 +149,7 @@ type ConnectionStatus = "disconnected" | "connecting" | "connected";
 ### ProviderType
 
 ```ts
-type ProviderType = "host" | "extension" | "dev";
+type ProviderType = "host" | "dev";
 ```
 
 ### Result


### PR DESCRIPTION
### Description
Fixes local docs setup and clears stale extension references after #21 (container-only refactor) and #33
(submodule removal).

### Changes
- docs README: added `pnpm docs:generate` step to run locally - required since `content/api/` is gitignored
- Removed broken `docs:check` script
- Removed `repos/` reference (#33 deleted the submodule)
- Removed extension references in docs, skill files, and TSDoc (#21 removed extension support)

### How to test
- Fresh checkout: `cd docs && pnpm install && pnpm docs:generate && pnpm dev` works
- `pnpm docs:generate && pnpm build` generates a working export
- No remaining "browser extension" references