### PR TITLE
docs: track pending changesets in pending-changesets/ at repo root

### DIFF
--- a/product-sdk/README.md
+++ b/product-sdk/README.md
@@ -87,6 +87,10 @@ pnpm bench           # measure current sizes locally
 pnpm bench:compare   # compare against a saved snapshot (CI uses this)
 ```
 
+## Releasing
+
+Releases are driven by [changesets](https://github.com/changesets/changesets). See [`RELEASES.md`](./RELEASES.md) for the full workflow — including the `pending-changesets/` staging directory for changesets that aren't yet ready to publish.
+
 ## License
 
 Apache-2.0

--- a/product-sdk/RELEASES.md
+++ b/product-sdk/RELEASES.md
@@ -1,26 +1,170 @@
 # Releases
 
-This project uses [changesets](https://github.com/changesets/changesets) for versioning and publishing.
+This project uses [changesets](https://github.com/changesets/changesets) for
+versioning and publishing. The release workflow at
+[`.github/workflows/product-sdk-release.yml`](../.github/workflows/product-sdk-release.yml)
+runs on every push to `main` and publishes whenever it finds at least one
+changeset file under `.changeset/`.
 
-## Creating a Release
+## TL;DR
 
-1. **Create a changeset** when making changes:
-   ```bash
-   pnpm changeset
-   ```
-   - Select affected packages
-   - Choose bump type: `patch` (fixes), `minor` (features), `major` (breaking)
-   - Write a short description
+1. Author your changeset on a feature branch — park it in
+   [`pending-changesets/`](./pending-changesets/) while the work is
+   in progress.
+2. On the PR that closes the work, move the changeset into `.changeset/`.
+3. Merging that PR to `main` is what triggers the release.
 
-2. **Commit the changeset** with your PR (`.changeset/*.md` file)
+## The two-directory pattern
 
-3. **Merge to main** - the release workflow automatically:
-   - Bumps versions and updates CHANGELOGs
-   - Creates git tags
-   - Publishes to NPM
+| Directory | Tracked by `@changesets/cli`? | Use for |
+|---|---|---|
+| `.changeset/` | **Yes** — every `.md` file (other than `README.md` and dotfiles) is consumed on the next release | Changesets ready to publish on the next merge to `main` |
+| `pending-changesets/` | No — sibling directory, invisible to the CLI | Changesets parked while the underlying PR is still in review or pending dependency work |
+
+Put differently: anything under `.changeset/` will go out on the next
+release. If you authored a changeset on a feature branch but the PR
+is still iterating, parking it under `.changeset/` means an unrelated
+merge could ship your unfinished work. Stage it in
+`pending-changesets/` instead and promote it on the closing PR.
+
+See [`pending-changesets/README.md`](./pending-changesets/README.md)
+for the details — including why we can't nest a subdirectory under
+`.changeset/` (the CLI parses subdirs as legacy v1 changesets).
+
+## Authoring a changeset
+
+```bash
+# From the product-sdk/ directory:
+pnpm changeset
+```
+
+You'll be prompted for:
+
+- **Affected packages** — every workspace package that needs a version
+  bump in this wave. Don't forget cascades: if package A consumes
+  package B via `workspace:*` and B's public API changes, A may need
+  to bump too (changesets-cli handles transitive cascades automatically,
+  but only at the patch level — see "Umbrella policy" below).
+- **Bump type per package**:
+  - `patch` — bug fix; no public-API change.
+  - `minor` — new public API surface; or, under pre-1.0 semver,
+    breaking changes (since major is still `0`). Most of our
+    packages are pre-1.0.
+  - `major` — reserved for post-1.0 breaking changes.
+- **Summary** — one sentence. The body renders into the per-package
+  `CHANGELOG.md`, so write it for your future self trying to remember
+  what changed.
+
+### Naming
+
+`pnpm changeset` generates files like `funny-rabbits-paint.md`. Rename
+to something descriptive in kebab-case before committing — past waves
+used names like:
+
+- `paseo-next-v2-swap.md`
+- `expose-query-failure-value.md`
+- `host-request-resource-allocation.md`
+- `terminal-papi-native-signer.md`
+
+Rename and move to `pending-changesets/` (while in progress) or leave
+in `.changeset/` (when ready to release).
+
+### Umbrella `@parity/product-sdk` policy
+
+When any constituent package gets a **minor** bump in a release wave,
+**list `@parity/product-sdk` (the umbrella) explicitly as a minor in
+the changeset alongside the constituent**.
+
+Without this, `@parity/product-sdk` only cascades at patch level
+(controlled by `updateInternalDependencies: "patch"` in
+`.changeset/config.json`) — and the umbrella ends up at a lower bump
+than the child it re-exports. Prior waves (0.3.0 → 0.4.0, 0.4.0 →
+0.5.0) have followed this policy; keep it consistent.
+
+Example changeset header:
+
+```md
+---
+"@parity/product-sdk": minor
+"@parity/product-sdk-contracts": minor
+---
+```
+
+## Promoting a pending changeset
+
+When the PR that closes the work is ready:
+
+```bash
+git mv pending-changesets/<name>.md .changeset/<name>.md
+```
+
+Commit the move. Merging that PR to `main` triggers the release.
+
+## Previewing what the next release will do
+
+```bash
+pnpm changeset status
+```
+
+Lists every package that will get bumped, at what level, including
+transitive-dependency cascades. Run this before merging anything into
+`.changeset/` so you can sanity-check the wave.
+
+Example output:
+
+```
+Packages to be bumped at patch:
+  - @parity/product-sdk-terminal
+  - @parity/product-sdk-bulletin
+  ...
+
+Packages to be bumped at minor:
+  - @parity/product-sdk
+  - @parity/product-sdk-contracts
+```
+
+## What happens on push to main
+
+The release workflow:
+
+1. Runs `pnpm changeset version` — consumes every `.md` under
+   `.changeset/`, bumps versions in each affected `package.json`,
+   appends entries to each `CHANGELOG.md`, deletes the consumed
+   changeset files.
+2. Commits the version bumps as `chore: version packages`.
+3. Builds every publishable package (`pnpm build`).
+4. Creates per-package git tags (`@parity/product-sdk@0.5.0`, etc.).
+5. Hands off to `paritytech/npm_publish_automation` to publish to npm.
+
+If `.changeset/` is empty (after `README.md` is excluded), nothing
+happens — no version bumps, no tags, no publish.
+
+## Authoring a GitHub release description
+
+The auto-generated changelog text in per-package `CHANGELOG.md` files
+is comprehensive but per-package. For the GitHub release on the
+umbrella version tag, write a consolidated description that:
+
+- Leads with the headline change(s) for the wave.
+- Groups bullet points by package.
+- References PR numbers.
+- Lists all bumped versions in a "Versions in this release" section.
+- Includes a "Migration" section if anything is breaking.
+
+Past release descriptions (linked from each GitHub release) are the
+template — match their structure for consistency.
 
 ## Notes
 
-- No changeset = no release
-- Multiple changesets can accumulate across PRs
-- Highest bump type wins per package (patch < minor < major)
+- **No changeset = no release.** A PR that doesn't change anything
+  user-visible (test fixes, CI tweaks, internal refactors that don't
+  affect the public API) doesn't need a changeset. The release
+  workflow will simply not fire.
+- **Multiple changesets accumulate across PRs.** Each one runs through
+  `pnpm changeset version` together at release time. Don't try to
+  pre-merge or combine them on disk — the tool handles aggregation.
+- **Highest bump type wins per package.** If two changesets both list
+  `@parity/product-sdk-foo` (one `patch`, one `minor`), the resulting
+  bump is `minor`.
+- **Pre-release tags aren't currently used.** Every push to `main` with
+  a changeset publishes a stable version.

--- a/product-sdk/pending-changesets/README.md
+++ b/product-sdk/pending-changesets/README.md
@@ -1,0 +1,118 @@
+# Pending Changesets
+
+A staging area for changesets that document changes which **aren't ready
+to publish yet**. Move them into `.changeset/` only on the PR that
+closes out the work they describe.
+
+## Why this directory exists separately from `.changeset/`
+
+`.github/workflows/product-sdk-release.yml` triggers a release on any
+push to `main` that contains at least one changeset file under
+`.changeset/`. The release pipeline:
+
+1. Runs `pnpm changeset version` (consumes every changeset, bumps every
+   listed package).
+2. Builds, packs, and publishes to npm.
+
+Once a changeset is under `.changeset/` and lands on `main`, the next
+release wave will pick it up. There is no "draft" or "do not release"
+flag on the changeset file format itself — presence inside
+`.changeset/` is the trigger.
+
+That makes `.changeset/` the wrong place to stage work-in-progress
+release notes. If a teammate authors a changeset on a feature branch
+they'll be iterating on for a few days, parking it under
+`.changeset/` means the moment any *unrelated* PR merges to `main`,
+their unfinished work gets published. This directory exists so that
+doesn't happen.
+
+## Why not just nest a subdirectory under `.changeset/`?
+
+`@changesets/cli` reads `.changeset/` with two parallel rules
+([source](../../node_modules/@changesets/read/dist/changesets-read.cjs.js)):
+
+1. **Top-level `.md` files**: anything that doesn't start with `.`,
+   ends in `.md`, and isn't `README.md` (case-insensitive) is parsed
+   as a changeset.
+2. **Subdirectories**: every subdirectory of `.changeset/` is treated
+   as a **legacy v1 changeset** and the tool tries to read
+   `changes.md` / `changes.json` from inside it. Missing those files
+   produces warnings; present-but-malformed produces errors.
+
+There's no safe path under `.changeset/` to park anything except
+non-`.md` files or `README.md`. Hence: a sibling directory.
+
+## Workflow
+
+**Authoring a changeset for in-progress work:**
+
+```bash
+# From the product-sdk/ directory:
+pnpm changeset
+# Answer the prompts; this drops a generated file in `.changeset/`.
+# Then move it here:
+mv .changeset/<generated-name>.md pending-changesets/<descriptive-name>.md
+```
+
+Pick a descriptive name (kebab-case, summarizes the change) — the
+generated names like `funny-rabbits-paint.md` aren't memorable for
+review. Examples that worked well in past waves:
+
+- `paseo-next-v2-swap.md`
+- `expose-query-failure-value.md`
+- `host-request-resource-allocation.md`
+- `terminal-papi-native-signer.md`
+
+**Promoting to release on the closing PR:**
+
+```bash
+mv pending-changesets/<name>.md .changeset/<name>.md
+```
+
+Stage that move in the same PR that closes the underlying work. When
+the PR merges to `main`, the release workflow picks up the changeset
+and publishes the wave.
+
+**Check what the next release will look like:**
+
+```bash
+pnpm changeset status
+```
+
+Lists every package the staged changesets will bump and at what level
+(patch / minor / major), including transitive-dependency cascades.
+
+## Changeset format
+
+Every file is a `.md` with a YAML frontmatter header naming the
+packages and the bump level for each:
+
+```md
+---
+"@parity/product-sdk-foo": minor
+"@parity/product-sdk-bar": patch
+---
+
+**One-sentence summary.**
+
+Body describing what changed, breaking changes (if any), and migration
+notes. Renders as-is into the per-package `CHANGELOG.md` on the next
+release.
+```
+
+### Bump-level conventions used in this repo
+
+- `patch` — bug fix; no public-API change.
+- `minor` — new public API surface; or, under pre-1.0 semver, breaking
+  changes (since major is still `0`). Most of our packages are pre-1.0.
+- `major` — reserved for post-1.0 breaking changes.
+
+### Umbrella `@parity/product-sdk` policy
+
+When any constituent package gets a minor bump in a release wave,
+**list the umbrella `@parity/product-sdk` package explicitly as a
+minor in the changeset** alongside the constituent. Otherwise it
+cascades only at patch level (controlled by `updateInternalDependencies:
+"patch"` in `.changeset/config.json`) and the umbrella ends up at an
+oddly lower bump than its child. Prior waves (0.3.0 → 0.4.0,
+0.4.0 → 0.5.0) followed this policy.


### PR DESCRIPTION
Adds `pending-changesets/` at the product-sdk root for parking changesets that aren't ready to publish on the next merge to `main`. Previously the staging convention lived in `local-docs/pending-changesets/`, which is gitignored — so it was  
  effectively local-only and not shareable with the team.                                                                                                                                                                                           
                                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  - `pending-changesets/README.md` (new) — tracked staging dir + README explaining the directory's purpose, why subdirs of `.changeset/` aren't safe (`@changesets/cli` parses them as legacy v1 changesets), the workflow, and the umbrella        
  `@parity/product-sdk` bump policy.                                                                                                                                                                                                                
  - `RELEASES.md` — rewritten with the full release workflow: authoring, the two-directory pattern, `pnpm changeset status`, and what the release workflow does on each push to main.                                                               
  - `README.md` — adds a "Releasing" section pointing at `RELEASES.md`. 