### PR TITLE
docs: keep host URL params on client-side navigation

### DIFF
--- a/docs/app/_components/preserve-host-params.tsx
+++ b/docs/app/_components/preserve-host-params.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+// dot.li (and similar sandbox hosts) load each app inside an iframe at
+// `<cid>.app.dot.li` and re-validate URL params (`contentBackend`,
+// `chainBackend`, `skipArchiveCache`, ...) on every page load. Next.js
+// soft navigation rewrites the URL via history.pushState and drops query
+// params by default, which trips the host validator the next time anything
+// re-bootstraps the iframe.
+//
+// Strategy: on first navigation effect after mount, capture whatever
+// params the host put in the URL. After every subsequent navigation,
+// re-add any missing stashed params via history.replaceState — that
+// updates the address bar without triggering navigation or pushing a
+// history entry.
+
+const STORAGE_KEY = "__host_url_params";
+
+function PreserveHostParamsInner() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const url = new URL(window.location.href);
+    const current = url.searchParams;
+
+    let stashed = sessionStorage.getItem(STORAGE_KEY);
+    if (stashed === null && current.toString().length > 0) {
+      stashed = current.toString();
+      sessionStorage.setItem(STORAGE_KEY, stashed);
+    }
+    if (!stashed) return;
+
+    const stashedParams = new URLSearchParams(stashed);
+    let changed = false;
+    stashedParams.forEach((value, key) => {
+      if (!current.has(key)) {
+        current.set(key, value);
+        changed = true;
+      }
+    });
+    if (changed) {
+      window.history.replaceState(window.history.state, "", url.toString());
+    }
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+export function PreserveHostParams() {
+  // useSearchParams requires a Suspense boundary in Next 15 / static export.
+  return (
+    <Suspense fallback={null}>
+      <PreserveHostParamsInner />
+    </Suspense>
+  );
+}

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -4,6 +4,7 @@ import { Layout, Navbar } from "nextra-theme-docs";
 import { Head, Search } from "nextra/components";
 import { getPageMap } from "nextra/page-map";
 import { Logo } from "./_components/logo";
+import { PreserveHostParams } from "./_components/preserve-host-params";
 import "./globals.css";
 
 const inter = Inter({
@@ -49,6 +50,7 @@ export default async function RootLayout({
     >
       <Head />
       <body className="bg-surface-main text-primary font-sans antialiased">
+        <PreserveHostParams />
         <Layout
           navbar={navbar}
           pageMap={pageMap}


### PR DESCRIPTION
## Summary

Fixes "Invalid sandbox URL — Missing required URL param `contentBackend`" when navigating between sections of the deployed docs site on dot.li

<img width="529" height="435" alt="image" src="https://github.com/user-attachments/assets/d127b5e5-69d0-4428-a050-bfa3de9dadab" />
When the docs site is deployed to dot.li, every internal `<Link>` click eventually causes the sandbox to fail with:

> Invalid sandbox URL — Missing required URL param `contentBackend`. The host did not specify a backend — reload from dot.li.

It happens reliably after a few in-app navigations, or immediately on any reload that follows an internal click.

## Why

dot.li loads each app inside an iframe at `<cid>.app.dot.li` and the sandbox bootstrap validates required URL params (`contentBackend`, `chainBackend`, `skipArchiveCache`, ...) on every page load. From dot.li's bootstrap:

```ts
// The sandbox lives on cid.app.dot.li and cannot read the host's
// localStorage, so every user-chosen axis MUST arrive via URL param.
const urlParams = new URL(window.location.href).searchParams;
const parsed = validateSandboxParams(urlParams);
if (!parsed.ok) {
  showError("Invalid sandbox URL", parsed.reason);
  return;
}
```

Next.js App Router (with `output: "export"`) does soft navigation via `history.pushState`, which rewrites the path but drops the query string. The address bar goes from `…?contentBackend=…&chainBackend=…` to just `/api/sdk/`. Any subsequent reload (manual, browser history navigation, dev tools refresh, anchor that triggers a bootstrap, etc.) re-runs the validator against a now-paramless URL and fails.

This is a contract every sandbox-hosted app has to satisfy. It is not specific to Next.js. Any app using client-side routing (Vite + React Router, Vue Router, SvelteKit, etc.) hits the same wall once deployed to dot.li.
