### PR TITLE
fix: enable `treeshake` to drop dead in-source test code from published bundles

### DIFF
--- a/product-sdk/packages/address/tsup.config.ts
+++ b/product-sdk/packages/address/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/bulletin/tsup.config.ts
+++ b/product-sdk/packages/bulletin/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/chain-client/tsup.config.ts
+++ b/product-sdk/packages/chain-client/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     external: ["@parity/product-sdk-descriptors"],
     define: {
         "import.meta.vitest": "undefined",

--- a/product-sdk/packages/contracts/tsup.config.ts
+++ b/product-sdk/packages/contracts/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/crypto/tsup.config.ts
+++ b/product-sdk/packages/crypto/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/host/tsup.config.ts
+++ b/product-sdk/packages/host/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/keys/tsup.config.ts
+++ b/product-sdk/packages/keys/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/logger/tsup.config.ts
+++ b/product-sdk/packages/logger/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/sdk/tsup.config.ts
+++ b/product-sdk/packages/sdk/tsup.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     external: ["react"],
     define: {
         "import.meta.vitest": "undefined",

--- a/product-sdk/packages/signer/tsup.config.ts
+++ b/product-sdk/packages/signer/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     external: ["@novasamatech/product-sdk", "@novasamatech/host-api"],
     define: {
         "import.meta.vitest": "undefined",

--- a/product-sdk/packages/statement-store/tsup.config.ts
+++ b/product-sdk/packages/statement-store/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     external: ["@novasamatech/sdk-statement", "@novasamatech/product-sdk"],
     define: {
         "import.meta.vitest": "undefined",

--- a/product-sdk/packages/storage/tsup.config.ts
+++ b/product-sdk/packages/storage/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/tx/tsup.config.ts
+++ b/product-sdk/packages/tx/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/utils/tsup.config.ts
+++ b/product-sdk/packages/utils/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
     target: "es2022",
+    treeshake: true,
     define: {
         "import.meta.vitest": "undefined",
     },


### PR DESCRIPTION
## Summary

Enables `treeshake: true` in every `tsup.config.ts` across the SDK packages. This eliminates the dead `if (import.meta.vitest) { ... }` branches from the published `dist/index.js` files, which were leaking unused `await` expressions at the top level and causing `topLevelAwait` warnings in webpack-based consumers.

One-line change per package, 14 packages affected. No source-code changes.

## The warning

Consumers of the SDK (e.g. `t3rminal` running `next dev --webpack`) see this on every build:

```
⚠ ./node_modules/@parity/product-sdk-logger/dist/index.js
The generated code contains 'async/await' because this module is using "topLevelAwait".
However, your target environment does not appear to support 'async/await'.
As a result, the code may not run as expected or may cause runtime errors.

Import trace for requested module:
./node_modules/@parity/product-sdk-logger/dist/index.js
./node_modules/@parity/product-sdk-host/dist/index.js
./node_modules/@parity/product-sdk/dist/host/index.js
```

The warning fires for `@parity/product-sdk-logger`, `@parity/product-sdk-host`, and transitively for any consumer importing from `@parity/product-sdk`.

## Root cause

Every SDK source file uses Vitest's **in-source testing** pattern, with test setup that does dynamic imports inside the guard:

```ts
// packages/logger/src/create-logger.ts
if (import.meta.vitest) {
    const { test, expect, describe, beforeEach } = import.meta.vitest;
    const { configure } = await import("./configure.js");   // top-level await
    const { resetState } = await import("./state.js");       // top-level await
    // ...tests...
}
```

## Verification

After rebuilding all packages with the new config:

- **No `await null`, `await 0`, `import.meta`, or `if (undefined)` remnants** in any `packages/*/dist/index.js`. Verified with `grep`.
- **All remaining `await` keywords** in the dists are inside `async function` bodies (legitimate runtime awaits), not top-level. Sampled `host`, `keys`, `signer`, `tx`, `storage`.

