### PR TITLE
chore: Fix docs-deploy CI

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -72,7 +72,14 @@ jobs:
               working-directory: docs
               run: pnpm build
 
+            - name: Install bulletin-deploy
+              if: steps.gate.outputs.skip != 'true'
+              run: npm install -g bulletin-deploy
+
             - name: Deploy to Bulletin Chain
               if: steps.gate.outputs.skip != 'true'
-              working-directory: docs
-              run: npx -y bulletin-deploy ./out product-sdk.dot
+              uses: nick-fields/retry@v3
+              with:
+                  timeout_minutes: 10
+                  max_attempts: 3
+                  command: cd docs && bulletin-deploy ./out product-sdk.dot --js-merkle


### PR DESCRIPTION
After the latest release the docs [deploy CI failed](https://github.com/paritytech/product-sdk/actions/runs/25578490011). It was due to a missing `ipfs` dependency. 

This PR resolves the issue by adding the `--js-merkle` flag to the bulletin-deploy command which allows to run a js implementation of ipfs avoiding the need to install it on the runner. Also now the runner will retry the deploy 3 times in case it fails