### PR TITLE
fix(descriptors): update exports from .mjs to .js for papi 2.x

### DIFF
--- a/product-sdk/packages/descriptors/chains/bulletin/generated/package.json
+++ b/product-sdk/packages/descriptors/chains/bulletin/generated/package.json
@@ -4,21 +4,22 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "module": "./dist/index.mjs",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "module": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "browser": "./dist/index.mjs",
+  "module": "./dist/index.js",
+  "browser": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "polkadot-api": ">=1.21.0"
+    "polkadot-api": ">=2.0.0"
   }
 }

--- a/product-sdk/packages/descriptors/chains/individuality/generated/package.json
+++ b/product-sdk/packages/descriptors/chains/individuality/generated/package.json
@@ -4,21 +4,22 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "module": "./dist/index.mjs",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "module": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "browser": "./dist/index.mjs",
+  "module": "./dist/index.js",
+  "browser": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "polkadot-api": ">=1.21.0"
+    "polkadot-api": ">=2.0.0"
   }
 }

--- a/product-sdk/packages/descriptors/chains/kusama-asset-hub/.papi/polkadot-api.json
+++ b/product-sdk/packages/descriptors/chains/kusama-asset-hub/.papi/polkadot-api.json
@@ -1,12 +1,12 @@
 {
-    "version": 0,
-    "descriptorPath": "generated",
-    "entries": {
-        "kusama_asset_hub": {
-            "chain": "ksmcc3_asset_hub",
-            "metadata": "../../.papi/metadata/kusama_asset_hub.scale",
-            "genesis": "0x48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
-            "codeHash": "0xdefa3628d113f815fda8bbf9874c879adec02779df43737d77473347e72138c6"
-        }
+  "version": 0,
+  "descriptorPath": "generated",
+  "entries": {
+    "kusama_asset_hub": {
+      "chain": "kusama_asset_hub",
+      "metadata": "../../.papi/metadata/kusama_asset_hub.scale",
+      "genesis": "0x48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+      "codeHash": "0xdefa3628d113f815fda8bbf9874c879adec02779df43737d77473347e72138c6"
     }
+  }
 }

--- a/product-sdk/packages/descriptors/chains/kusama-asset-hub/generated/package.json
+++ b/product-sdk/packages/descriptors/chains/kusama-asset-hub/generated/package.json
@@ -4,21 +4,22 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "module": "./dist/index.mjs",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "module": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "browser": "./dist/index.mjs",
+  "module": "./dist/index.js",
+  "browser": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "polkadot-api": ">=1.21.0"
+    "polkadot-api": ">=2.0.0"
   }
 }

--- a/product-sdk/packages/descriptors/chains/paseo-asset-hub/generated/package.json
+++ b/product-sdk/packages/descriptors/chains/paseo-asset-hub/generated/package.json
@@ -4,21 +4,22 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "module": "./dist/index.mjs",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "module": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "browser": "./dist/index.mjs",
+  "module": "./dist/index.js",
+  "browser": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "polkadot-api": ">=1.21.0"
+    "polkadot-api": ">=2.0.0"
   }
 }

--- a/product-sdk/packages/descriptors/chains/polkadot-asset-hub/generated/package.json
+++ b/product-sdk/packages/descriptors/chains/polkadot-asset-hub/generated/package.json
@@ -4,21 +4,22 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "module": "./dist/index.mjs",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "module": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "browser": "./dist/index.mjs",
+  "module": "./dist/index.js",
+  "browser": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "polkadot-api": ">=1.21.0"
+    "polkadot-api": ">=2.0.0"
   }
 }

--- a/product-sdk/packages/descriptors/package.json
+++ b/product-sdk/packages/descriptors/package.json
@@ -8,28 +8,23 @@
     "exports": {
         "./bulletin": {
             "types": "./chains/bulletin/generated/dist/index.d.ts",
-            "import": "./chains/bulletin/generated/dist/index.mjs",
-            "require": "./chains/bulletin/generated/dist/index.js"
+            "import": "./chains/bulletin/generated/dist/index.js"
         },
         "./individuality": {
             "types": "./chains/individuality/generated/dist/index.d.ts",
-            "import": "./chains/individuality/generated/dist/index.mjs",
-            "require": "./chains/individuality/generated/dist/index.js"
+            "import": "./chains/individuality/generated/dist/index.js"
         },
         "./kusama-asset-hub": {
             "types": "./chains/kusama-asset-hub/generated/dist/index.d.ts",
-            "import": "./chains/kusama-asset-hub/generated/dist/index.mjs",
-            "require": "./chains/kusama-asset-hub/generated/dist/index.js"
+            "import": "./chains/kusama-asset-hub/generated/dist/index.js"
         },
         "./paseo-asset-hub": {
             "types": "./chains/paseo-asset-hub/generated/dist/index.d.ts",
-            "import": "./chains/paseo-asset-hub/generated/dist/index.mjs",
-            "require": "./chains/paseo-asset-hub/generated/dist/index.js"
+            "import": "./chains/paseo-asset-hub/generated/dist/index.js"
         },
         "./polkadot-asset-hub": {
             "types": "./chains/polkadot-asset-hub/generated/dist/index.d.ts",
-            "import": "./chains/polkadot-asset-hub/generated/dist/index.mjs",
-            "require": "./chains/polkadot-asset-hub/generated/dist/index.js"
+            "import": "./chains/polkadot-asset-hub/generated/dist/index.js"
         }
     },
     "scripts": {
@@ -46,7 +41,6 @@
     "files": [
         "chains/*/generated/dist/**/*.js",
         "chains/*/generated/dist/**/*.d.ts",
-        "chains/*/generated/dist/**/*.mjs",
         "chains/*/.papi/**/*"
     ]
 }

--- a/product-sdk/packages/descriptors/scripts/build.sh
+++ b/product-sdk/packages/descriptors/scripts/build.sh
@@ -12,7 +12,7 @@ for chain in $CHAINS; do
     dir="chains/$chain"
 
     # Skip if already built
-    if [ -f "$dir/generated/dist/index.mjs" ]; then
+    if [ -f "$dir/generated/dist/index.js" ]; then
         echo "  Skipping $chain (already built)"
         continue
     fi


### PR DESCRIPTION
## Summary
- polkadot-api 2.x changed `papi generate` to output `.js` instead of `.mjs`
- Updated descriptors package exports, generated `package.json` files, build script skip-check, and `files` globs to match the new output
- Fixes `pnpm build` failure: `Rollup failed to resolve import "@parity/product-sdk-descriptors/paseo-asset-hub"`

## Test plan
- [x] `pnpm build` completes successfully