### PR TITLE
refactor: Docs auto discover packages from the workspace

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -21,3 +21,4 @@ out/
 
 # bulletin-deploy CAR snapshots (written next to the build dir)
 *.car
+typedoc.generated.json

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "postbuild": "pagefind --site out --output-path out/_pagefind",
     "start": "serve out",
-    "docs:extract": "typedoc",
+    "docs:extract": "tsx scripts/extract.ts",
     "docs:render": "tsx scripts/generate-api.ts",
     "docs:generate": "pnpm docs:extract && pnpm docs:render"
   },

--- a/docs/scripts/extract.ts
+++ b/docs/scripts/extract.ts
@@ -1,0 +1,45 @@
+// Pre-extract step for `docs:extract`.
+//
+// Discovers documentable packages via the workspace registry and writes a
+// `typedoc.generated.json` whose `entryPoints` list is built dynamically.
+// TypeDoc is then invoked against the generated config.
+//
+// This lets adding/renaming/removing a package "just work" — the registry
+// picks up any folder under `packages/` that contains `package.json` + a
+// `src/index.ts`. Tooling-only packages without `src/index.ts` (e.g.
+// `descriptors`) are skipped automatically.
+
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { discoverPackages } from "./lib/registry.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOCS_ROOT = resolve(__dirname, "..");
+const PACKAGES_DIR = resolve(DOCS_ROOT, "..", "product-sdk", "packages");
+const BASE_CONFIG_PATH = resolve(DOCS_ROOT, "typedoc.json");
+const GENERATED_CONFIG_PATH = resolve(DOCS_ROOT, "typedoc.generated.json");
+
+const baseConfig = JSON.parse(readFileSync(BASE_CONFIG_PATH, "utf8")) as Record<string, unknown>;
+const registry = discoverPackages(PACKAGES_DIR);
+if (registry.folders.size === 0) {
+  console.error(`No documentable packages discovered in ${PACKAGES_DIR}`);
+  process.exit(1);
+}
+
+const entryPoints = [...registry.folders]
+  .sort()
+  .map((folder) => `../product-sdk/packages/${folder}`);
+
+const generatedConfig = { ...baseConfig, entryPoints };
+writeFileSync(GENERATED_CONFIG_PATH, JSON.stringify(generatedConfig, null, 2) + "\n", "utf8");
+
+console.log(`docs:extract — ${entryPoints.length} package(s): ${[...registry.folders].sort().join(", ")}`);
+
+const child = spawn("typedoc", ["--options", GENERATED_CONFIG_PATH], {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+child.on("close", (code) => process.exit(code ?? 0));

--- a/docs/scripts/generate-api.ts
+++ b/docs/scripts/generate-api.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { kebab, packageSlug } from "./lib/kebab.js";
+import { discoverPackages, type PackageRegistry } from "./lib/registry.js";
 import {
   getOwnExportGroups,
   renderPackageOverview,
@@ -13,10 +14,17 @@ import { Kind, type Declaration, type Project } from "./lib/types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DOCS_ROOT = resolve(__dirname, "..");
+const PACKAGES_DIR = resolve(DOCS_ROOT, "..", "product-sdk", "packages");
 const API_JSON = join(DOCS_ROOT, "generated/api.json");
 const API_CONTENT = join(DOCS_ROOT, "content/api");
 
-function ownFolderFor(pkg: Declaration): string {
+// The on-disk folder for a package, looked up from the workspace registry.
+// Falls back to deriving the folder from the package name if a TypeDoc-emitted
+// package isn't in the registry (shouldn't happen — guards a future scenario
+// where TypeDoc surfaces a package that lacks a discoverable package.json).
+function ownFolderFor(pkg: Declaration, registry: PackageRegistry): string {
+  const folder = registry.nameToFolder.get(pkg.name);
+  if (folder) return folder;
   if (pkg.name === "@parity/product-sdk") return "sdk";
   return pkg.name.replace(/^@parity\/product-sdk-/, "");
 }
@@ -33,8 +41,13 @@ function labelFor(item: Declaration): string {
 // Build the per-package sidebar: symbols grouped by kind with separator
 // headers, each symbol linking to an anchor on the package's own page so
 // navigation stays within the single consolidated document.
-function buildPackageSidebar(pkg: Declaration, ownFolder: string, slug: string): MetaEntry[] {
-  const groups = getOwnExportGroups(pkg, ownFolder);
+function buildPackageSidebar(
+  pkg: Declaration,
+  ownFolder: string,
+  slug: string,
+  registry: PackageRegistry,
+): MetaEntry[] {
+  const groups = getOwnExportGroups(pkg, ownFolder, registry);
   // "Overview" points back to the package page itself (without a fragment),
   // so clicking it takes the reader to the top of the consolidated page.
   // Without this entry, Nextra labels the index page by its frontmatter
@@ -55,15 +68,18 @@ function buildPackageSidebar(pkg: Declaration, ownFolder: string, slug: string):
   return entries;
 }
 
-async function generateForPackage(pkg: Declaration): Promise<string> {
+async function generateForPackage(
+  pkg: Declaration,
+  registry: PackageRegistry,
+): Promise<string> {
   const slug = packageSlug(pkg.name);
-  const ownFolder = ownFolderFor(pkg);
+  const ownFolder = ownFolderFor(pkg, registry);
   const pkgDir = join(API_CONTENT, slug);
 
-  const overview = renderPackageOverview(pkg, ownFolder);
+  const overview = renderPackageOverview(pkg, ownFolder, registry);
   await writeFileAtomic(join(pkgDir, "index.mdx"), overview);
 
-  const sidebar = buildPackageSidebar(pkg, ownFolder, slug);
+  const sidebar = buildPackageSidebar(pkg, ownFolder, slug, registry);
   await writeFileAtomic(join(pkgDir, "_meta.ts"), renderMeta(sidebar));
 
   return slug;
@@ -105,13 +121,21 @@ async function main(): Promise<void> {
     throw new Error("No packages in TypeDoc JSON — did docs:extract run?");
   }
 
+  // Discover the workspace package registry once. This drives folder ↔ name
+  // resolution everywhere else, replacing what used to be a hardcoded list of
+  // folder names.
+  const registry = discoverPackages(PACKAGES_DIR);
+  if (registry.folders.size === 0) {
+    throw new Error(`No documentable packages discovered in ${PACKAGES_DIR}`);
+  }
+
   // Nuke-and-repave the generated tree. Everything under content/api/ is
   // generator-owned so stale artifacts never drift across runs.
   if (existsSync(API_CONTENT)) rmSync(API_CONTENT, { recursive: true, force: true });
 
   const packageInfos: { slug: string; name: string; summary: string }[] = [];
   for (const pkg of project.children) {
-    const slug = await generateForPackage(pkg);
+    const slug = await generateForPackage(pkg, registry);
     const rawSummary = (pkg.comment?.summary ?? [])
       .map((p) => ("text" in p ? (p as { text: string }).text : ""))
       .join("");

--- a/docs/scripts/lib/reexports.ts
+++ b/docs/scripts/lib/reexports.ts
@@ -1,4 +1,5 @@
 import { packageSlug } from "./kebab.js";
+import type { PackageRegistry } from "./registry.js";
 import type { Declaration } from "./types.js";
 
 // TypeDoc emits `sources[].fileName` paths whose prefix depends on the working
@@ -9,27 +10,9 @@ import type { Declaration } from "./types.js";
 //   - "sdk/src/core/types.ts"                (umbrella, sibling packages root)
 //   - "bulletin/dist/index.d.ts"             (umbrella, leaf consumed via dist)
 //   - "node_modules/.pnpm/.../dist/..."      (external re-export)
-// So we can't trust the first path segment — instead we look for a known SDK
-// package folder anywhere in the path, and fall back to treating the symbol as
-// own-package when no internal match is found.
-
-// These are the folders under product-sdk/packages/ we generate docs for.
-const INTERNAL_PACKAGE_FOLDERS = new Set([
-  "address",
-  "bulletin",
-  "chain-client",
-  "contracts",
-  "crypto",
-  "host",
-  "keys",
-  "logger",
-  "sdk",
-  "signer",
-  "statement-store",
-  "storage",
-  "tx",
-  "utils",
-]);
+// So we can't trust the first path segment — instead we look for any segment
+// that matches a folder discovered from the workspace registry, falling back
+// to "external" when no internal match is found.
 
 export function firstSourceFile(d: Declaration): string {
   return d.sources?.[0]?.fileName ?? "";
@@ -41,16 +24,20 @@ function isFromNodeModules(src: string): boolean {
 
 // Find which internal SDK package folder (if any) a declaration originates from.
 // Returns null for external / node_modules sources.
-export function originPackageFolder(d: Declaration): string | null {
+export function originPackageFolder(
+  d: Declaration,
+  registry: PackageRegistry,
+): string | null {
   const src = firstSourceFile(d);
   if (!src || isFromNodeModules(src)) return null;
 
-  // Match any segment that is a known internal package folder and is followed by
-  // /src/ or /dist/. Covers "packages/<f>/src/", "<f>/dist/", "product-sdk/packages/<f>/src/".
+  // Match any segment that is a known workspace package folder and is followed
+  // by /src/ or /dist/. Covers "packages/<f>/src/", "<f>/dist/",
+  // "product-sdk/packages/<f>/src/".
   const matches = src.matchAll(/(?:^|\/)([^/]+)\/(?:src|dist)\//g);
   for (const m of matches) {
     const folder = m[1]!;
-    if (INTERNAL_PACKAGE_FOLDERS.has(folder)) return folder;
+    if (registry.folders.has(folder)) return folder;
   }
   return null;
 }
@@ -61,17 +48,34 @@ export function originPackageFolder(d: Declaration): string | null {
 //     types re-exported from @polkadot-api/substrate-bindings). External re-exports
 //     should still get a standalone page under the leaf that re-exports them, since
 //     there's no internal doc page to link to.
-export function isOwnExport(d: Declaration, ownFolder: string): boolean {
-  const origin = originPackageFolder(d);
+export function isOwnExport(
+  d: Declaration,
+  ownFolder: string,
+  registry: PackageRegistry,
+): boolean {
+  const origin = originPackageFolder(d, registry);
   if (origin === null) return true;
   return origin === ownFolder;
 }
 
-export function isReExport(d: Declaration, ownFolder: string): boolean {
-  return !isOwnExport(d, ownFolder);
+export function isReExport(
+  d: Declaration,
+  ownFolder: string,
+  registry: PackageRegistry,
+): boolean {
+  return !isOwnExport(d, ownFolder, registry);
 }
 
-// Map package folder name (e.g. "signer") to the slug used for doc URLs.
-export function packageFolderToSlug(folder: string): string {
-  return packageSlug(`@parity/product-sdk-${folder}`);
+// Map a package folder name to its URL slug.
+//
+// The slug comes from the package's `name` field (kebab-cased after stripping
+// the `@parity/product-sdk-` prefix), NOT the folder. This decouples filesystem
+// layout from URL paths so a package can rename its `name` without renaming
+// the directory (or vice-versa) and still get correct cross-package links.
+export function packageFolderToSlug(
+  folder: string,
+  registry: PackageRegistry,
+): string | null {
+  const name = registry.folderToName.get(folder);
+  return name ? packageSlug(name) : null;
 }

--- a/docs/scripts/lib/registry.ts
+++ b/docs/scripts/lib/registry.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+export interface PackageRegistry {
+  /** Folder names under `packages/` that contain a documentable workspace package. */
+  folders: ReadonlySet<string>;
+  /** Map package name (from package.json `name`) → folder name. */
+  nameToFolder: ReadonlyMap<string, string>;
+  /** Map folder name → package name. */
+  folderToName: ReadonlyMap<string, string>;
+}
+
+// Scan `packagesDir` and build a registry of every documentable package.
+//
+// "Documentable" means the folder contains a `package.json` with a `name` field
+// AND a `src/index.ts` entry point. Packages without `src/index.ts` (e.g.
+// tooling packages like `descriptors` that only expose generated artifacts)
+// are intentionally skipped.
+//
+// The registry decouples the docs generator from any hardcoded list of
+// folders or package names, so renaming a package or adding a new one needs
+// no changes here.
+export function discoverPackages(packagesDir: string): PackageRegistry {
+  const folders = new Set<string>();
+  const nameToFolder = new Map<string, string>();
+  const folderToName = new Map<string, string>();
+
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const pkgDir = join(packagesDir, entry.name);
+    const pkgJsonPath = join(pkgDir, "package.json");
+    const entryFile = join(pkgDir, "src", "index.ts");
+    if (!existsSync(pkgJsonPath) || !existsSync(entryFile)) continue;
+
+    let pkgJson: { name?: string };
+    try {
+      pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as { name?: string };
+    } catch {
+      continue;
+    }
+    if (!pkgJson.name) continue;
+
+    folders.add(entry.name);
+    nameToFolder.set(pkgJson.name, entry.name);
+    folderToName.set(entry.name, pkgJson.name);
+  }
+
+  return { folders, nameToFolder, folderToName };
+}

--- a/docs/scripts/lib/render-package.ts
+++ b/docs/scripts/lib/render-package.ts
@@ -4,6 +4,7 @@ import {
   originPackageFolder,
   packageFolderToSlug,
 } from "./reexports.js";
+import type { PackageRegistry } from "./registry.js";
 import { firstLine, renderSummary } from "./render-comment.js";
 import { renderSymbolSection } from "./render-symbol.js";
 import { kindLabel } from "./render-type.js";
@@ -27,11 +28,17 @@ export interface OwnExportGroup {
 // Returns the package's own (non-re-exported) children grouped by kind in the
 // same order the overview page renders them. Used by both the overview
 // renderer and the sidebar _meta.ts builder so the two stay in sync.
-export function getOwnExportGroups(pkg: Declaration, ownFolder: string): OwnExportGroup[] {
+export function getOwnExportGroups(
+  pkg: Declaration,
+  ownFolder: string,
+  registry: PackageRegistry,
+): OwnExportGroup[] {
   const byId = new Map<number, Declaration>();
   (pkg.children ?? []).forEach((c) => byId.set(c.id, c));
   const ownIds = new Set(
-    (pkg.children ?? []).filter((c) => isOwnExport(c, ownFolder)).map((c) => c.id),
+    (pkg.children ?? [])
+      .filter((c) => isOwnExport(c, ownFolder, registry))
+      .map((c) => c.id),
   );
   const groups = pkg.groups ?? [];
   const result: OwnExportGroup[] = [];
@@ -80,7 +87,11 @@ function labelFor(item: Declaration): string {
   return item.kind === Kind.Function ? `${item.name}()` : item.name;
 }
 
-export function renderPackageOverview(pkg: Declaration, ownFolder: string): string {
+export function renderPackageOverview(
+  pkg: Declaration,
+  ownFolder: string,
+  registry: PackageRegistry,
+): string {
   const rawSummary = renderSummary(pkg.comment);
   const cleanedSummary = sanitizePackageSummary(rawSummary, pkg.name);
   const frontmatterDesc = firstLine(cleanedSummary);
@@ -107,8 +118,10 @@ export function renderPackageOverview(pkg: Declaration, ownFolder: string): stri
   (pkg.children ?? []).forEach((c) => byId.set(c.id, c));
   const groups = pkg.groups ?? [];
 
-  const ownChildren = (pkg.children ?? []).filter((c) => isOwnExport(c, ownFolder));
-  const reExportChildren = (pkg.children ?? []).filter((c) => !isOwnExport(c, ownFolder));
+  const ownChildren = (pkg.children ?? []).filter((c) => isOwnExport(c, ownFolder, registry));
+  const reExportChildren = (pkg.children ?? []).filter(
+    (c) => !isOwnExport(c, ownFolder, registry),
+  );
   const ownIds = new Set(ownChildren.map((c) => c.id));
 
   // Overview table: same-page anchor links grouped by kind.
@@ -153,14 +166,14 @@ export function renderPackageOverview(pkg: Declaration, ownFolder: string): stri
       .slice()
       .sort((a, b) => a.name.localeCompare(b.name))
       .forEach((item) => {
-        const folder = originPackageFolder(item);
-        const leafSlug = folder ? packageFolderToSlug(folder) : null;
+        const folder = originPackageFolder(item, registry);
+        const leafSlug = folder ? packageFolderToSlug(folder, registry) : null;
+        const leafPkgName = folder ? registry.folderToName.get(folder) ?? null : null;
         const href = leafSlug ? `/api/${leafSlug}/#${kebab(item.name)}` : null;
         const nameCell = href ? `[\`${labelFor(item)}\`](${href})` : `\`${labelFor(item)}\``;
         const kindCell = kindLabel(item.kind);
-        const leafPackage = folder
-          ? `[\`@parity/product-sdk-${folder}\`](/api/${leafSlug})`
-          : "—";
+        const leafPackage =
+          leafPkgName && leafSlug ? `[\`${leafPkgName}\`](/api/${leafSlug})` : "—";
         lines.push(`| ${nameCell} | ${kindCell} | ${leafPackage} |`);
       });
     lines.push("");

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -1,21 +1,6 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": [
-    "../product-sdk/packages/address",
-    "../product-sdk/packages/bulletin",
-    "../product-sdk/packages/chain-client",
-    "../product-sdk/packages/contracts",
-    "../product-sdk/packages/crypto",
-    "../product-sdk/packages/host",
-    "../product-sdk/packages/keys",
-    "../product-sdk/packages/logger",
-    "../product-sdk/packages/sdk",
-    "../product-sdk/packages/signer",
-    "../product-sdk/packages/statement-store",
-    "../product-sdk/packages/storage",
-    "../product-sdk/packages/tx",
-    "../product-sdk/packages/utils"
-  ],
+  "entryPoints": [],
   "entryPointStrategy": "packages",
   "packageOptions": {
     "entryPoints": ["src/index.ts"]


### PR DESCRIPTION
While working on the storage refactor in #54 I noticed that the current way that we where generating the docs with fixed paths was not ideal.

This PR future proofs the process by allowing the docs to auto discover the available packages allowing the generator to pick up on package name changes or new packages.