### PR TITLE
feat(contracts): add .prepare() for batching + cover cdm.json flow

### DIFF
--- a/product-sdk/packages/contracts/README.md
+++ b/product-sdk/packages/contracts/README.md
@@ -1,0 +1,224 @@
+# @parity/product-sdk-contracts
+
+Typed contract interactions on Polkadot Asset Hub. Resolve deployed contracts from a `cdm.json` manifest, get fully-typed handles for `query`, `tx`, and batched `prepare` calls — all backed by the ink SDK.
+
+## Install
+
+```bash
+pnpm add @parity/product-sdk-contracts
+```
+
+## Quick start (with cdm.json)
+
+The `cdm.json` flow is the primary path. A `cdm.json` manifest in your project root pins each contract to an address + ABI per target chain; `ContractManager.fromClient(cdm, api)` resolves them at runtime.
+
+```ts
+import { createChainClient } from "@parity/product-sdk-chain-client";
+import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
+import { ContractManager } from "@parity/product-sdk-contracts";
+import { SignerManager } from "@parity/product-sdk-signer";
+import cdmJson from "./cdm.json";
+
+const client = await createChainClient({
+    chains: { assetHub: paseo_asset_hub },
+    rpcs: { assetHub: ["wss://asset-hub-paseo-rpc.n.dwellir.com"] },
+});
+
+const signerManager = new SignerManager();
+await signerManager.connect();
+
+const manager = await ContractManager.fromClient(cdmJson, client.raw.assetHub, {
+    signerManager,
+});
+
+// Resolve by library name — typed handle returned.
+const registry = manager.getContract("@w3s/playground-registry");
+
+// Read state
+const { value } = await registry.publish.query("my-app00", "ipfs://...", 0);
+
+// Submit a tx (uses signerManager's logged-in account)
+await registry.publish.tx("my-app00", "ipfs://...", 0);
+```
+
+## `ContractManager` API
+
+### `ContractManager.fromClient(cdmJson, client, options?)`
+
+Async factory. Lazy-imports `@polkadot-api/sdk-ink` (~4 MB) only when called, so the install footprint stays small for callers who never resolve contracts.
+
+| Param | Type | Notes |
+| --- | --- | --- |
+| `cdmJson` | `CdmJson` | Imported `cdm.json` |
+| `client` | `PolkadotClient` | E.g. `client.raw.assetHub` |
+| `options.signerManager?` | `SignerManager` | Resolves signer + origin from the logged-in account |
+| `options.defaultOrigin?` | `SS58String` | Static fallback origin for queries |
+| `options.defaultSigner?` | `PolkadotSigner` | Static fallback signer for txs |
+| `options.targetHash?` | `string` | Pin to a specific target. Defaults to first target in the manifest. |
+
+### `manager.getContract(library)`
+
+Returns a typed `Contract<C>` handle. Each ABI method exposes:
+
+- `.query(...args, opts?)` — read-only dry-run; returns `{ success, value, gasRequired }`
+- `.tx(...args, opts?)` — sign, submit, and watch; resolves at best-block
+- `.prepare(...args, opts?)` — batch-ready handle (see *Batching* below)
+
+When codegen-generated types are present, the call is fully typed:
+
+```ts
+const registry = manager.getContract("@w3s/playground-registry");
+//                                    ^ autocompletes from cdm.json
+await registry.publish.tx("domain", "ipfs://cid", 0);
+//             ^ method name typed
+//                       ^ args typed
+```
+
+Throws `ContractNotFoundError` if the library name isn't in the manifest for the active target.
+
+### `manager.getAddress(library)`
+
+Returns the on-chain address. Useful for logging or display.
+
+### `manager.setDefaults(defaults)`
+
+Update `origin`, `signer`, or `signerManager` after construction. Only the fields you pass are updated.
+
+## Signer / origin resolution
+
+Order, highest wins:
+
+1. Explicit `{ signer }` / `{ origin }` in the call options
+2. `signerManager`'s currently selected account
+3. Static `defaultSigner` / `defaultOrigin`
+4. (Queries only) Dev fallback (Alice) for dry-run gas estimation
+
+Throws `ContractSignerMissingError` from `.tx()` if no signer is available. `.query()` and `.prepare()` never need a signer.
+
+## Batching with `.prepare()`
+
+Use `.prepare()` to build `BatchableCall` handles consumable by `batchSubmitAndWatch` from `@parity/product-sdk-tx`. Combine multiple contract calls — or contract calls mixed with other Asset Hub transactions — into a single atomic `Utility.batch_all` extrinsic.
+
+```ts
+import { batchSubmitAndWatch } from "@parity/product-sdk-tx";
+
+const a = registry.publish.prepare("app-one00", "ipfs://...", 0);
+const b = registry.publish.prepare("app-two00", "ipfs://...", 0);
+
+await batchSubmitAndWatch([a, b], client.raw.assetHub, signer);
+```
+
+**`.prepare()` doesn't require a signer.** The resolved origin is used purely for dry-run gas estimation; the batch submission's signer is the dispatched origin at submission time.
+
+`PrepareOptions` accepts: `origin`, `value`, `gasLimit`, `storageDepositLimit`. Signer and submission lifecycle options (`signer`, `waitFor`, etc.) are intentionally absent — those belong to the batch submit, not the individual prepared call.
+
+## Without cdm.json — manual path
+
+If you don't have a `cdm.json` (or want to test against a contract not yet in your manifest), use `createContract` / `createContractFromClient` with an explicit address and ABI:
+
+```ts
+import { createContractFromClient } from "@parity/product-sdk-contracts";
+
+const counter = await createContractFromClient(
+    client.raw.assetHub,
+    "0xC472...",
+    counterAbi,
+    { signerManager },
+);
+
+const { value } = await counter.getCount.query();
+await counter.increment.tx();
+```
+
+`createContract` is the same but takes a pre-created `InkSdk` if you want to control when `@polkadot-api/sdk-ink` loads.
+
+## cdm.json schema
+
+Top-level shape:
+
+```jsonc
+{
+  "targets": {
+    "<targetHash>": {
+      "asset-hub": "wss://asset-hub-paseo-rpc.n.dwellir.com",
+      "bulletin": "https://paseo-ipfs.polkadot.io/ipfs"
+    }
+  },
+  "dependencies": {
+    "<targetHash>": {
+      "@org/contract-name": "latest"
+    }
+  },
+  "contracts": {
+    "<targetHash>": {
+      "@org/contract-name": {
+        "version": 6,
+        "address": "0x4A37B123b0BA2A894cA5953f472264921d44e298",
+        "abi": [ /* Solidity-compatible ABI entries */ ]
+      }
+    }
+  }
+}
+```
+
+`<targetHash>` is a 16-character hex string identifying a chain runtime + Bulletin gateway pairing. A manifest can declare multiple targets; `ContractManager` defaults to the first, or pin one via `options.targetHash`.
+
+A real-world example: [`paritytech/playground-cli/cdm.json`](https://github.com/paritytech/playground-cli/blob/main/cdm.json).
+
+## Type generation
+
+`generateContractTypes(...)` (from `@parity/product-sdk-contracts/codegen`) emits a `.d.ts` that augments the package's `Contracts` interface so `manager.getContract("@org/name")` returns a fully-typed handle:
+
+```ts
+import { generateContractTypes } from "@parity/product-sdk-contracts/codegen";
+import cdm from "./cdm.json";
+import { writeFileSync } from "node:fs";
+
+const src = generateContractTypes(cdm);
+writeFileSync(".cdm/contracts.d.ts", src);
+```
+
+Wire `.cdm/contracts.d.ts` into your `tsconfig.json`'s `include` and the next time you call `getContract("@org/name")`, the method names, parameter types, and return types come straight from the ABI.
+
+Without codegen, `getContract()` still works — methods are accessible but untyped (`Contract<ContractDef>`).
+
+## Errors
+
+| Error | When |
+| --- | --- |
+| `ContractNotFoundError` | `getContract(name)` and `name` isn't in the manifest for the active target |
+| `ContractSignerMissingError` | `.tx()` called with no signer + no signerManager + no defaultSigner |
+| Generic | ABI decode failures, RPC errors, gas estimation failures — surface from the underlying ink SDK |
+
+## Public API
+
+```ts
+export {
+    ContractManager,
+    createContract,
+    createContractFromClient,
+    generateContractTypes,
+    ContractError,
+    ContractSignerMissingError,
+    ContractNotFoundError,
+};
+export type {
+    CdmJson,
+    CdmJsonTarget,
+    CdmJsonContract,
+    AbiParam,
+    AbiEntry,
+    Contract,
+    ContractDef,
+    Contracts,
+    QueryResult,
+    QueryOptions,
+    TxOptions,
+    TxResult,
+    PrepareOptions,
+    BatchableCall,
+    ContractDefaults,
+    ContractManagerOptions,
+    ContractOptions,
+};
+```

--- a/product-sdk/packages/contracts/src/index.ts
+++ b/product-sdk/packages/contracts/src/index.ts
@@ -28,6 +28,8 @@ export type {
     QueryOptions,
     TxOptions,
     TxResult,
+    PrepareOptions,
+    BatchableCall,
     ContractDefaults,
     ContractManagerOptions,
     ContractOptions,

--- a/product-sdk/packages/contracts/src/manager.ts
+++ b/product-sdk/packages/contracts/src/manager.ts
@@ -200,3 +200,196 @@ export async function createContractFromClient(
     const inkSdk = createInkSdk(client, { atBest: true });
     return createContract(inkSdk, address, abi, options);
 }
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    /**
+     * Real-world cdm.json structure as it appears in
+     * `paritytech/playground-cli/cdm.json`. Used here as the reproducer
+     * for the cdm-resolution flow: if `getContract()` works against
+     * this manifest shape, it works against any consumer's manifest.
+     *
+     * Notable shape differences from the generated examples:
+     *   - `metadataCid` is absent (made optional in 0.2.1)
+     *   - target hash is a single 16-char hex string
+     *   - `dependencies` uses `"latest"` for version
+     *   - contract addresses are 20-byte EVM-shaped (Polkadot Asset Hub
+     *     uses Solidity-compatible addresses for Revive contracts)
+     */
+    const playgroundCdm: CdmJson = {
+        targets: {
+            acc2c3b5e912b762: {
+                "asset-hub": "wss://asset-hub-paseo-rpc.n.dwellir.com",
+                bulletin: "https://paseo-ipfs.polkadot.io/ipfs",
+            },
+        },
+        dependencies: {
+            acc2c3b5e912b762: {
+                "@w3s/playground-registry": "latest",
+            },
+        },
+        contracts: {
+            acc2c3b5e912b762: {
+                "@w3s/playground-registry": {
+                    version: 6,
+                    address: "0x4A37B123b0BA2A894cA5953f472264921d44e298",
+                    abi: [
+                        { type: "constructor", inputs: [], stateMutability: "nonpayable" },
+                        {
+                            type: "function",
+                            name: "publish",
+                            inputs: [
+                                { name: "domain", type: "string" },
+                                { name: "metadata_uri", type: "string" },
+                                { name: "visibility", type: "uint8" },
+                            ],
+                            outputs: [],
+                            stateMutability: "nonpayable",
+                        },
+                        {
+                            type: "function",
+                            name: "unpublish",
+                            inputs: [{ name: "domain", type: "string" }],
+                            outputs: [],
+                            stateMutability: "nonpayable",
+                        },
+                    ],
+                },
+            },
+        },
+    };
+
+    /**
+     * Minimal InkSdk stub — `getContract()` is the only method
+     * `ContractManager.getContract()` calls. Everything else on the SDK
+     * is left undefined so a misroute through any other method would
+     * throw and surface in the test.
+     */
+    function fakeInkSdk(): InkSdk {
+        return {
+            getContract: (descriptor: unknown, address: unknown) => ({
+                __descriptor: descriptor,
+                __address: address,
+                // Each method on a real ink contract has `query` + `send`.
+                // We don't invoke them in the smoke test — just need the
+                // shape to flow through `wrapContract`'s proxy.
+                query: async () => ({ success: true, value: { response: undefined } }),
+                send: () => ({ waited: Promise.resolve({}) }),
+            }),
+        } as unknown as InkSdk;
+    }
+
+    describe("ContractManager — cdm.json resolution", () => {
+        test("constructs from a real-world cdm.json without errors", () => {
+            const manager = new ContractManager(playgroundCdm, fakeInkSdk());
+            expect(manager.getAddress("@w3s/playground-registry")).toBe(
+                "0x4A37B123b0BA2A894cA5953f472264921d44e298",
+            );
+        });
+
+        test("getContract returns a typed handle for a library in the manifest", () => {
+            const manager = new ContractManager(playgroundCdm, fakeInkSdk());
+            const registry = manager.getContract("@w3s/playground-registry");
+
+            // Methods from the abi are accessible
+            expect(typeof registry.publish.query).toBe("function");
+            expect(typeof registry.publish.tx).toBe("function");
+            expect(typeof registry.publish.prepare).toBe("function");
+            expect(typeof registry.unpublish.query).toBe("function");
+        });
+
+        test("getContract throws ContractNotFoundError for an unknown library", () => {
+            const manager = new ContractManager(playgroundCdm, fakeInkSdk());
+            expect(() => manager.getContract("@nonexistent/contract")).toThrow(
+                /not found in cdm\.json/,
+            );
+        });
+
+        test("auto-selects the first target when no targetHash is provided", () => {
+            const manager = new ContractManager(playgroundCdm, fakeInkSdk());
+            // Single-target manifest — should resolve cleanly without
+            // requiring an explicit targetHash.
+            expect(() => manager.getContract("@w3s/playground-registry")).not.toThrow();
+        });
+
+        test("getContract passes the right address to inkSdk", () => {
+            let capturedAddress: unknown;
+            const inkSdk = {
+                getContract: (_descriptor: unknown, address: unknown) => {
+                    capturedAddress = address;
+                    return {
+                        query: async () => ({ success: true, value: { response: undefined } }),
+                        send: () => ({ waited: Promise.resolve({}) }),
+                    };
+                },
+            } as unknown as InkSdk;
+
+            const manager = new ContractManager(playgroundCdm, inkSdk);
+            manager.getContract("@w3s/playground-registry");
+            expect(capturedAddress).toBe("0x4A37B123b0BA2A894cA5953f472264921d44e298");
+        });
+
+        test("explicit targetHash option selects the right contracts subtree", () => {
+            // Multi-target manifest: we should be able to pin to a specific
+            // target hash and have getContract resolve against it.
+            const multiTargetCdm: CdmJson = {
+                targets: {
+                    target_a: { "asset-hub": "wss://a", bulletin: "https://a" },
+                    target_b: { "asset-hub": "wss://b", bulletin: "https://b" },
+                },
+                dependencies: {
+                    target_a: { "@org/foo": "1.0" },
+                    target_b: { "@org/foo": "2.0" },
+                },
+                contracts: {
+                    target_a: {
+                        "@org/foo": {
+                            version: 1,
+                            address: "0x1111111111111111111111111111111111111111",
+                            abi: [],
+                        },
+                    },
+                    target_b: {
+                        "@org/foo": {
+                            version: 2,
+                            address: "0x2222222222222222222222222222222222222222",
+                            abi: [],
+                        },
+                    },
+                },
+            };
+
+            const aManager = new ContractManager(multiTargetCdm, fakeInkSdk(), {
+                targetHash: "target_a",
+            });
+            const bManager = new ContractManager(multiTargetCdm, fakeInkSdk(), {
+                targetHash: "target_b",
+            });
+
+            expect(aManager.getAddress("@org/foo")).toBe(
+                "0x1111111111111111111111111111111111111111",
+            );
+            expect(bManager.getAddress("@org/foo")).toBe(
+                "0x2222222222222222222222222222222222222222",
+            );
+        });
+
+        test("constructor throws when cdm.json has no targets", () => {
+            const emptyCdm: CdmJson = { targets: {}, dependencies: {} };
+            expect(() => new ContractManager(emptyCdm, fakeInkSdk())).toThrow(/No targets found/);
+        });
+    });
+
+    describe("ContractManager defaults", () => {
+        test("setDefaults updates origin / signer / signerManager mid-flight", () => {
+            const manager = new ContractManager(playgroundCdm, fakeInkSdk(), {
+                defaultOrigin: "5OldOrigin" as HexString,
+            });
+            // This is a behavioral check via private-ish field — we don't
+            // expose `defaults` directly, but `setDefaults` returning
+            // without error is the contract.
+            expect(() => manager.setDefaults({ origin: "5NewOrigin" as HexString })).not.toThrow();
+        });
+    });
+}

--- a/product-sdk/packages/contracts/src/types.ts
+++ b/product-sdk/packages/contracts/src/types.ts
@@ -1,9 +1,9 @@
 import type { HexString, PolkadotSigner, SS58String } from "polkadot-api";
-import type { SubmitOptions, TxResult, Weight } from "@parity/product-sdk-tx";
+import type { BatchableCall, SubmitOptions, TxResult, Weight } from "@parity/product-sdk-tx";
 import type { SignerManager } from "@parity/product-sdk-signer";
 
 // Re-export from the tx package — single source of truth.
-export type { TxResult, SubmitOptions } from "@parity/product-sdk-tx";
+export type { TxResult, SubmitOptions, BatchableCall } from "@parity/product-sdk-tx";
 
 // ---------------------------------------------------------------------------
 // cdm.json schema
@@ -15,12 +15,18 @@ export interface CdmJsonTarget {
     bulletin: string;
 }
 
-/** A deployed contract's on-chain address, ABI, and metadata CID. */
+/**
+ * A deployed contract's on-chain address, ABI, and optional metadata CID.
+ *
+ * `metadataCid` is optional because real-world cdm.json files (e.g.
+ * `paritytech/playground-cli/cdm.json`) don't always include it — only
+ * `version`, `address`, and `abi` are load-bearing for `getContract()`.
+ */
 export interface CdmJsonContract {
     version: number;
     address: HexString;
     abi: AbiEntry[];
-    metadataCid: string;
+    metadataCid?: string;
 }
 
 /** A project's `cdm.json` manifest: declared targets, runtime dependencies, and per-target contract deployments. */
@@ -91,6 +97,20 @@ export interface TxOptions extends SubmitOptions {
     storageDepositLimit?: bigint;
 }
 
+/**
+ * Options for `.prepare()` — subset of {@link TxOptions}.
+ *
+ * Signer and submission lifecycle options (`signer`, `waitFor`, `timeoutMs`,
+ * `mortalityPeriod`, `onStatus`) are intentionally absent — those belong to
+ * the batch submission, not the individual prepared call.
+ */
+export interface PrepareOptions {
+    origin?: SS58String;
+    value?: bigint;
+    gasLimit?: Weight;
+    storageDepositLimit?: bigint;
+}
+
 /** Mutable defaults shared across all contract handles from a manager. */
 export interface ContractDefaults {
     origin?: SS58String;
@@ -152,5 +172,28 @@ export type Contract<C extends ContractDef> = {
          * defaultSigner. Throws {@link ContractSignerMissingError} if none available.
          */
         tx: (...args: [...C["methods"][K]["args"], opts?: TxOptions]) => Promise<TxResult>;
+        /**
+         * Prepare the method as a {@link BatchableCall} — returns a handle
+         * consumable by `batchSubmitAndWatch` from `@parity/product-sdk-tx`
+         * without signing or submitting.
+         *
+         * Use this to group multiple contract calls (or contract calls mixed
+         * with other transactions on the same chain) into a single atomic
+         * `Utility.batch_all` transaction:
+         *
+         * ```ts
+         * import { batchSubmitAndWatch } from "@parity/product-sdk-tx";
+         *
+         * const a = contract.transfer.prepare(addr1, 100n);
+         * const b = contract.transfer.prepare(addr2, 200n);
+         * await batchSubmitAndWatch([a, b], api, signer);
+         * ```
+         *
+         * Origin is resolved the same way as `.tx()` but falls back to the
+         * dev address for dry-run gas estimation if no signer context is
+         * available (prepare does not require a signer; the batch submission
+         * does).
+         */
+        prepare: (...args: [...C["methods"][K]["args"], opts?: PrepareOptions]) => BatchableCall;
     };
 };

--- a/product-sdk/packages/contracts/src/wrap.ts
+++ b/product-sdk/packages/contracts/src/wrap.ts
@@ -6,9 +6,11 @@ import { DEV_PHRASE, ss58Address } from "@polkadot-labs/hdkd-helpers";
 import { ContractSignerMissingError } from "./errors.js";
 import type {
     AbiEntry,
+    BatchableCall,
     Contract,
     ContractDef,
     ContractDefaults,
+    PrepareOptions,
     QueryOptions,
     TxOptions,
 } from "./types.js";
@@ -168,6 +170,27 @@ export function wrapContract(
                         timeoutMs: overrides?.timeoutMs,
                         mortalityPeriod: overrides?.mortalityPeriod,
                         onStatus: overrides?.onStatus,
+                    });
+                },
+
+                prepare: (...args: unknown[]): BatchableCall => {
+                    const { positionalArgs, overrides } = extractOverrides<PrepareOptions>(
+                        argNames,
+                        args,
+                    );
+                    const data = positionalToNamed(argNames, positionalArgs);
+                    // prepare() doesn't require a signer — origin here is for
+                    // dry-run gas estimation; the batch's signer replaces it
+                    // as the dispatched origin at submission.
+                    const origin = resolveOrigin(defaults, overrides?.origin, true)!;
+                    return inkContract.send(methodName, {
+                        data,
+                        origin,
+                        ...(overrides?.value !== undefined && { value: overrides.value }),
+                        ...(overrides?.gasLimit && { gasLimit: overrides.gasLimit }),
+                        ...(overrides?.storageDepositLimit !== undefined && {
+                            storageDepositLimit: overrides.storageDepositLimit,
+                        }),
                     });
                 },
             };
@@ -334,6 +357,158 @@ if (import.meta.vitest) {
                 signerManager: mockSigner({}),
             };
             expect(resolveSigner(defaults)).toBe(fakeSigner);
+        });
+    });
+
+    describe("wrapContract — prepare", () => {
+        // .prepare() port from polkadot-apps@4b60d19. Asserts that the
+        // method returns a BatchableCall consumable by batchSubmitAndWatch
+        // without going through submission, doesn't require a signer, and
+        // forwards the gas/value overrides the same way `.tx()` does.
+
+        const abi: AbiEntry[] = [
+            {
+                type: "function",
+                name: "increment",
+                inputs: [],
+                outputs: [],
+                stateMutability: "nonpayable",
+            },
+            {
+                type: "function",
+                name: "add",
+                inputs: [{ name: "n", type: "uint32" }],
+                outputs: [],
+                stateMutability: "nonpayable",
+            },
+        ];
+
+        test("prepare returns ink send result without submitting", () => {
+            let sendCapture: any;
+            const fakeSendResult = { waited: Promise.resolve({ decodedCall: { pallet: "X" } }) };
+            const fakeInk = {
+                send: (method: string, args: any) => {
+                    sendCapture = { method, args };
+                    return fakeSendResult;
+                },
+            };
+            const wrapped = wrapContract(fakeInk, abi, { origin: "5Alice" as any });
+
+            const result = wrapped.add.prepare(42);
+            expect(sendCapture.method).toBe("add");
+            expect(sendCapture.args.data).toEqual({ n: 42 });
+            expect(sendCapture.args.origin).toBe("5Alice");
+            expect(result).toBe(fakeSendResult);
+        });
+
+        test("prepare does not require a signer", () => {
+            const fakeInk = {
+                send: () => ({ waited: Promise.resolve({ decodedCall: {} }) }),
+            };
+            const wrapped = wrapContract(fakeInk, abi, {});
+            // No signer, no signerManager, no default origin — should still work
+            expect(() => wrapped.increment.prepare()).not.toThrow();
+        });
+
+        test("prepare uses fallback origin for dry-run gas estimation", () => {
+            let captured: any;
+            const fakeInk = {
+                send: (_: string, args: any) => {
+                    captured = args;
+                    return { waited: Promise.resolve({ decodedCall: {} }) };
+                },
+            };
+            const wrapped = wrapContract(fakeInk, abi, {});
+
+            wrapped.increment.prepare();
+            expect(captured.origin).toBe(QUERY_FALLBACK_ORIGIN);
+        });
+
+        test("prepare forwards value, gasLimit, storageDepositLimit", () => {
+            let captured: any;
+            const fakeInk = {
+                send: (_: string, args: any) => {
+                    captured = args;
+                    return { waited: Promise.resolve({ decodedCall: {} }) };
+                },
+            };
+            const wrapped = wrapContract(fakeInk, abi, { origin: "5A" as any });
+
+            const gasLimit = { ref_time: 1_000_000n, proof_size: 1024n };
+            wrapped.add.prepare(7, {
+                value: 500n,
+                gasLimit,
+                storageDepositLimit: 999n,
+            });
+            expect(captured.data).toEqual({ n: 7 });
+            expect(captured.value).toBe(500n);
+            expect(captured.gasLimit).toBe(gasLimit);
+            expect(captured.storageDepositLimit).toBe(999n);
+        });
+
+        test("prepare override origin wins over signerManager and default", () => {
+            let captured: any;
+            const fakeInk = {
+                send: (_: string, args: any) => {
+                    captured = args;
+                    return { waited: Promise.resolve({ decodedCall: {} }) };
+                },
+            };
+            const wrapped = wrapContract(fakeInk, abi, {
+                origin: "5Default" as any,
+                signerManager: mockSigner({ address: "5Source" }),
+            });
+
+            wrapped.increment.prepare({ origin: "5Override" as any });
+            expect(captured.origin).toBe("5Override");
+        });
+
+        test("prepare result is consumable by batchSubmitAndWatch", async () => {
+            const { batchSubmitAndWatch } = await import("@parity/product-sdk-tx");
+            const prepared = [
+                { waited: Promise.resolve({ decodedCall: { call: "one" } }) },
+                { waited: Promise.resolve({ decodedCall: { call: "two" } }) },
+            ];
+            const fakeInk = {
+                send: (_: string, _args: any) => prepared.shift()!,
+            };
+            const wrapped = wrapContract(fakeInk, abi, { origin: "5A" as any });
+
+            const a = wrapped.increment.prepare();
+            const b = wrapped.add.prepare(1);
+
+            const captured: unknown[][] = [];
+            const fakeApi = {
+                tx: {
+                    Utility: {
+                        batch_all: (args: { calls: unknown[] }) => {
+                            captured.push(args.calls);
+                            return {
+                                signSubmitAndWatch: () => ({
+                                    subscribe: (h: any) => {
+                                        h.next({ type: "signed", txHash: "0xb" });
+                                        h.next({
+                                            type: "txBestBlocksState",
+                                            txHash: "0xb",
+                                            found: true,
+                                            ok: true,
+                                            events: [],
+                                            block: { hash: "0xblk", number: 1, index: 0 },
+                                        });
+                                        return { unsubscribe: () => {} };
+                                    },
+                                }),
+                            };
+                        },
+                    },
+                },
+            } as any;
+
+            const result = await batchSubmitAndWatch([a, b], fakeApi, {
+                publicKey: new Uint8Array(32),
+            } as any);
+            expect(result.ok).toBe(true);
+            expect(captured[0]).toEqual([{ call: "one" }, { call: "two" }]);
         });
     });
 }


### PR DESCRIPTION
# fix(contracts): port `.prepare()` and cover the cdm.json flow                                                                                                                                                                                   
                                                                                                                                                                                                                                                  
  ## Summary                                                                                                                                                                                                                                        
   
  Two pieces flagged as missing from `@parity/product-sdk-contracts` vs the upstream source. After investigation:                                                                                                                                   
                                                            
  - **`.prepare()` was actually missing.** Ported from `polkadot-apps@4b60d19`.                                                                                                                                                                     
  - **`ContractManager.getContract("@org/name")` already worked** — but the package shipped without a README or any `manager.ts` tests, so the feature was effectively invisible. Added both.
                                                                                                                                                                                                                                                    
  ## Changes                                                
                                                                                                                                                                                                                                                    
  - **`.prepare()`** on every wrapped ABI method — returns a `BatchableCall` consumable by `batchSubmitAndWatch`. Doesn't require a signer; the batch's signer is the dispatched origin at submission. New `PrepareOptions` type. `BatchableCall`   
  re-exported from `@parity/product-sdk-tx`.
  - **8 `ContractManager` tests** in `manager.ts` covering construction from a real-world cdm.json, `getContract` resolution, `getAddress`, `ContractNotFoundError`, auto-target-selection, explicit `targetHash`, empty-targets error,             
  `setDefaults`. Closes a pre-existing test gap (manager.ts had zero tests in 0.2.0).                                                                                                                                                               
  - **`packages/contracts/README.md`** — new file. Primary `cdm.json` flow front-and-center, full `ContractManager` API, signer/origin resolution hierarchy, batching with `.prepare()`, manual `createContract` escape hatch, `cdm.json` schema
  reference, type generation, errors table.                                                                                                                                                                                                         
  - **`CdmJsonContract.metadataCid` made optional** — real-world cdm.json files often omit it, runtime never reads it.