### PR TITLE
feat: terminal request resource allocation

### DIFF
--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -30,6 +30,7 @@ export {
     getPreimageManager,
     getAccountsProvider,
     requestResourceAllocation,
+    createProofAuthorized,
     // Helpers from @novasamatech/host-api
     enumValue,
     isEnumVariant,
@@ -51,4 +52,5 @@ export type {
     ResultAsync,
     AllocatableResource,
     AllocationOutcome,
+    Statement,
 } from "./truapi.js";

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -22,6 +22,22 @@ import type { StatementProof } from "./types.js";
 
 const log = createLogger("host");
 
+/**
+ * Extract a human-readable message from an unknown error. `JSON.stringify`
+ * on `Error` returns `"{}"` because `message` and `stack` are non-enumerable
+ * — without this helper, wire failures surface as `"... failed: {}"` with
+ * zero diagnostic context.
+ */
+function formatError(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    if (typeof err === "string") return err;
+    try {
+        return JSON.stringify(err);
+    } catch {
+        return String(err);
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers from @novasamatech/host-api (re-exported from @novasamatech/scale)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -261,7 +277,9 @@ export async function requestResourceAllocation(
     return await truApi.requestResourceAllocation(enumValue("v1", resources)).match(
         (envelope: { tag: "v1"; value: AllocationOutcome[] }) => envelope.value,
         (err: unknown) => {
-            throw new Error(`requestResourceAllocation failed: ${JSON.stringify(err)}`);
+            throw new Error(`requestResourceAllocation failed: ${formatError(err)}`, {
+                cause: err,
+            });
         },
     );
 }
@@ -341,7 +359,7 @@ export async function createProofAuthorized(statement: Statement): Promise<State
     return await truApi.statementStoreCreateProofAuthorized(enumValue("v1", statement)).match(
         (envelope: { tag: "v1"; value: StatementProof }) => envelope.value,
         (err: unknown) => {
-            throw new Error(`createProofAuthorized failed: ${JSON.stringify(err)}`);
+            throw new Error(`createProofAuthorized failed: ${formatError(err)}`, { cause: err });
         },
     );
 }

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -15,7 +15,10 @@ import type {
     AllocatableResource as AllocatableResourceCodec,
     AllocationOutcome as AllocationOutcomeCodec,
     CodecType,
+    Statement as StatementCodec,
 } from "@novasamatech/host-api";
+
+import type { StatementProof } from "./types.js";
 
 const log = createLogger("host");
 
@@ -263,6 +266,86 @@ export async function requestResourceAllocation(
     );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Authorized Statement Store proof creation (RFC-10 §"Statement Store allowance")
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A Statement payload destined for the Statement Store. Matches the
+ * `pallet-statement` Statement structure.
+ *
+ * The optional `proof` field is the same {@link StatementProof} shape that
+ * {@link createProofAuthorized} returns: pass `undefined` here, call
+ * `createProofAuthorized` to obtain the proof, then attach it before
+ * submitting via `HostStatementStore.submit`. The `OnChain` variant of
+ * `StatementProof` is a chain-attestation reference; the `Sr25519` /
+ * `Ed25519` / `Ecdsa` variants are signing proofs.
+ *
+ * Derived from the upstream codec so structural changes surface as compile
+ * errors here, not runtime decode failures.
+ */
+export type Statement = CodecType<typeof StatementCodec>;
+
+/**
+ * Have the host sign a Statement using an allowance-bearing account it
+ * picks internally — RFC-10 §"Statement Store allowance".
+ *
+ * The product passes only the Statement payload; the host chooses the
+ * `//allowance//statement-store//{productId}` account that holds SSS
+ * allowance and signs with it. Allowance is provisioned implicitly on
+ * first use if the host hasn't already pre-allocated via
+ * {@link requestResourceAllocation}; products never see the signing
+ * account or its key material.
+ *
+ * Pairs with {@link getStatementStore}'s `submit`: call this to obtain
+ * a proof, attach it to the Statement, and submit the result.
+ *
+ * @param statement - The Statement to be signed.
+ * @returns The proof to attach before submitting.
+ * @throws If the host is unavailable or the host-side signing fails.
+ *
+ * @example
+ * ```ts
+ * import { createProofAuthorized, getStatementStore } from "@parity/product-sdk-host";
+ *
+ * const statement = {
+ *     proof: undefined,
+ *     decryptionKey: undefined,
+ *     expiry: undefined,
+ *     channel: undefined,
+ *     topics: [],
+ *     data: payload,
+ * };
+ * const proof = await createProofAuthorized(statement);
+ * const store = await getStatementStore();
+ * await store?.submit({ ...statement, proof });
+ * ```
+ *
+ * @remarks
+ * RFC-10 introduces this as a new, strictly additive TruAPI call. The
+ * pre-existing `HostStatementStore.createProof(accountId, statement)`
+ * surface stays available for products that own a non-allowance signing
+ * account; this wrapper is the sponsored-submission path.
+ */
+export async function createProofAuthorized(statement: Statement): Promise<StatementProof> {
+    const truApi = await getTruApi();
+    if (!truApi) {
+        throw new Error("createProofAuthorized: TruAPI unavailable");
+    }
+    log.debug("createProofAuthorized", {
+        topics: statement.topics.length,
+        dataLen: statement.data?.length ?? 0,
+    });
+
+    // `.match()` because the host returns a neverthrow ResultAsync, not a Promise.
+    return await truApi.statementStoreCreateProofAuthorized(enumValue("v1", statement)).match(
+        (envelope: { tag: "v1"; value: StatementProof }) => envelope.value,
+        (err: unknown) => {
+            throw new Error(`createProofAuthorized failed: ${JSON.stringify(err)}`);
+        },
+    );
+}
+
 /**
  * One of the user's existing wallet accounts, surfaced through the host and
  * identified by its public key and an optional name. Contrast with
@@ -447,6 +530,25 @@ if (import.meta.vitest) {
             ).rejects.toThrow(/TruAPI unavailable/);
         } else {
             expect(typeof requestResourceAllocation).toBe("function");
+        }
+    });
+
+    test("createProofAuthorized throws when TruAPI is unavailable", async () => {
+        cachedTruApi = null;
+        const api = await getTruApi();
+        if (api === null) {
+            await expect(
+                createProofAuthorized({
+                    proof: undefined,
+                    decryptionKey: undefined,
+                    expiry: undefined,
+                    channel: undefined,
+                    topics: [],
+                    data: undefined,
+                }),
+            ).rejects.toThrow(/TruAPI unavailable/);
+        } else {
+            expect(typeof createProofAuthorized).toBe("function");
         }
     });
 }

--- a/product-sdk/packages/terminal/README.md
+++ b/product-sdk/packages/terminal/README.md
@@ -129,6 +129,44 @@ File-based storage adapter for Node.js. Data persists in `storageDir` (defaults 
 
 Waits for the session list to emit at least one entry, or resolves with `[]` after `timeoutMs`.
 
+## Allowance management (`./host` subpath)
+
+For CLIs that need to write to Bulletin / Statement Store / Asset Hub smart contracts: the QR-paired mobile wallet is the Account Holder, the CLI plays the Host role, and `@parity/product-sdk-terminal/host` exposes that Host-runner surface (the [RFC-10](https://github.com/paritytech/triangle-js-sdks/blob/valentunn-rfc-0010/docs/rfcs/0010-allowance.md) Accounts Protocol companion, an on-disk allowance-key cache, and a local sr25519 signer over the cached keys).
+
+```ts
+import {
+    ensureSlotAccountSigner,
+    requestResourceAllocation,
+    getCachedAllocation,
+    createSlotAccountSigner,
+} from "@parity/product-sdk-terminal/host";
+
+// First call prompts the wallet; subsequent calls are wire-free.
+const signer = await ensureSlotAccountSigner(session, adapter, {
+    tag: "BulletInAllowance",
+    value: undefined,
+});
+await bulletinTx.submitAndWatch(signer);
+```
+
+### `ensureSlotAccountSigner(session, adapter, resource): Promise<PolkadotSigner>`
+
+The one call most CLIs want. Cache hit → returns signer; cache miss → allocates via the wallet, then returns signer. Throws on `Rejected` / `NotAvailable`. Slot-table resources only (`BulletInAllowance`, `StatementStoreAllowance`).
+
+### `requestResourceAllocation(session, adapter, resources, options?): Promise<ApAllocationOutcome[]>`
+
+Lower-level: pre-allocate any combination of resources. Granted keys cached at `{storageDir}/{appId}_AllowanceKeys.json` (`0o600`, atomic write). `onExisting` auto-picks `Ignore`/`Increase` based on cache state; override via `options.onExisting`.
+
+### `getCachedAllocation(adapter, resource): Promise<CachedAllocation | null>`
+
+Read-only cache lookup; no wire round-trip.
+
+### `createSlotAccountSigner(adapter, resource): Promise<PolkadotSigner | null>`
+
+Build a `PolkadotSigner` from the cached slot key without round-tripping. Returns `null` if nothing's cached (use `ensureSlotAccountSigner` for the round-trip-if-missing flow).
+
+> **Caveats.** `AutoSigning` currently returns `NotAvailable` on both Android and iOS wallets. Slot renewal at expiry depends on [paritytech/individuality#931](https://github.com/paritytech/individuality/pull/931) (open) — first-time allocation works end-to-end today.
+
 ## Migration from `@polkadot-apps/terminal`
 
 For consumers moving from `@polkadot-apps/terminal` v0.2.0 / v0.3.0. Existing sessions on disk (`~/.polkadot-apps/`) carry over — same `appId`, same path. No re-pairing required for the migration itself.
@@ -245,18 +283,4 @@ Sessions are persisted to `~/.polkadot-apps/` and survive across restarts. The S
 
 - **`KvStore`↔`StorageAdapter` bridge.** This package implements its own file-backed `StorageAdapter` for Node.js (`createNodeStorageAdapter`). Once `@parity/product-sdk-storage` grows a file backend with the same `read/write/clear/subscribe` `ResultAsync` shape, replace `node-storage.ts` with a thin adapter over it.
 - **Codec re-exports from `@parity/product-sdk-statement-store`.** `testing.ts` imports session-account codec helpers (`AccountIdCodec`, `LocalSessionAccountCodec`, etc.) directly from `@novasamatech/statement-store`. Re-exporting them through the in-monorepo wrapper would let this package depend only on workspace siblings.
-- **Embedded host runner for allowance / attestation refresh.** Today this package consumes a paired session and signs against it, but cannot renew the on-chain attestation that gates allowance writes — once it expires the user has to re-do the full QR pairing. The proposed fix is a new `./host` sub-export (in addition to `.`, `./register`, `./testing`) exposing roughly:
-  ```ts
-  // proposed shape — not yet implemented
-  export interface AllowanceManager {
-      isExpired(): boolean;
-      refresh(): ResultAsync<void, Error>;
-      currentAttestation(): ResultAsync<Attestation, Error>;
-  }
-  export function createAllowanceManager(
-      adapter: TerminalAdapter,
-      options?: { hostEndpoint?: string },
-  ): AllowanceManager;
-  ```
-  Implementation should sit on top of `@parity/product-sdk-host`'s container/storage primitives so the host runner is shared with browser/desktop hosts rather than being CLI-specific. This is the gap Tarik flagged as "the CLI might also need to run some kind of host to get allowances".
 - **`@noble/*` major version drift.** This package pins `@noble/{ciphers,curves,hashes}: ^2.x` because upstream `@polkadot-apps/terminal` did, and the `testing.ts` codec helpers use the v2 import paths (`@noble/hashes/blake2.js`, `@noble/curves/nist.js`). The rest of the monorepo is on `^1.x`. Both majors coexist in the lockfile; not a runtime problem today but worth a coordinated bump. Either move the whole monorepo to v2, or rewrite `testing.ts` against v1 paths (`@noble/hashes/blake2b.js` etc.).

--- a/product-sdk/packages/terminal/package.json
+++ b/product-sdk/packages/terminal/package.json
@@ -19,6 +19,10 @@
         "./testing": {
             "types": "./dist/testing.d.ts",
             "import": "./dist/testing.js"
+        },
+        "./host": {
+            "types": "./dist/host.d.ts",
+            "import": "./dist/host.js"
         }
     },
     "files": ["dist", "scripts"],

--- a/product-sdk/packages/terminal/src/adapter.ts
+++ b/product-sdk/packages/terminal/src/adapter.ts
@@ -60,8 +60,8 @@ export type TerminalAdapter = PappAdapter & {
      * The on-disk storage directory used for sessions and (when the
      * host-runner facet is in use) for the allowance-key cache the
      * `./host` subpath maintains. `undefined` when the default
-     * `~/.polkadot-apps/` location is in use; set explicitly when the
-     * caller passed `storageDir` to {@link createTerminalAdapter}.
+     * is in use; set explicitly when the caller passed `storageDir` to
+     * {@link createTerminalAdapter}.
      */
     readonly storageDir?: string;
     /**

--- a/product-sdk/packages/terminal/src/adapter.ts
+++ b/product-sdk/packages/terminal/src/adapter.ts
@@ -57,6 +57,14 @@ export type TerminalAdapter = PappAdapter & {
     /** The `appId` passed to {@link createTerminalAdapter}. Useful for {@link createSessionSigner}. */
     readonly appId: string;
     /**
+     * The on-disk storage directory used for sessions and (when the
+     * host-runner facet is in use) for the allowance-key cache the
+     * `./host` subpath maintains. `undefined` when the default
+     * `~/.polkadot-apps/` location is in use; set explicitly when the
+     * caller passed `storageDir` to {@link createTerminalAdapter}.
+     */
+    readonly storageDir?: string;
+    /**
      * Disconnect the WebSocket and release resources.
      *
      * @remarks
@@ -112,6 +120,7 @@ export function createTerminalAdapter(options: TerminalAdapterOptions): Terminal
     return {
         ...adapter,
         appId: options.appId,
+        storageDir: options.storageDir,
         destroy(): Promise<void> {
             if (destroyPromise) return destroyPromise;
             destroyPromise = teardown(adapter.sessions, trackedLazyClient);

--- a/product-sdk/packages/terminal/src/host-cache.ts
+++ b/product-sdk/packages/terminal/src/host-cache.ts
@@ -1,0 +1,486 @@
+/**
+ * Persistent allowance-key cache. One JSON file per `appId`, 0o600.
+ *
+ * Cache key is the variant tag, except `SmartContractAllowance::{dest}`
+ * which disambiguates per-derivation-index PGAS pre-warming.
+ *
+ * @internal
+ */
+import { createLogger } from "@parity/product-sdk-logger";
+import { toHex } from "@polkadot-api/utils";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import type { AllocatableResource, ApAllocationOutcome } from "./host.js";
+
+const log = createLogger("terminal");
+
+const DEFAULT_STORAGE_DIR = join(homedir(), ".polkadot-apps");
+const CACHE_FILE_MODE = 0o600;
+
+/** One cached allowance entry. Hex strings are 0x-prefixed. */
+export type CachedAllocation =
+    | { tag: "BulletInAllowance"; slotAccountKey: string }
+    | { tag: "StatementStoreAllowance"; slotAccountKey: string }
+    | { tag: "SmartContractAllowance"; dest: number }
+    | {
+          tag: "AutoSigning";
+          productDerivationSecret: string;
+          productRootPrivateKey: string;
+      };
+
+interface AllowanceCacheV1 {
+    version: 1;
+    entries: Record<string, CachedAllocation>;
+}
+
+function sanitizeAppId(appId: string): string {
+    return appId.replace(/[^a-zA-Z0-9_.-]/g, "_");
+}
+
+function cachePath(appId: string, storageDir?: string): string {
+    return join(storageDir ?? DEFAULT_STORAGE_DIR, `${sanitizeAppId(appId)}_AllowanceKeys.json`);
+}
+
+function emptyCache(): AllowanceCacheV1 {
+    return { version: 1, entries: {} };
+}
+
+export async function loadCache(appId: string, storageDir?: string): Promise<AllowanceCacheV1> {
+    const path = cachePath(appId, storageDir);
+    let raw: string;
+    try {
+        raw = await readFile(path, "utf-8");
+    } catch (e: unknown) {
+        if ((e as NodeJS.ErrnoException)?.code === "ENOENT") return emptyCache();
+        throw e;
+    }
+    try {
+        const parsed = JSON.parse(raw) as AllowanceCacheV1;
+        if (
+            parsed?.version !== 1 ||
+            typeof parsed.entries !== "object" ||
+            parsed.entries === null
+        ) {
+            log.warn("allowance cache schema mismatch; starting fresh", { appId, path });
+            return emptyCache();
+        }
+        return parsed;
+    } catch (e) {
+        log.warn("allowance cache parse failed; starting fresh", { appId, path, error: String(e) });
+        return emptyCache();
+    }
+}
+
+export async function saveCache(
+    appId: string,
+    cache: AllowanceCacheV1,
+    storageDir?: string,
+): Promise<void> {
+    const path = cachePath(appId, storageDir);
+    await mkdir(dirname(path), { recursive: true });
+    // Temp + rename so a mid-write crash can't leave a half-written file.
+    // Concurrent Hosts: the Account Holder serializes per (user, product,
+    // resource) and returns the same key to all callers, so racing writes
+    // converge on identical bytes.
+    const tmp = `${path}.tmp`;
+    await writeFile(tmp, JSON.stringify(cache, null, 2), { mode: CACHE_FILE_MODE });
+    await rename(tmp, path);
+}
+
+export function cacheKey(resource: AllocatableResource): string {
+    if (resource.tag === "SmartContractAllowance") {
+        return `${resource.tag}::${resource.value}`;
+    }
+    return resource.tag;
+}
+
+/**
+ * Pick the wire `onExisting` policy from current cache state. `Ignore`
+ * unless every requested resource is a slot-table variant (Bulletin /
+ * SSS) AND already cached, in which case `Increase`. SC and AutoSigning
+ * aren't slot-additive so they always force `Ignore`.
+ */
+export function pickOnExistingPolicy(
+    cache: AllowanceCacheV1,
+    resources: AllocatableResource[],
+): "Ignore" | "Increase" {
+    if (resources.length === 0) return "Ignore";
+    const allSlotTableAndCached = resources.every((r) => {
+        if (r.tag !== "BulletInAllowance" && r.tag !== "StatementStoreAllowance") return false;
+        return Object.hasOwn(cache.entries, cacheKey(r));
+    });
+    return allSlotTableAndCached ? "Increase" : "Ignore";
+}
+
+/**
+ * Merge `Allocated` outcomes into the cache. Non-`Allocated` outcomes
+ * leave the cache unchanged.
+ */
+export function mergeOutcomes(
+    cache: AllowanceCacheV1,
+    requested: AllocatableResource[],
+    outcomes: ApAllocationOutcome[],
+): AllowanceCacheV1 {
+    const entries = { ...cache.entries };
+    const n = Math.min(requested.length, outcomes.length);
+    for (let i = 0; i < n; i++) {
+        const req = requested[i];
+        const out = outcomes[i];
+        if (out.tag !== "Allocated") continue;
+        const inner = out.value;
+        const key = cacheKey(req);
+        switch (inner.tag) {
+            case "BulletInAllowance":
+            case "StatementStoreAllowance":
+                entries[key] = {
+                    tag: inner.tag,
+                    slotAccountKey: toHex(inner.value.slotAccountKey),
+                };
+                break;
+            case "SmartContractAllowance":
+                // dest comes from the request; the response payload is undefined.
+                if (req.tag === "SmartContractAllowance") {
+                    entries[key] = { tag: "SmartContractAllowance", dest: req.value };
+                }
+                break;
+            case "AutoSigning":
+                entries[key] = {
+                    tag: "AutoSigning",
+                    productDerivationSecret: inner.value.productDerivationSecret,
+                    productRootPrivateKey: toHex(inner.value.productRootPrivateKey),
+                };
+                break;
+        }
+    }
+    return { version: 1, entries };
+}
+
+/** Look up a single cached allocation, or `null` if absent. */
+export function readCacheEntry(
+    cache: AllowanceCacheV1,
+    resource: AllocatableResource,
+): CachedAllocation | null {
+    return cache.entries[cacheKey(resource)] ?? null;
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect, beforeEach } = import.meta.vitest;
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+
+    let storageDir: string;
+    beforeEach(() => {
+        storageDir = mkdtempSync(join(tmpdir(), "host-cache-test-"));
+        return () => rmSync(storageDir, { recursive: true, force: true });
+    });
+
+    describe("cacheKey", () => {
+        test("returns the variant tag for slot-table resources and AutoSigning", () => {
+            expect(cacheKey({ tag: "BulletInAllowance", value: undefined })).toBe(
+                "BulletInAllowance",
+            );
+            expect(cacheKey({ tag: "StatementStoreAllowance", value: undefined })).toBe(
+                "StatementStoreAllowance",
+            );
+            expect(cacheKey({ tag: "AutoSigning", value: undefined })).toBe("AutoSigning");
+        });
+
+        test("disambiguates SmartContractAllowance by dest", () => {
+            expect(cacheKey({ tag: "SmartContractAllowance", value: 0 })).toBe(
+                "SmartContractAllowance::0",
+            );
+            expect(cacheKey({ tag: "SmartContractAllowance", value: 7 })).toBe(
+                "SmartContractAllowance::7",
+            );
+        });
+    });
+
+    describe("loadCache / saveCache round-trip", () => {
+        test("loadCache on missing file returns empty cache, not an error", async () => {
+            const cache = await loadCache("my-app", storageDir);
+            expect(cache).toEqual({ version: 1, entries: {} });
+        });
+
+        test("saveCache then loadCache returns the same content", async () => {
+            const original: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0xdeadbeef" },
+                },
+            };
+            await saveCache("my-app", original, storageDir);
+            const reloaded = await loadCache("my-app", storageDir);
+            expect(reloaded).toEqual(original);
+        });
+
+        test("two appIds in the same storageDir don't collide", async () => {
+            const a: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0x01" },
+                },
+            };
+            const b: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0x02" },
+                },
+            };
+            await saveCache("app-a", a, storageDir);
+            await saveCache("app-b", b, storageDir);
+            expect((await loadCache("app-a", storageDir)).entries.BulletInAllowance).toEqual(
+                a.entries.BulletInAllowance,
+            );
+            expect((await loadCache("app-b", storageDir)).entries.BulletInAllowance).toEqual(
+                b.entries.BulletInAllowance,
+            );
+        });
+
+        test("appId with non-alphanumeric characters sanitizes to a safe path", async () => {
+            // Verifies a path-traversal-style appId can't escape storageDir.
+            const cache: AllowanceCacheV1 = { version: 1, entries: {} };
+            await expect(saveCache("../escape", cache, storageDir)).resolves.toBeUndefined();
+            const reloaded = await loadCache("../escape", storageDir);
+            expect(reloaded).toEqual(cache);
+        });
+
+        test("malformed cache file is treated as empty, not thrown", async () => {
+            await writeFile(cachePath("my-app", storageDir), "{ not valid json", "utf-8");
+            const cache = await loadCache("my-app", storageDir);
+            expect(cache).toEqual({ version: 1, entries: {} });
+        });
+
+        test("version mismatch is treated as empty, not thrown", async () => {
+            await writeFile(
+                cachePath("my-app", storageDir),
+                JSON.stringify({ version: 99, entries: {} }),
+                "utf-8",
+            );
+            const cache = await loadCache("my-app", storageDir);
+            expect(cache).toEqual({ version: 1, entries: {} });
+        });
+
+        test("file is written with 0o600 permissions (defense-in-depth)", async () => {
+            const { stat } = await import("node:fs/promises");
+            const cache: AllowanceCacheV1 = { version: 1, entries: {} };
+            await saveCache("my-app", cache, storageDir);
+            const s = await stat(cachePath("my-app", storageDir));
+            // Mask to permission bits only — file type bits are above 0o777.
+            expect(s.mode & 0o777).toBe(0o600);
+        });
+    });
+
+    describe("pickOnExistingPolicy", () => {
+        test("empty request resolves to Ignore", () => {
+            const cache = emptyCache();
+            expect(pickOnExistingPolicy(cache, [])).toBe("Ignore");
+        });
+
+        test("no cached entries → Ignore", () => {
+            const cache = emptyCache();
+            expect(
+                pickOnExistingPolicy(cache, [{ tag: "BulletInAllowance", value: undefined }]),
+            ).toBe("Ignore");
+        });
+
+        test("all slot-table resources cached → Increase", () => {
+            const cache: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0x01" },
+                    StatementStoreAllowance: {
+                        tag: "StatementStoreAllowance",
+                        slotAccountKey: "0x02",
+                    },
+                },
+            };
+            expect(
+                pickOnExistingPolicy(cache, [
+                    { tag: "BulletInAllowance", value: undefined },
+                    { tag: "StatementStoreAllowance", value: undefined },
+                ]),
+            ).toBe("Increase");
+        });
+
+        test("mixed cached + uncached → Ignore (conservative)", () => {
+            const cache: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0x01" },
+                },
+            };
+            expect(
+                pickOnExistingPolicy(cache, [
+                    { tag: "BulletInAllowance", value: undefined },
+                    { tag: "StatementStoreAllowance", value: undefined },
+                ]),
+            ).toBe("Ignore");
+        });
+
+        test("AutoSigning in the request → Ignore even if cached (not slot-additive)", () => {
+            const cache: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    AutoSigning: {
+                        tag: "AutoSigning",
+                        productDerivationSecret: "x",
+                        productRootPrivateKey: "0xaa",
+                    },
+                },
+            };
+            expect(pickOnExistingPolicy(cache, [{ tag: "AutoSigning", value: undefined }])).toBe(
+                "Ignore",
+            );
+        });
+
+        test("SC in the request → Ignore (not slot-additive; PGAS claim is per-call)", () => {
+            const cache: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    "SmartContractAllowance::5": { tag: "SmartContractAllowance", dest: 5 },
+                },
+            };
+            expect(pickOnExistingPolicy(cache, [{ tag: "SmartContractAllowance", value: 5 }])).toBe(
+                "Ignore",
+            );
+        });
+    });
+
+    describe("mergeOutcomes", () => {
+        test("ignores Rejected and NotAvailable", () => {
+            const cache = emptyCache();
+            const requested: AllocatableResource[] = [
+                { tag: "BulletInAllowance", value: undefined },
+                { tag: "StatementStoreAllowance", value: undefined },
+            ];
+            const outcomes: ApAllocationOutcome[] = [
+                { tag: "Rejected", value: undefined },
+                { tag: "NotAvailable", value: undefined },
+            ];
+            const merged = mergeOutcomes(cache, requested, outcomes);
+            expect(merged.entries).toEqual({});
+        });
+
+        test("stores Allocated Bulletin/SSS keys with hex encoding", () => {
+            const cache = emptyCache();
+            const requested: AllocatableResource[] = [
+                { tag: "BulletInAllowance", value: undefined },
+            ];
+            const outcomes: ApAllocationOutcome[] = [
+                {
+                    tag: "Allocated",
+                    value: {
+                        tag: "BulletInAllowance",
+                        value: { slotAccountKey: new Uint8Array([0xde, 0xad, 0xbe, 0xef]) },
+                    },
+                },
+            ];
+            const merged = mergeOutcomes(cache, requested, outcomes);
+            expect(merged.entries.BulletInAllowance).toEqual({
+                tag: "BulletInAllowance",
+                slotAccountKey: "0xdeadbeef",
+            });
+        });
+
+        test("stores SmartContractAllowance with dest from the request", () => {
+            const cache = emptyCache();
+            const requested: AllocatableResource[] = [{ tag: "SmartContractAllowance", value: 7 }];
+            const outcomes: ApAllocationOutcome[] = [
+                {
+                    tag: "Allocated",
+                    value: { tag: "SmartContractAllowance", value: undefined },
+                },
+            ];
+            const merged = mergeOutcomes(cache, requested, outcomes);
+            expect(merged.entries["SmartContractAllowance::7"]).toEqual({
+                tag: "SmartContractAllowance",
+                dest: 7,
+            });
+        });
+
+        test("stores AutoSigning subtree key + secret", () => {
+            const cache = emptyCache();
+            const requested: AllocatableResource[] = [{ tag: "AutoSigning", value: undefined }];
+            const outcomes: ApAllocationOutcome[] = [
+                {
+                    tag: "Allocated",
+                    value: {
+                        tag: "AutoSigning",
+                        value: {
+                            productDerivationSecret: "secret-hex",
+                            productRootPrivateKey: new Uint8Array([0xab, 0xcd]),
+                        },
+                    },
+                },
+            ];
+            const merged = mergeOutcomes(cache, requested, outcomes);
+            expect(merged.entries.AutoSigning).toEqual({
+                tag: "AutoSigning",
+                productDerivationSecret: "secret-hex",
+                productRootPrivateKey: "0xabcd",
+            });
+        });
+
+        test("preserves existing entries when merging new ones", () => {
+            const cache: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    StatementStoreAllowance: {
+                        tag: "StatementStoreAllowance",
+                        slotAccountKey: "0xaa",
+                    },
+                },
+            };
+            const requested: AllocatableResource[] = [
+                { tag: "BulletInAllowance", value: undefined },
+            ];
+            const outcomes: ApAllocationOutcome[] = [
+                {
+                    tag: "Allocated",
+                    value: {
+                        tag: "BulletInAllowance",
+                        value: { slotAccountKey: new Uint8Array([0xbb]) },
+                    },
+                },
+            ];
+            const merged = mergeOutcomes(cache, requested, outcomes);
+            expect(Object.keys(merged.entries).sort()).toEqual([
+                "BulletInAllowance",
+                "StatementStoreAllowance",
+            ]);
+            expect(merged.entries.StatementStoreAllowance).toEqual({
+                tag: "StatementStoreAllowance",
+                slotAccountKey: "0xaa",
+            });
+        });
+    });
+
+    describe("readCacheEntry", () => {
+        test("returns the cached entry by resource discriminator", () => {
+            const cache: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    "SmartContractAllowance::5": {
+                        tag: "SmartContractAllowance",
+                        dest: 5,
+                    },
+                },
+            };
+            expect(readCacheEntry(cache, { tag: "SmartContractAllowance", value: 5 })).toEqual({
+                tag: "SmartContractAllowance",
+                dest: 5,
+            });
+            // Different dest doesn't match.
+            expect(readCacheEntry(cache, { tag: "SmartContractAllowance", value: 6 })).toBeNull();
+        });
+
+        test("returns null when nothing cached", () => {
+            const cache = emptyCache();
+            expect(
+                readCacheEntry(cache, { tag: "BulletInAllowance", value: undefined }),
+            ).toBeNull();
+        });
+    });
+}

--- a/product-sdk/packages/terminal/src/host-cache.ts
+++ b/product-sdk/packages/terminal/src/host-cache.ts
@@ -116,20 +116,39 @@ export function pickOnExistingPolicy(
 
 /**
  * Merge `Allocated` outcomes into the cache. Non-`Allocated` outcomes
- * leave the cache unchanged.
+ * leave the cache unchanged. Returns the input `cache` reference rather
+ * than a copy when no entry was added, so callers can short-circuit a
+ * disk write via reference equality.
+ *
+ * Throws on length mismatch — `outcomes` must be length-matched with
+ * `requested`. A divergence is a wire contract violation, not data to
+ * silently truncate.
  */
 export function mergeOutcomes(
     cache: AllowanceCacheV1,
     requested: AllocatableResource[],
     outcomes: ApAllocationOutcome[],
 ): AllowanceCacheV1 {
+    if (requested.length !== outcomes.length) {
+        throw new Error(
+            `mergeOutcomes: length mismatch — requested ${requested.length}, got ${outcomes.length}`,
+        );
+    }
     const entries = { ...cache.entries };
-    const n = Math.min(requested.length, outcomes.length);
-    for (let i = 0; i < n; i++) {
+    let mutated = false;
+    for (let i = 0; i < outcomes.length; i++) {
         const req = requested[i];
         const out = outcomes[i];
         if (out.tag !== "Allocated") continue;
         const inner = out.value;
+        // outcomes must align positionally AND by variant with the request.
+        // A divergence is a wire contract violation: throw rather than
+        // silently miscaching a key under the wrong cache slot.
+        if (inner.tag !== req.tag) {
+            throw new Error(
+                `mergeOutcomes: variant mismatch at index ${i} — requested ${req.tag}, got Allocated<${inner.tag}>`,
+            );
+        }
         const key = cacheKey(req);
         switch (inner.tag) {
             case "BulletInAllowance":
@@ -138,11 +157,15 @@ export function mergeOutcomes(
                     tag: inner.tag,
                     slotAccountKey: toHex(inner.value.slotAccountKey),
                 };
+                mutated = true;
                 break;
             case "SmartContractAllowance":
                 // dest comes from the request; the response payload is undefined.
+                // Variant alignment is enforced above, so req.tag is guaranteed
+                // to be SmartContractAllowance here — the cast narrows it.
                 if (req.tag === "SmartContractAllowance") {
                     entries[key] = { tag: "SmartContractAllowance", dest: req.value };
+                    mutated = true;
                 }
                 break;
             case "AutoSigning":
@@ -151,10 +174,11 @@ export function mergeOutcomes(
                     productDerivationSecret: inner.value.productDerivationSecret,
                     productRootPrivateKey: toHex(inner.value.productRootPrivateKey),
                 };
+                mutated = true;
                 break;
         }
     }
-    return { version: 1, entries };
+    return mutated ? { version: 1, entries } : cache;
 }
 
 /** Look up a single cached allocation, or `null` if absent. */
@@ -163,6 +187,35 @@ export function readCacheEntry(
     resource: AllocatableResource,
 ): CachedAllocation | null {
     return cache.entries[cacheKey(resource)] ?? null;
+}
+
+/**
+ * Serialize load/merge/save sequences for the same cache file within a
+ * single process. Without this, parallel `requestResourceAllocation`
+ * calls for *different* resources can race: each snapshots the cache
+ * before the other writes, last writer wins, the loser's key is lost.
+ *
+ * Cross-process races are out of scope here — the Account Holder
+ * serializes per user/product/resource and returns identical bytes
+ * to concurrent callers for the same resource, so two CLI processes
+ * writing the same key converge.
+ */
+const cacheLocks = new Map<string, Promise<unknown>>();
+
+export function withCacheLock<T>(
+    appId: string,
+    storageDir: string | undefined,
+    fn: () => Promise<T>,
+): Promise<T> {
+    const key = cachePath(appId, storageDir);
+    const prev = cacheLocks.get(key) ?? Promise.resolve();
+    // Neutralize a prior rejection so one failure doesn't block subsequent waiters.
+    const next = prev.catch(() => {}).then(fn);
+    cacheLocks.set(
+        key,
+        next.catch(() => {}),
+    );
+    return next;
 }
 
 if (import.meta.vitest) {
@@ -423,6 +476,79 @@ if (import.meta.vitest) {
             });
         });
 
+        test("returns the same cache reference when no Allocated outcomes (no-op)", () => {
+            // Lets callers gate disk writes on reference equality.
+            const cache: AllowanceCacheV1 = {
+                version: 1,
+                entries: {
+                    BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0xaa" },
+                },
+            };
+            const requested: AllocatableResource[] = [
+                { tag: "BulletInAllowance", value: undefined },
+                { tag: "StatementStoreAllowance", value: undefined },
+            ];
+            const outcomes: ApAllocationOutcome[] = [
+                { tag: "Rejected", value: undefined },
+                { tag: "NotAvailable", value: undefined },
+            ];
+            expect(mergeOutcomes(cache, requested, outcomes)).toBe(cache);
+        });
+
+        test("empty inputs return the same cache reference", () => {
+            const cache = emptyCache();
+            expect(mergeOutcomes(cache, [], [])).toBe(cache);
+        });
+
+        test("returns a new object reference when at least one entry is added", () => {
+            const cache = emptyCache();
+            const requested: AllocatableResource[] = [
+                { tag: "BulletInAllowance", value: undefined },
+            ];
+            const outcomes: ApAllocationOutcome[] = [
+                {
+                    tag: "Allocated",
+                    value: {
+                        tag: "BulletInAllowance",
+                        value: { slotAccountKey: new Uint8Array([1]) },
+                    },
+                },
+            ];
+            expect(mergeOutcomes(cache, requested, outcomes)).not.toBe(cache);
+        });
+
+        test("throws when outcomes do not length-match requested", () => {
+            const cache = emptyCache();
+            const requested: AllocatableResource[] = [
+                { tag: "BulletInAllowance", value: undefined },
+                { tag: "StatementStoreAllowance", value: undefined },
+            ];
+            const outcomes: ApAllocationOutcome[] = [{ tag: "Rejected", value: undefined }];
+            expect(() => mergeOutcomes(cache, requested, outcomes)).toThrow(/length mismatch/);
+        });
+
+        test("throws when an Allocated outcome's variant does not match the requested variant", () => {
+            // outcomes must align positionally AND by variant with the
+            // request. Without this guard, a Bulletin key would get stored
+            // under the StatementStoreAllowance cache slot.
+            const cache = emptyCache();
+            const requested: AllocatableResource[] = [
+                { tag: "StatementStoreAllowance", value: undefined },
+            ];
+            const outcomes: ApAllocationOutcome[] = [
+                {
+                    tag: "Allocated",
+                    value: {
+                        tag: "BulletInAllowance",
+                        value: { slotAccountKey: new Uint8Array([0xaa]) },
+                    },
+                },
+            ];
+            expect(() => mergeOutcomes(cache, requested, outcomes)).toThrow(
+                /variant mismatch at index 0 — requested StatementStoreAllowance, got Allocated<BulletInAllowance>/,
+            );
+        });
+
         test("preserves existing entries when merging new ones", () => {
             const cache: AllowanceCacheV1 = {
                 version: 1,
@@ -481,6 +607,45 @@ if (import.meta.vitest) {
             expect(
                 readCacheEntry(cache, { tag: "BulletInAllowance", value: undefined }),
             ).toBeNull();
+        });
+    });
+
+    describe("withCacheLock", () => {
+        test("serializes calls for the same (appId, storageDir)", async () => {
+            const order: string[] = [];
+            const a = withCacheLock("app", storageDir, async () => {
+                order.push("a-start");
+                await new Promise((r) => setTimeout(r, 10));
+                order.push("a-end");
+            });
+            const b = withCacheLock("app", storageDir, async () => {
+                order.push("b-start");
+                order.push("b-end");
+            });
+            await Promise.all([a, b]);
+            expect(order).toEqual(["a-start", "a-end", "b-start", "b-end"]);
+        });
+
+        test("different (appId, storageDir) keys do not block each other", async () => {
+            let bRan = false;
+            const a = withCacheLock("app-a", storageDir, async () => {
+                // b should run while a is still inside the await
+                await new Promise((r) => setTimeout(r, 20));
+                expect(bRan).toBe(true);
+            });
+            const b = withCacheLock("app-b", storageDir, async () => {
+                bRan = true;
+            });
+            await Promise.all([a, b]);
+        });
+
+        test("a rejection in one call does not block subsequent calls on the same key", async () => {
+            const a = withCacheLock("app", storageDir, async () => {
+                throw new Error("boom");
+            });
+            await expect(a).rejects.toThrow("boom");
+            const b = await withCacheLock("app", storageDir, async () => "ok");
+            expect(b).toBe("ok");
         });
     });
 }

--- a/product-sdk/packages/terminal/src/host-signer.ts
+++ b/product-sdk/packages/terminal/src/host-signer.ts
@@ -11,7 +11,7 @@ import type { PolkadotSigner } from "polkadot-api";
 import { getPolkadotSigner } from "polkadot-api/signer";
 
 import type { TerminalAdapter } from "./adapter.js";
-import { loadCache, readCacheEntry } from "./host-cache.js";
+import { type CachedAllocation, loadCache, readCacheEntry } from "./host-cache.js";
 import type { AllocatableResource } from "./host.js";
 
 // Wire encoding for slotAccountKey isn't pinned: mobile may send a
@@ -38,6 +38,25 @@ function buildKeypair(secret: Uint8Array): {
 }
 
 /**
+ * Build a `PolkadotSigner` from an already-loaded cache entry. Throws
+ * for SC and AutoSigning — they don't carry a slot account key. See
+ * the module docstring.
+ *
+ * Useful when the caller already holds the cache in memory, e.g. inside
+ * a `withCacheLock` block, and wants to avoid re-reading disk.
+ */
+export function buildSignerFromEntry(entry: CachedAllocation): PolkadotSigner {
+    if (entry.tag !== "BulletInAllowance" && entry.tag !== "StatementStoreAllowance") {
+        throw new Error(
+            `createSlotAccountSigner: ${entry.tag} does not carry a slot account key. Slot-table signing is defined for BulletInAllowance and StatementStoreAllowance only.`,
+        );
+    }
+    const secret = fromHex(entry.slotAccountKey);
+    const { publicKey, sign } = buildKeypair(secret);
+    return getPolkadotSigner(publicKey, "Sr25519", async (data) => sign(data));
+}
+
+/**
  * `PolkadotSigner` backed by the cached slot account key. Returns `null`
  * when nothing's cached for `(adapter.appId, resource)`. Throws for SC
  * and AutoSigning (no slot account key — see module docstring).
@@ -57,18 +76,9 @@ export async function createSlotAccountSigner(
     resource: AllocatableResource,
 ): Promise<PolkadotSigner | null> {
     const cache = await loadCache(adapter.appId, adapter.storageDir);
-    const cached = readCacheEntry(cache, resource);
-    if (!cached) return null;
-
-    if (cached.tag !== "BulletInAllowance" && cached.tag !== "StatementStoreAllowance") {
-        throw new Error(
-            `createSlotAccountSigner: ${cached.tag} does not carry a slot account key. Slot-table signing is defined for BulletInAllowance and StatementStoreAllowance only.`,
-        );
-    }
-
-    const secret = fromHex(cached.slotAccountKey);
-    const { publicKey, sign } = buildKeypair(secret);
-    return getPolkadotSigner(publicKey, "Sr25519", async (data) => sign(data));
+    const entry = readCacheEntry(cache, resource);
+    if (!entry) return null;
+    return buildSignerFromEntry(entry);
 }
 
 if (import.meta.vitest) {

--- a/product-sdk/packages/terminal/src/host-signer.ts
+++ b/product-sdk/packages/terminal/src/host-signer.ts
@@ -1,0 +1,361 @@
+/**
+ * Slot-account signer: reads the cached Bulletin/SSS allowance key and
+ * returns a `PolkadotSigner` that signs locally with sr25519. SC and
+ * AutoSigning are not slot-table variants and throw.
+ *
+ * @module
+ */
+import { fromHex } from "@polkadot-api/utils";
+import { createDerive, sr25519, sr25519Derive } from "@polkadot-labs/hdkd-helpers";
+import type { PolkadotSigner } from "polkadot-api";
+import { getPolkadotSigner } from "polkadot-api/signer";
+
+import type { TerminalAdapter } from "./adapter.js";
+import { loadCache, readCacheEntry } from "./host-cache.js";
+import type { AllocatableResource } from "./host.js";
+
+// Wire encoding for slotAccountKey isn't pinned: mobile may send a
+// 32-byte mini-secret or a 64-byte expanded secret. Detect length and
+// route; any other length throws.
+function buildKeypair(secret: Uint8Array): {
+    publicKey: Uint8Array;
+    sign: (data: Uint8Array) => Uint8Array;
+} {
+    if (secret.length === 32) {
+        const derive = createDerive({ seed: secret, curve: sr25519, derive: sr25519Derive });
+        const keypair = derive("");
+        return { publicKey: keypair.publicKey, sign: (data) => keypair.sign(data) };
+    }
+    if (secret.length === 64) {
+        return {
+            publicKey: sr25519.getPublicKey(secret),
+            sign: (data) => sr25519.sign(data, secret),
+        };
+    }
+    throw new Error(
+        `createSlotAccountSigner: unexpected slotAccountKey length ${secret.length}. Expected 32 (mini-secret) or 64 (expanded secret).`,
+    );
+}
+
+/**
+ * `PolkadotSigner` backed by the cached slot account key. Returns `null`
+ * when nothing's cached for `(adapter.appId, resource)`. Throws for SC
+ * and AutoSigning (no slot account key — see module docstring).
+ *
+ * Signs locally with sr25519 — no wallet round-trip on the hot path.
+ *
+ * @example
+ * ```ts
+ * const signer = await createSlotAccountSigner(adapter, {
+ *   tag: "BulletInAllowance", value: undefined,
+ * });
+ * if (signer) await tx.submitAndWatch(signer);
+ * ```
+ */
+export async function createSlotAccountSigner(
+    adapter: TerminalAdapter,
+    resource: AllocatableResource,
+): Promise<PolkadotSigner | null> {
+    const cache = await loadCache(adapter.appId, adapter.storageDir);
+    const cached = readCacheEntry(cache, resource);
+    if (!cached) return null;
+
+    if (cached.tag !== "BulletInAllowance" && cached.tag !== "StatementStoreAllowance") {
+        throw new Error(
+            `createSlotAccountSigner: ${cached.tag} does not carry a slot account key. Slot-table signing is defined for BulletInAllowance and StatementStoreAllowance only.`,
+        );
+    }
+
+    const secret = fromHex(cached.slotAccountKey);
+    const { publicKey, sign } = buildKeypair(secret);
+    return getPolkadotSigner(publicKey, "Sr25519", async (data) => sign(data));
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect, beforeEach } = import.meta.vitest;
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join: pathJoin } = await import("node:path");
+    const { saveCache } = await import("./host-cache.js");
+    const { DEV_PHRASE, mnemonicToMiniSecret } = await import("@polkadot-labs/hdkd-helpers");
+    const { toHex } = await import("@polkadot-api/utils");
+
+    let storageDir: string;
+    beforeEach(() => {
+        storageDir = mkdtempSync(pathJoin(tmpdir(), "host-signer-test-"));
+        return () => rmSync(storageDir, { recursive: true, force: true });
+    });
+
+    function fakeAdapter(appId: string): TerminalAdapter {
+        return { appId, storageDir } as unknown as TerminalAdapter;
+    }
+
+    function knownSecret(): {
+        secret: Uint8Array;
+        publicKey: Uint8Array;
+        hex: string;
+        sign: (msg: Uint8Array) => Uint8Array;
+    } {
+        // Deterministic across runs — uses the standard substrate dev
+        // mnemonic. `mnemonicToMiniSecret` returns the 32-byte mini-secret
+        // form (one of the two shapes `createSlotAccountSigner` accepts).
+        const secret = mnemonicToMiniSecret(DEV_PHRASE);
+        const derive = createDerive({ seed: secret, curve: sr25519, derive: sr25519Derive });
+        const keypair = derive("");
+        return {
+            secret,
+            publicKey: keypair.publicKey,
+            hex: toHex(secret),
+            sign: (msg) => keypair.sign(msg),
+        };
+    }
+
+    describe("createSlotAccountSigner", () => {
+        test("returns null when no allocation is cached", async () => {
+            const adapter = fakeAdapter("p");
+            const signer = await createSlotAccountSigner(adapter, {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(signer).toBeNull();
+        });
+
+        test("returns a signer with the sr25519 public key derived from the cached secret", async () => {
+            const { hex, publicKey } = knownSecret();
+            await saveCache(
+                "p",
+                {
+                    version: 1,
+                    entries: {
+                        BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: hex },
+                    },
+                },
+                storageDir,
+            );
+
+            const signer = await createSlotAccountSigner(fakeAdapter("p"), {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(signer).not.toBeNull();
+            expect(signer?.publicKey).toEqual(publicKey);
+        });
+
+        test("signs locally and the signature verifies against the cached account", async () => {
+            const { hex, publicKey } = knownSecret();
+            await saveCache(
+                "p",
+                {
+                    version: 1,
+                    entries: {
+                        BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: hex },
+                    },
+                },
+                storageDir,
+            );
+
+            const signer = await createSlotAccountSigner(fakeAdapter("p"), {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            // `signBytes` wraps with `<Bytes>...</Bytes>` like all PAPI
+            // PolkadotSigners do; for direct payload signing PAPI calls
+            // `signTx` which routes through the same `sign` callback we
+            // installed. Test that callback directly by reaching for the
+            // typed surface: PAPI exposes signTx but the easiest direct
+            // verification is `signBytes` which is wired through our sign.
+            const payload = new TextEncoder().encode("hello slot");
+            // signBytes wraps in <Bytes>...</Bytes> before calling our sign.
+            // To verify, reconstruct the wrap manually.
+            const wrapped = new Uint8Array([
+                ...new TextEncoder().encode("<Bytes>"),
+                ...payload,
+                ...new TextEncoder().encode("</Bytes>"),
+            ]);
+            const signature = await signer!.signBytes(payload);
+            expect(sr25519.verify(signature, wrapped, publicKey)).toBe(true);
+        });
+
+        test("64-byte expanded-secret form produces a valid signer", async () => {
+            // Pre-computed: @scure/sr25519's secretFromSeed(mnemonicToMiniSecret(DEV_PHRASE)).
+            // Public key must match the 32-byte path's derived key.
+            const SECRET_64_HEX =
+                "0x28b0ae221c6bb06856b287f60d7ea0d98552ea5a16db16956849aa371db3eb51fd190cce74df356432b410bd64682309d6dedb27c76845daf388557cbac3ca34";
+
+            await saveCache(
+                "p",
+                {
+                    version: 1,
+                    entries: {
+                        BulletInAllowance: {
+                            tag: "BulletInAllowance",
+                            slotAccountKey: SECRET_64_HEX,
+                        },
+                    },
+                },
+                storageDir,
+            );
+
+            const signer = await createSlotAccountSigner(fakeAdapter("p"), {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(signer).not.toBeNull();
+
+            // Public key from the 64-byte path matches the 32-byte path's
+            // — same logical key, two encodings.
+            const { publicKey: pubFrom32Bytes } = knownSecret();
+            expect(signer?.publicKey).toEqual(pubFrom32Bytes);
+
+            // Signature from the 64-byte branch verifies against the same
+            // public key.
+            const payload = new TextEncoder().encode("hello 64-byte path");
+            const wrapped = new Uint8Array([
+                ...new TextEncoder().encode("<Bytes>"),
+                ...payload,
+                ...new TextEncoder().encode("</Bytes>"),
+            ]);
+            const sig = await signer!.signBytes(payload);
+            expect(sr25519.verify(sig, wrapped, pubFrom32Bytes)).toBe(true);
+        });
+
+        test("works for StatementStoreAllowance the same way", async () => {
+            const { hex, publicKey } = knownSecret();
+            await saveCache(
+                "p",
+                {
+                    version: 1,
+                    entries: {
+                        StatementStoreAllowance: {
+                            tag: "StatementStoreAllowance",
+                            slotAccountKey: hex,
+                        },
+                    },
+                },
+                storageDir,
+            );
+
+            const signer = await createSlotAccountSigner(fakeAdapter("p"), {
+                tag: "StatementStoreAllowance",
+                value: undefined,
+            });
+            expect(signer?.publicKey).toEqual(publicKey);
+        });
+
+        test("throws for SmartContractAllowance (no slot account key)", async () => {
+            await saveCache(
+                "p",
+                {
+                    version: 1,
+                    entries: {
+                        "SmartContractAllowance::5": { tag: "SmartContractAllowance", dest: 5 },
+                    },
+                },
+                storageDir,
+            );
+
+            await expect(
+                createSlotAccountSigner(fakeAdapter("p"), {
+                    tag: "SmartContractAllowance",
+                    value: 5,
+                }),
+            ).rejects.toThrow(/SmartContractAllowance does not carry a slot account key/);
+        });
+
+        test("throws for AutoSigning (subtree key, not slot account)", async () => {
+            await saveCache(
+                "p",
+                {
+                    version: 1,
+                    entries: {
+                        AutoSigning: {
+                            tag: "AutoSigning",
+                            productDerivationSecret: "secret",
+                            productRootPrivateKey: "0xabcd",
+                        },
+                    },
+                },
+                storageDir,
+            );
+
+            await expect(
+                createSlotAccountSigner(fakeAdapter("p"), {
+                    tag: "AutoSigning",
+                    value: undefined,
+                }),
+            ).rejects.toThrow(/AutoSigning does not carry a slot account key/);
+        });
+
+        test("different appIds yield different signers from disjoint caches", async () => {
+            const a = knownSecret();
+            // Distinct mini-secret → distinct derived keypair.
+            const otherMiniSecret = new Uint8Array(32).fill(0x07);
+            const otherKeypair = createDerive({
+                seed: otherMiniSecret,
+                curve: sr25519,
+                derive: sr25519Derive,
+            })("");
+
+            await saveCache(
+                "app-a",
+                {
+                    version: 1,
+                    entries: {
+                        BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: a.hex },
+                    },
+                },
+                storageDir,
+            );
+            await saveCache(
+                "app-b",
+                {
+                    version: 1,
+                    entries: {
+                        BulletInAllowance: {
+                            tag: "BulletInAllowance",
+                            slotAccountKey: toHex(otherMiniSecret),
+                        },
+                    },
+                },
+                storageDir,
+            );
+
+            const signerA = await createSlotAccountSigner(fakeAdapter("app-a"), {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            const signerB = await createSlotAccountSigner(fakeAdapter("app-b"), {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(signerA?.publicKey).toEqual(a.publicKey);
+            expect(signerB?.publicKey).toEqual(otherKeypair.publicKey);
+            expect(signerA?.publicKey).not.toEqual(signerB?.publicKey);
+        });
+
+        test("rejects an unexpected slotAccountKey length", async () => {
+            // Variable-length codec on the wire, but our keypair builder
+            // only recognizes the standard 32 / 64 byte forms.
+            await saveCache(
+                "p",
+                {
+                    version: 1,
+                    entries: {
+                        BulletInAllowance: {
+                            tag: "BulletInAllowance",
+                            slotAccountKey: toHex(new Uint8Array(48).fill(1)),
+                        },
+                    },
+                },
+                storageDir,
+            );
+
+            await expect(
+                createSlotAccountSigner(fakeAdapter("p"), {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+            ).rejects.toThrow(/unexpected slotAccountKey length 48/);
+        });
+    });
+}

--- a/product-sdk/packages/terminal/src/host.ts
+++ b/product-sdk/packages/terminal/src/host.ts
@@ -1,0 +1,760 @@
+/**
+ * Host-runner facet of `@parity/product-sdk-terminal`. A CLI using this
+ * package plays the Host role per RFC-10; this module implements the
+ * three §Stakeholders Host responsibilities (AP client, cache, signer)
+ * over `@novasamatech/host-papp@0.7.7`'s `UserSession`.
+ *
+ * @module
+ */
+import type { UserSession } from "@novasamatech/host-papp";
+import { createLogger } from "@parity/product-sdk-logger";
+import type { ResultAsync } from "neverthrow";
+import type { PolkadotSigner } from "polkadot-api";
+
+import type { TerminalAdapter } from "./adapter.js";
+import {
+    type CachedAllocation,
+    loadCache,
+    mergeOutcomes,
+    pickOnExistingPolicy,
+    readCacheEntry,
+    saveCache,
+} from "./host-cache.js";
+import { createSlotAccountSigner } from "./host-signer.js";
+
+// `terminal` namespace matches adapter.ts / node-storage.ts.
+const log = createLogger("terminal");
+
+// Public re-exports — internal helpers (loadCache, mergeOutcomes, etc.)
+// stay private. CachedAllocation must be exported because it's the return
+// type of getCachedAllocation.
+export type { CachedAllocation };
+export { createSlotAccountSigner };
+
+// Types derived from `UserSession['requestResourceAllocation']` so upstream
+// codec changes surface as compile errors here, not runtime decode failures.
+// host-papp doesn't re-export these codec types from its root.
+type ResourceAllocationRequest = Parameters<UserSession["requestResourceAllocation"]>[0];
+
+/**
+ * One resource a Host can request from the Account Holder. AutoSigning
+ * currently returns `NotAvailable` on both Android and iOS wallets.
+ */
+export type AllocatableResource = ResourceAllocationRequest["resources"][number];
+
+/**
+ * `"Ignore"`: return existing keys if any, else allocate one slot.
+ * `"Increase"`: add one slot to an existing allowance account.
+ */
+export type OnExistingAllowancePolicy = ResourceAllocationRequest["onExisting"];
+
+type ExtractOk<R> = R extends ResultAsync<infer T, unknown> ? T : never;
+
+/**
+ * Per-resource outcome. `Allocated.value` carries the materialized payload
+ * (slot account key for Bulletin/SSS; subtree key + secret for AutoSigning;
+ * undefined for SC). Each entry is independent — no rollback on partial
+ * success.
+ */
+export type ApAllocationOutcome = ExtractOk<
+    ReturnType<UserSession["requestResourceAllocation"]>
+>[number];
+
+export interface RequestResourceAllocationOptions {
+    /**
+     * Override the auto-picked `onExisting`. Default: `Ignore` unless every
+     * requested resource is a cached slot-table variant, then `Increase`.
+     */
+    onExisting?: OnExistingAllowancePolicy;
+}
+
+/**
+ * Send the AP `request_resource_allocation` message over the paired
+ * session; block on the user's mobile dialog; return outcomes in request
+ * order. Granted key material is cached on disk so subsequent calls skip
+ * the wallet prompt.
+ *
+ * @throws If the session call fails (transport, timeout, AH protocol error).
+ *
+ * @example
+ * ```ts
+ * const [session] = adapter.sessions.sessions.read();
+ * const outcomes = await requestResourceAllocation(session, adapter, [
+ *   { tag: "BulletInAllowance", value: undefined },
+ * ]);
+ * ```
+ */
+export async function requestResourceAllocation(
+    session: UserSession,
+    adapter: TerminalAdapter,
+    resources: AllocatableResource[],
+    options: RequestResourceAllocationOptions = {},
+): Promise<ApAllocationOutcome[]> {
+    const cache = await loadCache(adapter.appId, adapter.storageDir);
+    const onExisting = options.onExisting ?? pickOnExistingPolicy(cache, resources);
+    log.debug("requestResourceAllocation", {
+        productId: adapter.appId,
+        resources: resources.map((r) => r.tag),
+        onExisting,
+        autoPolicy: options.onExisting === undefined,
+    });
+
+    const result = await session.requestResourceAllocation({
+        callingProductId: adapter.appId,
+        resources,
+        onExisting,
+    });
+
+    if (result.isErr()) {
+        throw new Error(`requestResourceAllocation failed: ${result.error.message}`);
+    }
+
+    const next = mergeOutcomes(cache, resources, result.value);
+    if (next !== cache) {
+        await saveCache(adapter.appId, next, adapter.storageDir);
+    }
+
+    return result.value;
+}
+
+/**
+ * Read a cached allowance entry without going over the wire. Returns
+ * `null` if nothing's cached for `(adapter.appId, resource)`. For
+ * `SmartContractAllowance`, the same `dest` must be passed — entries
+ * are keyed per-dest.
+ */
+export async function getCachedAllocation(
+    adapter: TerminalAdapter,
+    resource: AllocatableResource,
+): Promise<CachedAllocation | null> {
+    const cache = await loadCache(adapter.appId, adapter.storageDir);
+    return readCacheEntry(cache, resource);
+}
+
+/**
+ * Cache hit → return signer. Cache miss → call
+ * {@link requestResourceAllocation} for `[resource]`, then build the signer.
+ * Throws on `Rejected` / `NotAvailable`.
+ *
+ * @example
+ * ```ts
+ * const signer = await ensureSlotAccountSigner(session, adapter, {
+ *   tag: "BulletInAllowance", value: undefined,
+ * });
+ * await someBulletinTx.submitAndWatch(signer);
+ * ```
+ */
+export async function ensureSlotAccountSigner(
+    session: UserSession,
+    adapter: TerminalAdapter,
+    resource: AllocatableResource,
+): Promise<PolkadotSigner> {
+    // Cache check first; SC / AutoSigning throw here (no signer to build).
+    const cached = await createSlotAccountSigner(adapter, resource);
+    if (cached) return cached;
+
+    log.debug("ensureSlotAccountSigner: cache miss, allocating", { resource: resource.tag });
+    const outcomes = await requestResourceAllocation(session, adapter, [resource]);
+    const outcome = outcomes[0];
+    if (!outcome) {
+        // Defensive: wire response is length-matched, so this is unreachable
+        // unless the wire contract breaks.
+        throw new Error(
+            `ensureSlotAccountSigner: protocol violation — empty outcomes for ${resource.tag}`,
+        );
+    }
+    if (outcome.tag !== "Allocated") {
+        throw new Error(`ensureSlotAccountSigner: allocation ${outcome.tag} for ${resource.tag}`);
+    }
+
+    const fresh = await createSlotAccountSigner(adapter, resource);
+    if (!fresh) {
+        // Unreachable: requestResourceAllocation just wrote the entry.
+        // Kept as a typed-non-null guard against mergeOutcomes regressions.
+        throw new Error(
+            `ensureSlotAccountSigner: allocation succeeded but cache lookup returned null for ${resource.tag}`,
+        );
+    }
+    return fresh;
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect, vi, beforeEach } = import.meta.vitest;
+    const { ok, err } = await import("neverthrow");
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join: pathJoin } = await import("node:path");
+    // Needed by the ensureSlotAccountSigner suite. Lifted up here because
+    // top-level await is only allowed at module top-level (or inside this
+    // top-level vitest block), not inside `describe`.
+    const { mnemonicToMiniSecret, DEV_PHRASE } = await import("@polkadot-labs/hdkd-helpers");
+
+    let testStorageDir: string;
+    beforeEach(() => {
+        // Per-test temp dir so cache writes don't leak between tests or
+        // touch the real `~/.polkadot-apps/`. The wrapper inherits
+        // `storageDir` from `adapter.storageDir`; we pin it here.
+        testStorageDir = mkdtempSync(pathJoin(tmpdir(), "host-test-"));
+        return () => rmSync(testStorageDir, { recursive: true, force: true });
+    });
+
+    function fakeAdapter(appId: string): TerminalAdapter {
+        // appId + storageDir are the only fields the wrapper touches.
+        return { appId, storageDir: testStorageDir } as unknown as TerminalAdapter;
+    }
+
+    type RequestCapture = ResourceAllocationRequest;
+    type StubReturn = Awaited<ReturnType<UserSession["requestResourceAllocation"]>>;
+
+    function makeSession(opts: {
+        requestResourceAllocation?: (req: RequestCapture) => Promise<StubReturn>;
+    }): UserSession {
+        return {
+            requestResourceAllocation: vi.fn(
+                opts.requestResourceAllocation ??
+                    (async () => {
+                        throw new Error("requestResourceAllocation not stubbed in this test");
+                    }),
+            ),
+        } as unknown as UserSession;
+    }
+
+    describe("requestResourceAllocation", () => {
+        test("forwards resources verbatim and returns outcomes in order", async () => {
+            const captured: RequestCapture[] = [];
+            const stubbed = [
+                {
+                    tag: "Allocated" as const,
+                    value: {
+                        tag: "BulletInAllowance" as const,
+                        value: { slotAccountKey: new Uint8Array([1, 2, 3]) },
+                    },
+                },
+                { tag: "Rejected" as const, value: undefined },
+            ];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return ok(stubbed) as StubReturn;
+                },
+            });
+
+            const outcomes = await requestResourceAllocation(session, fakeAdapter("my-app"), [
+                { tag: "BulletInAllowance", value: undefined },
+                { tag: "StatementStoreAllowance", value: undefined },
+            ]);
+
+            expect(captured).toHaveLength(1);
+            expect(captured[0].callingProductId).toBe("my-app");
+            expect(captured[0].resources.map((r) => r.tag)).toEqual([
+                "BulletInAllowance",
+                "StatementStoreAllowance",
+            ]);
+            expect(outcomes).toEqual(stubbed);
+        });
+
+        test("uses adapter.appId as callingProductId", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return ok([]) as StubReturn;
+                },
+            });
+
+            await requestResourceAllocation(session, fakeAdapter("alt-product.dot"), []);
+
+            expect(captured[0].callingProductId).toBe("alt-product.dot");
+        });
+
+        test("auto-picks Ignore for an empty resources array", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return ok([]) as StubReturn;
+                },
+            });
+
+            await requestResourceAllocation(session, fakeAdapter("p"), []);
+
+            expect(captured[0].onExisting).toBe("Ignore");
+        });
+
+        test("forwards onExisting when explicitly set to 'Increase'", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return ok([]) as StubReturn;
+                },
+            });
+
+            await requestResourceAllocation(
+                session,
+                fakeAdapter("p"),
+                [{ tag: "BulletInAllowance", value: undefined }],
+                { onExisting: "Increase" },
+            );
+
+            expect(captured[0].onExisting).toBe("Increase");
+        });
+
+        test("forwards SmartContractAllowance derivation index", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return ok([]) as StubReturn;
+                },
+            });
+
+            await requestResourceAllocation(session, fakeAdapter("p"), [
+                { tag: "SmartContractAllowance", value: 7 },
+            ]);
+
+            const sent = captured[0].resources[0];
+            expect(sent.tag).toBe("SmartContractAllowance");
+            if (sent.tag === "SmartContractAllowance") {
+                expect(sent.value).toBe(7);
+            }
+        });
+
+        test("throws a clear error when the session call fails", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () =>
+                    err(new Error("mobile disconnected")) as StubReturn,
+            });
+
+            await expect(
+                requestResourceAllocation(session, fakeAdapter("p"), [
+                    { tag: "BulletInAllowance", value: undefined },
+                ]),
+            ).rejects.toThrow("requestResourceAllocation failed: mobile disconnected");
+        });
+
+        test("forwards AutoSigning and returns NotAvailable verbatim (mobile-default path)", async () => {
+            // Both Android (paritytech/polkadot-app-android-v2#563) and iOS
+            // (paritytech/polkadot-app-ios-v2#759) currently return NotAvailable
+            // for any AutoSigning request. The wrapper must round-trip both
+            // the request variant and the NotAvailable outcome without
+            // filtering, transforming, or throwing — that's the only state
+            // real users see for one of the four AllocatableResource variants
+            // today.
+            const captured: RequestCapture[] = [];
+            const stubbed = [{ tag: "NotAvailable" as const, value: undefined }];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return ok(stubbed) as StubReturn;
+                },
+            });
+
+            const outcomes = await requestResourceAllocation(session, fakeAdapter("p"), [
+                { tag: "AutoSigning", value: undefined },
+            ]);
+
+            const sent = captured[0].resources[0];
+            expect(sent.tag).toBe("AutoSigning");
+            expect(outcomes).toEqual(stubbed);
+        });
+
+        test("passes empty resources through (no-op request still hits the wire)", async () => {
+            // Wrappers shouldn't second-guess the caller: an empty resource
+            // list is a legitimate (if degenerate) request and the wire
+            // accepts it. The Account Holder may use it as a probe.
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return ok([]) as StubReturn;
+                },
+            });
+
+            const outcomes = await requestResourceAllocation(session, fakeAdapter("p"), []);
+
+            expect(captured).toHaveLength(1);
+            expect(captured[0].resources).toEqual([]);
+            expect(outcomes).toEqual([]);
+        });
+    });
+
+    describe("requestResourceAllocation — cache integration", () => {
+        function bulletinAllocated(slotKey: Uint8Array): StubReturn {
+            return ok([
+                {
+                    tag: "Allocated" as const,
+                    value: {
+                        tag: "BulletInAllowance" as const,
+                        value: { slotAccountKey: slotKey },
+                    },
+                },
+            ]) as StubReturn;
+        }
+
+        test("first call sends Ignore when cache is empty", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return bulletinAllocated(new Uint8Array([1, 2, 3]));
+                },
+            });
+
+            await requestResourceAllocation(session, fakeAdapter("p"), [
+                { tag: "BulletInAllowance", value: undefined },
+            ]);
+
+            expect(captured[0].onExisting).toBe("Ignore");
+        });
+
+        test("second call for same slot-table resource auto-picks Increase", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return bulletinAllocated(new Uint8Array([1, 2, 3]));
+                },
+            });
+
+            const adapter = fakeAdapter("p");
+            const req: AllocatableResource[] = [{ tag: "BulletInAllowance", value: undefined }];
+
+            await requestResourceAllocation(session, adapter, req);
+            await requestResourceAllocation(session, adapter, req);
+
+            expect(captured.map((c) => c.onExisting)).toEqual(["Ignore", "Increase"]);
+        });
+
+        test("explicit options.onExisting overrides the auto-pick", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return bulletinAllocated(new Uint8Array([1, 2, 3]));
+                },
+            });
+
+            const adapter = fakeAdapter("p");
+            const req: AllocatableResource[] = [{ tag: "BulletInAllowance", value: undefined }];
+
+            // Even after a cache-populating first call, passing Ignore
+            // explicitly forces Ignore — useful for callers that want
+            // idempotent "ensure I have allowance" semantics rather than
+            // the additive-scaling default.
+            await requestResourceAllocation(session, adapter, req);
+            await requestResourceAllocation(session, adapter, req, { onExisting: "Ignore" });
+
+            expect(captured.map((c) => c.onExisting)).toEqual(["Ignore", "Ignore"]);
+        });
+
+        test("populates cache on Allocated and survives across separate calls", async () => {
+            const slotKey = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+            const session = makeSession({
+                requestResourceAllocation: async () => bulletinAllocated(slotKey),
+            });
+
+            const adapter = fakeAdapter("p");
+            await requestResourceAllocation(session, adapter, [
+                { tag: "BulletInAllowance", value: undefined },
+            ]);
+
+            // Second call reads cache via the public lookup, no wire.
+            const cached = await getCachedAllocation(adapter, {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(cached).toEqual({
+                tag: "BulletInAllowance",
+                slotAccountKey: "0xdeadbeef",
+            });
+        });
+
+        test("does not cache Rejected or NotAvailable outcomes", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () =>
+                    ok([
+                        { tag: "Rejected" as const, value: undefined },
+                        { tag: "NotAvailable" as const, value: undefined },
+                    ]) as StubReturn,
+            });
+
+            const adapter = fakeAdapter("p");
+            await requestResourceAllocation(session, adapter, [
+                { tag: "BulletInAllowance", value: undefined },
+                { tag: "StatementStoreAllowance", value: undefined },
+            ]);
+
+            expect(
+                await getCachedAllocation(adapter, { tag: "BulletInAllowance", value: undefined }),
+            ).toBeNull();
+            expect(
+                await getCachedAllocation(adapter, {
+                    tag: "StatementStoreAllowance",
+                    value: undefined,
+                }),
+            ).toBeNull();
+        });
+
+        test("mixed cached + uncached request stays on Ignore (conservative)", async () => {
+            // Bulletin cached, SSS not. Auto-pick must NOT send Increase
+            // — the wire takes one policy for the whole request, and
+            // Increase against an uncached resource is at-best a no-op
+            // and at-worst a mis-allocation.
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return bulletinAllocated(new Uint8Array([1]));
+                },
+            });
+
+            const adapter = fakeAdapter("p");
+            // Populate Bulletin in cache.
+            await requestResourceAllocation(session, adapter, [
+                { tag: "BulletInAllowance", value: undefined },
+            ]);
+
+            // Now request both Bulletin (cached) and SSS (uncached).
+            await requestResourceAllocation(session, adapter, [
+                { tag: "BulletInAllowance", value: undefined },
+                { tag: "StatementStoreAllowance", value: undefined },
+            ]);
+
+            expect(captured[captured.length - 1].onExisting).toBe("Ignore");
+        });
+
+        test("AutoSigning never auto-Increases even when cached", async () => {
+            // AutoSigning isn't slot-additive; auto-pick must stay on Ignore.
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return ok([
+                        {
+                            tag: "Allocated" as const,
+                            value: {
+                                tag: "AutoSigning" as const,
+                                value: {
+                                    productDerivationSecret: "secret",
+                                    productRootPrivateKey: new Uint8Array([0xab]),
+                                },
+                            },
+                        },
+                    ]) as StubReturn;
+                },
+            });
+
+            const adapter = fakeAdapter("p");
+            const req: AllocatableResource[] = [{ tag: "AutoSigning", value: undefined }];
+
+            await requestResourceAllocation(session, adapter, req);
+            await requestResourceAllocation(session, adapter, req);
+
+            expect(captured.map((c) => c.onExisting)).toEqual(["Ignore", "Ignore"]);
+        });
+
+        test("two appIds maintain independent caches in the same storageDir", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () => bulletinAllocated(new Uint8Array([1, 2, 3])),
+            });
+
+            const adapterA = fakeAdapter("app-a");
+            const adapterB = fakeAdapter("app-b");
+
+            await requestResourceAllocation(session, adapterA, [
+                { tag: "BulletInAllowance", value: undefined },
+            ]);
+
+            // app-b's cache is empty even though app-a's is populated.
+            expect(
+                await getCachedAllocation(adapterB, {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+            ).toBeNull();
+            expect(
+                await getCachedAllocation(adapterA, {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+            ).not.toBeNull();
+        });
+    });
+
+    describe("getCachedAllocation", () => {
+        test("returns null when nothing is cached", async () => {
+            const adapter = fakeAdapter("p");
+            const cached = await getCachedAllocation(adapter, {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(cached).toBeNull();
+        });
+
+        test("disambiguates SmartContractAllowance entries by dest", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () =>
+                    ok([
+                        {
+                            tag: "Allocated" as const,
+                            value: {
+                                tag: "SmartContractAllowance" as const,
+                                value: undefined,
+                            },
+                        },
+                    ]) as StubReturn,
+            });
+            const adapter = fakeAdapter("p");
+            await requestResourceAllocation(session, adapter, [
+                { tag: "SmartContractAllowance", value: 5 },
+            ]);
+
+            expect(
+                await getCachedAllocation(adapter, { tag: "SmartContractAllowance", value: 5 }),
+            ).toEqual({ tag: "SmartContractAllowance", dest: 5 });
+            // Different dest doesn't match.
+            expect(
+                await getCachedAllocation(adapter, { tag: "SmartContractAllowance", value: 6 }),
+            ).toBeNull();
+        });
+    });
+
+    describe("ensureSlotAccountSigner", () => {
+        // Deterministic mini-secret so the signer is constructable.
+        const slotKey = mnemonicToMiniSecret(DEV_PHRASE);
+
+        function bulletinAllocatedResponse() {
+            return ok([
+                {
+                    tag: "Allocated" as const,
+                    value: {
+                        tag: "BulletInAllowance" as const,
+                        value: { slotAccountKey: slotKey },
+                    },
+                },
+            ]) as StubReturn;
+        }
+
+        test("cache hit returns a signer without invoking the AP wire", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return bulletinAllocatedResponse();
+                },
+            });
+            const adapter = fakeAdapter("p");
+
+            // Populate cache.
+            await requestResourceAllocation(session, adapter, [
+                { tag: "BulletInAllowance", value: undefined },
+            ]);
+            expect(captured).toHaveLength(1);
+
+            // ensureSlotAccountSigner should find the cached key and NOT
+            // call the wire again.
+            const signer = await ensureSlotAccountSigner(session, adapter, {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(signer.publicKey).toBeInstanceOf(Uint8Array);
+            expect(captured).toHaveLength(1); // still 1 — no extra round-trip
+        });
+
+        test("cache miss triggers allocation and returns a fresh signer", async () => {
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    return bulletinAllocatedResponse();
+                },
+            });
+            const adapter = fakeAdapter("p");
+
+            // No prior call. ensureSlotAccountSigner should round-trip.
+            const signer = await ensureSlotAccountSigner(session, adapter, {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(signer.publicKey).toBeInstanceOf(Uint8Array);
+            expect(captured).toHaveLength(1);
+            // Implicit allocation requests exactly one resource.
+            expect(captured[0].resources.map((r) => r.tag)).toEqual(["BulletInAllowance"]);
+        });
+
+        test("Rejected outcome surfaces as a throw — no signer to return", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () =>
+                    ok([{ tag: "Rejected" as const, value: undefined }]) as StubReturn,
+            });
+
+            await expect(
+                ensureSlotAccountSigner(session, fakeAdapter("p"), {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+            ).rejects.toThrow(/allocation Rejected for BulletInAllowance/);
+        });
+
+        test("empty outcomes array from the wire surfaces as a protocol-violation throw", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () => ok([]) as StubReturn,
+            });
+
+            await expect(
+                ensureSlotAccountSigner(session, fakeAdapter("p"), {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+            ).rejects.toThrow(/protocol violation — empty outcomes for BulletInAllowance/);
+        });
+
+        test("NotAvailable outcome surfaces as a throw", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () =>
+                    ok([{ tag: "NotAvailable" as const, value: undefined }]) as StubReturn,
+            });
+
+            await expect(
+                ensureSlotAccountSigner(session, fakeAdapter("p"), {
+                    tag: "StatementStoreAllowance",
+                    value: undefined,
+                }),
+            ).rejects.toThrow(/allocation NotAvailable for StatementStoreAllowance/);
+        });
+
+        test("transport error propagates from the underlying allocation call", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () =>
+                    err(new Error("mobile timed out")) as StubReturn,
+            });
+
+            await expect(
+                ensureSlotAccountSigner(session, fakeAdapter("p"), {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+            ).rejects.toThrow(/mobile timed out/);
+        });
+
+        test("populates the cache so a later call is a hit", async () => {
+            const session = makeSession({
+                requestResourceAllocation: async () => bulletinAllocatedResponse(),
+            });
+            const adapter = fakeAdapter("p");
+
+            await ensureSlotAccountSigner(session, adapter, {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+
+            // After the implicit allocation, getCachedAllocation should see the key.
+            const cached = await getCachedAllocation(adapter, {
+                tag: "BulletInAllowance",
+                value: undefined,
+            });
+            expect(cached?.tag).toBe("BulletInAllowance");
+        });
+    });
+}

--- a/product-sdk/packages/terminal/src/host.ts
+++ b/product-sdk/packages/terminal/src/host.ts
@@ -19,8 +19,9 @@ import {
     pickOnExistingPolicy,
     readCacheEntry,
     saveCache,
+    withCacheLock,
 } from "./host-cache.js";
-import { createSlotAccountSigner } from "./host-signer.js";
+import { buildSignerFromEntry, createSlotAccountSigner } from "./host-signer.js";
 
 // `terminal` namespace matches adapter.ts / node-storage.ts.
 const log = createLogger("terminal");
@@ -90,31 +91,33 @@ export async function requestResourceAllocation(
     resources: AllocatableResource[],
     options: RequestResourceAllocationOptions = {},
 ): Promise<ApAllocationOutcome[]> {
-    const cache = await loadCache(adapter.appId, adapter.storageDir);
-    const onExisting = options.onExisting ?? pickOnExistingPolicy(cache, resources);
-    log.debug("requestResourceAllocation", {
-        productId: adapter.appId,
-        resources: resources.map((r) => r.tag),
-        onExisting,
-        autoPolicy: options.onExisting === undefined,
+    return withCacheLock(adapter.appId, adapter.storageDir, async () => {
+        const cache = await loadCache(adapter.appId, adapter.storageDir);
+        const onExisting = options.onExisting ?? pickOnExistingPolicy(cache, resources);
+        log.debug("requestResourceAllocation", {
+            productId: adapter.appId,
+            resources: resources.map((r) => r.tag),
+            onExisting,
+            autoPolicy: options.onExisting === undefined,
+        });
+
+        const result = await session.requestResourceAllocation({
+            callingProductId: adapter.appId,
+            resources,
+            onExisting,
+        });
+
+        if (result.isErr()) {
+            throw new Error(`requestResourceAllocation failed: ${result.error.message}`);
+        }
+
+        const next = mergeOutcomes(cache, resources, result.value);
+        if (next !== cache) {
+            await saveCache(adapter.appId, next, adapter.storageDir);
+        }
+
+        return result.value;
     });
-
-    const result = await session.requestResourceAllocation({
-        callingProductId: adapter.appId,
-        resources,
-        onExisting,
-    });
-
-    if (result.isErr()) {
-        throw new Error(`requestResourceAllocation failed: ${result.error.message}`);
-    }
-
-    const next = mergeOutcomes(cache, resources, result.value);
-    if (next !== cache) {
-        await saveCache(adapter.appId, next, adapter.storageDir);
-    }
-
-    return result.value;
 }
 
 /**
@@ -149,33 +152,66 @@ export async function ensureSlotAccountSigner(
     adapter: TerminalAdapter,
     resource: AllocatableResource,
 ): Promise<PolkadotSigner> {
-    // Cache check first; SC / AutoSigning throw here (no signer to build).
-    const cached = await createSlotAccountSigner(adapter, resource);
-    if (cached) return cached;
+    // The cache-hit check and the allocation path must share the same
+    // critical section: otherwise two concurrent calls for the same
+    // resource both see an empty cache, then both serialize through the
+    // lock but each issues its own wallet prompt and burns a slot.
+    return withCacheLock(adapter.appId, adapter.storageDir, async () => {
+        // Single loadCache for the whole critical section — we hold the
+        // lock, so no other writer can change disk under us. The fast
+        // cache-hit path and the slow allocate-then-build path both
+        // reuse this in-memory `cache` reference.
+        const cache = await loadCache(adapter.appId, adapter.storageDir);
+        const hit = readCacheEntry(cache, resource);
+        if (hit) return buildSignerFromEntry(hit);
 
-    log.debug("ensureSlotAccountSigner: cache miss, allocating", { resource: resource.tag });
-    const outcomes = await requestResourceAllocation(session, adapter, [resource]);
-    const outcome = outcomes[0];
-    if (!outcome) {
-        // Defensive: wire response is length-matched, so this is unreachable
-        // unless the wire contract breaks.
-        throw new Error(
-            `ensureSlotAccountSigner: protocol violation — empty outcomes for ${resource.tag}`,
-        );
-    }
-    if (outcome.tag !== "Allocated") {
-        throw new Error(`ensureSlotAccountSigner: allocation ${outcome.tag} for ${resource.tag}`);
-    }
+        log.debug("ensureSlotAccountSigner: cache miss, allocating", { resource: resource.tag });
 
-    const fresh = await createSlotAccountSigner(adapter, resource);
-    if (!fresh) {
-        // Unreachable: requestResourceAllocation just wrote the entry.
-        // Kept as a typed-non-null guard against mergeOutcomes regressions.
-        throw new Error(
-            `ensureSlotAccountSigner: allocation succeeded but cache lookup returned null for ${resource.tag}`,
-        );
-    }
-    return fresh;
+        // Inline the wire → merge → save sequence rather than calling the
+        // public `requestResourceAllocation` wrapper. `withCacheLock` is
+        // non-reentrant, so calling the wrapper from inside would deadlock
+        // on the second lock acquisition.
+        const onExisting = pickOnExistingPolicy(cache, [resource]);
+        const result = await session.requestResourceAllocation({
+            callingProductId: adapter.appId,
+            resources: [resource],
+            onExisting,
+        });
+        if (result.isErr()) {
+            throw new Error(`requestResourceAllocation failed: ${result.error.message}`);
+        }
+        const outcomes = result.value;
+        const next = mergeOutcomes(cache, [resource], outcomes);
+        if (next !== cache) {
+            await saveCache(adapter.appId, next, adapter.storageDir);
+        }
+
+        const outcome = outcomes[0];
+        if (!outcome) {
+            // Unreachable: mergeOutcomes throws on length mismatch first.
+            // Kept as a typed-non-null guard.
+            throw new Error(
+                `ensureSlotAccountSigner: protocol violation — empty outcomes for ${resource.tag}`,
+            );
+        }
+        if (outcome.tag !== "Allocated") {
+            throw new Error(
+                `ensureSlotAccountSigner: allocation ${outcome.tag} for ${resource.tag}`,
+            );
+        }
+
+        // Build the signer from the in-memory post-merge cache — no third
+        // disk read.
+        const freshEntry = readCacheEntry(next, resource);
+        if (!freshEntry) {
+            // Unreachable: the entry was just merged in.
+            // Kept as a typed-non-null guard against mergeOutcomes regressions.
+            throw new Error(
+                `ensureSlotAccountSigner: allocation succeeded but cache lookup returned null for ${resource.tag}`,
+            );
+        }
+        return buildSignerFromEntry(freshEntry);
+    });
 }
 
 if (import.meta.vitest) {
@@ -188,6 +224,7 @@ if (import.meta.vitest) {
     // top-level await is only allowed at module top-level (or inside this
     // top-level vitest block), not inside `describe`.
     const { mnemonicToMiniSecret, DEV_PHRASE } = await import("@polkadot-labs/hdkd-helpers");
+    const { toHex } = await import("@polkadot-api/utils");
 
     let testStorageDir: string;
     beforeEach(() => {
@@ -286,7 +323,7 @@ if (import.meta.vitest) {
             const session = makeSession({
                 requestResourceAllocation: async (req) => {
                     captured.push(req);
-                    return ok([]) as StubReturn;
+                    return ok([{ tag: "Rejected" as const, value: undefined }]) as StubReturn;
                 },
             });
 
@@ -305,7 +342,7 @@ if (import.meta.vitest) {
             const session = makeSession({
                 requestResourceAllocation: async (req) => {
                     captured.push(req);
-                    return ok([]) as StubReturn;
+                    return ok([{ tag: "Rejected" as const, value: undefined }]) as StubReturn;
                 },
             });
 
@@ -505,7 +542,20 @@ if (import.meta.vitest) {
             const session = makeSession({
                 requestResourceAllocation: async (req) => {
                     captured.push(req);
-                    return bulletinAllocated(new Uint8Array([1]));
+                    // Length-match the request: 1 or 2 outcomes as needed.
+                    return ok(
+                        req.resources.map((_r, i) =>
+                            i === 0
+                                ? {
+                                      tag: "Allocated" as const,
+                                      value: {
+                                          tag: "BulletInAllowance" as const,
+                                          value: { slotAccountKey: new Uint8Array([1]) },
+                                      },
+                                  }
+                                : { tag: "Rejected" as const, value: undefined },
+                        ),
+                    ) as StubReturn;
                 },
             });
 
@@ -552,6 +602,58 @@ if (import.meta.vitest) {
             await requestResourceAllocation(session, adapter, req);
 
             expect(captured.map((c) => c.onExisting)).toEqual(["Ignore", "Ignore"]);
+        });
+
+        test("parallel calls for different resources both persist their keys (no last-writer-wins)", async () => {
+            // Regression test for the load → wire → save race: without
+            // serialization, both calls snapshot an empty cache, do their
+            // wire round-trip, then save — the second save clobbers the
+            // first. Both keys must end up in the cache.
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    // Force interleaving: each call yields before responding.
+                    await new Promise((r) => setTimeout(r, 5));
+                    const tag = req.resources[0]?.tag;
+                    return ok([
+                        {
+                            tag: "Allocated" as const,
+                            value:
+                                tag === "BulletInAllowance"
+                                    ? {
+                                          tag: "BulletInAllowance" as const,
+                                          value: { slotAccountKey: new Uint8Array([0xaa]) },
+                                      }
+                                    : {
+                                          tag: "StatementStoreAllowance" as const,
+                                          value: { slotAccountKey: new Uint8Array([0xbb]) },
+                                      },
+                        },
+                    ]) as StubReturn;
+                },
+            });
+            const adapter = fakeAdapter("p");
+
+            await Promise.all([
+                requestResourceAllocation(session, adapter, [
+                    { tag: "BulletInAllowance", value: undefined },
+                ]),
+                requestResourceAllocation(session, adapter, [
+                    { tag: "StatementStoreAllowance", value: undefined },
+                ]),
+            ]);
+
+            expect(
+                await getCachedAllocation(adapter, {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+            ).not.toBeNull();
+            expect(
+                await getCachedAllocation(adapter, {
+                    tag: "StatementStoreAllowance",
+                    value: undefined,
+                }),
+            ).not.toBeNull();
         });
 
         test("two appIds maintain independent caches in the same storageDir", async () => {
@@ -697,7 +799,9 @@ if (import.meta.vitest) {
             ).rejects.toThrow(/allocation Rejected for BulletInAllowance/);
         });
 
-        test("empty outcomes array from the wire surfaces as a protocol-violation throw", async () => {
+        test("empty outcomes array from the wire surfaces as a length-mismatch throw", async () => {
+            // mergeOutcomes enforces the length contract and throws before
+            // the downstream `outcomes[0]` defensive guard is reached.
             const session = makeSession({
                 requestResourceAllocation: async () => ok([]) as StubReturn,
             });
@@ -707,7 +811,7 @@ if (import.meta.vitest) {
                     tag: "BulletInAllowance",
                     value: undefined,
                 }),
-            ).rejects.toThrow(/protocol violation — empty outcomes for BulletInAllowance/);
+            ).rejects.toThrow(/length mismatch — requested 1, got 0/);
         });
 
         test("NotAvailable outcome surfaces as a throw", async () => {
@@ -755,6 +859,44 @@ if (import.meta.vitest) {
                 value: undefined,
             });
             expect(cached?.tag).toBe("BulletInAllowance");
+        });
+
+        test("parallel calls for the SAME resource share one allocation (no double-prompt)", async () => {
+            // Regression: previously the cache-hit check ran outside the
+            // lock, so two concurrent same-resource calls both passed it,
+            // then both hit the wire under the serialized lock — burning
+            // two slots and prompting the wallet twice. Both calls must
+            // resolve from a single allocation.
+            const captured: RequestCapture[] = [];
+            const session = makeSession({
+                requestResourceAllocation: async (req) => {
+                    captured.push(req);
+                    // Force a yield so the second caller has a chance to
+                    // race past the cache check if the lock isn't around it.
+                    await new Promise((r) => setTimeout(r, 5));
+                    return bulletinAllocatedResponse();
+                },
+            });
+            const adapter = fakeAdapter("p");
+
+            const [signerA, signerB] = await Promise.all([
+                ensureSlotAccountSigner(session, adapter, {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+                ensureSlotAccountSigner(session, adapter, {
+                    tag: "BulletInAllowance",
+                    value: undefined,
+                }),
+            ]);
+
+            // Exactly one wire round-trip — the second caller must observe
+            // the freshly-cached key, not start a second allocation.
+            expect(captured).toHaveLength(1);
+            // Both calls return functioning signers backed by the same key.
+            expect(signerA.publicKey).toBeInstanceOf(Uint8Array);
+            expect(signerB.publicKey).toBeInstanceOf(Uint8Array);
+            expect(toHex(signerA.publicKey)).toBe(toHex(signerB.publicKey));
         });
     });
 }

--- a/product-sdk/packages/terminal/src/host.ts
+++ b/product-sdk/packages/terminal/src/host.ts
@@ -192,7 +192,7 @@ if (import.meta.vitest) {
     let testStorageDir: string;
     beforeEach(() => {
         // Per-test temp dir so cache writes don't leak between tests or
-        // touch the real `~/.polkadot-apps/`. The wrapper inherits
+        // touch the real default storage directory. The wrapper inherits
         // `storageDir` from `adapter.storageDir`; we pin it here.
         testStorageDir = mkdtempSync(pathJoin(tmpdir(), "host-test-"));
         return () => rmSync(testStorageDir, { recursive: true, force: true });

--- a/product-sdk/packages/terminal/tsup.config.ts
+++ b/product-sdk/packages/terminal/tsup.config.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-    entry: ["src/index.ts", "src/register.ts", "src/testing.ts"],
+    entry: ["src/index.ts", "src/register.ts", "src/testing.ts", "src/host.ts"],
     format: ["esm"],
     dts: true,
     sourcemap: true,


### PR DESCRIPTION
Closes #88

## Description

Closes the unwrapped [RFC-10](https://github.com/paritytech/truapi/blob/main/docs/rfcs/0010-allowance.md) product-SDK surfaces and implements the Host-side responsibilities RFC-10 §Stakeholders assigns for the terminal-CLI architecture. Related to #82.

| RFC-10 surface or responsibility | Where | Status |
|---|---|---|
| `host_request_resource_allocation` TruAPI | `@parity/product-sdk-host` | #82 |
| `statement_create_proof_authorized` TruAPI | `@parity/product-sdk-host` | done |
| `request_resource_allocation` AP | `@parity/product-sdk-terminal/host` | done |
| `preimage_submit`, `statement_create_proof` (unchanged) | unchanged | unchanged |
| §Stakeholders: implement AP client | `requestResourceAllocation` | done |
| §Stakeholders: cache allowance private keys | per-`appId` JSON, atomic writes, `0o600` | done |
| §Stakeholders: use them to sign on the product's behalf | `createSlotAccountSigner` (local sr25519) | done |
| §"Implicit allocation" for the CLI architecture | `ensureSlotAccountSigner` | done |
| §"Renewal is not a product concern" | AH's job - verified absent | by design |
| §Drawbacks: "No revocation in v1" | deferred per the RFC | by design |

## What Changed

### `@parity/product-sdk-host`: `createProofAuthorized`

Typed wrapper around the new `statement_create_proof_authorized` TruAPI call. Same style as #82.

```ts
import { createProofAuthorized, getStatementStore } from "@parity/product-sdk-host";

const proof = await createProofAuthorized({
    proof: undefined,
    decryptionKey: undefined,
    expiry: undefined,
    channel: undefined,
    topics: [],
    data: payload,
});
const store = await getStatementStore();
await store?.submit({ ...statement, proof });
```

### `@parity/product-sdk-terminal`: new `./host` subpath

For CLIs paired via QR with a mobile wallet. The CLI plays the Host role; this subpath is the Host-runner facet.

```ts
import {
    ensureSlotAccountSigner,
    requestResourceAllocation,
    getCachedAllocation,
    createSlotAccountSigner,
    type AllocatableResource,
    type ApAllocationOutcome,
    type CachedAllocation,
} from "@parity/product-sdk-terminal/host";

// One call: ensure allowance, get a local signer. Prompts the wallet on
// first use; subsequent calls are wire-free.
const signer = await ensureSlotAccountSigner(session, adapter, {
    tag: "BulletInAllowance",
    value: undefined,
});
await bulletinTx.submitAndWatch(signer);
```

- `requestResourceAllocation` - AP wrapper. Auto-picks `onExisting`: `Ignore` unless every requested resource is a slot-table variant (Bulletin/SSS) AND already cached, then `Increase`. Override via `options.onExisting`.
- `getCachedAllocation` - read-only lookup; no wire.
- `createSlotAccountSigner` - local sr25519 `PolkadotSigner` backed by the cached slot key. Handles both 32-byte mini-secret and 64-byte expanded forms; throws on other lengths.
- `ensureSlotAccountSigner` - cache hit → signer; miss → allocate, then signer.
- Cache lives at `{adapter.storageDir}/{appId}_AllowanceKeys.json`, atomic write (temp + rename), `0o600`.
- `TerminalAdapter` exposes `readonly storageDir?: string` so the cache lands next to sessions.
- Terminal package README updated with the `./host` API reference.

### Caveats
- **`AutoSigning` returns `NotAvailable`** on both Android ([#563](https://github.com/paritytech/polkadot-app-android-v2/pull/563)) and iOS ([#759](https://github.com/paritytech/polkadot-app-ios-v2/pull/759)) as of 2026-05. The codec accepts the variant; mobile clients don't yet grant it.
- **Slot renewal at expiry** depends on [individuality#931](https://github.com/paritytech/individuality/pull/931) (open). First-time allocation works end-to-end today.
- **`slotAccountKey` wire encoding** isn't pinned by the RFC or host-papp codec. The signer auto-detects 32-byte (mini-secret → derive) vs 64-byte (expanded → direct sign). Any other length throws; a regression test pins the throw.

### Commits

```
986c27b feat(host): expose createProofAuthorized as typed wrapper
56fa065 feat(terminal): expose storageDir on TerminalAdapter
be4ada0 feat(terminal): add allowance-key cache for the host-runner facet
fb23fba feat(terminal): add createSlotAccountSigner for cached allowance keys
85863e8 feat(terminal): add ./host subpath with requestResourceAllocation + ensureSlotAccountSigner
e994e9e docs(terminal): document the ./host subpath
a6f7082 chore: change docs references
4e95e0d fix(terminal): address review feedback - lock scope, variant alignment, error unwrap, single loadCache
```

## Test plan

- [x] Workspace build clean (`pnpm -r build`)
- [x] Workspace unit tests pass - **794 tests across 67 files**, zero failures
  - `@parity/product-sdk-host`: 19 (was 18 + 1 new `createProofAuthorized` test)
  - `@parity/product-sdk-terminal`: 131 (was 65 at PR start, +56 net)
- [x] Biome clean (`pnpm check` - 208 files)
- [x] `./host` subpath resolves end-to-end via `node t.mjs` after symlinking the package
- [x] Co-located tests via `import.meta.vitest` (matches the existing terminal-package convention; same as `adapter.ts`, `signer.ts`, etc.)
- [x] Pre-existing chain-client-demo / contracts-demo / tx-demo e2e failures confirmed environmental (unreachable `wss://paseo-asset-hub-next-rpc.polkadot.io`)

## Design decisions

- **AP-shaped surface, not TruAPI-shaped**: the CLI is the Host, not a Product, so `Allocated` outcomes correctly carry private key material rather than the stripped form #82 returns for in-container products.
- **Cache as required infrastructure**: per RFC-10 §"How the Host picks OnExistingAllowancePolicy", the `Ignore` vs `Increase` decision is cache-driven. Without persistence the `Increase` branch is unreachable, so the cache ships with the wrapper rather than as a follow-up.
- **`0o600` cache file mode** is defense-in-depth, not RFC-mandated - the RFC's threat model explicitly trusts the Host. Documented as such in code comments.
- **`ensureSlotAccountSigner` substitutes for RFC §"Implicit allocation"** in the CLI architecture: the RFC's stated trigger (`preimage_submit` / `statement_create_proof_authorized` TruAPI calls) doesn't exist in a CLI, so the helper folds the implicit-allocation step into signer construction instead.