### PR TITLE
ci(descriptors): daily drift detector for @parity/product-sdk-descriptors

### DIFF
--- a/.github/workflows/product-sdk-descriptors-drift.yml
+++ b/.github/workflows/product-sdk-descriptors-drift.yml
@@ -1,0 +1,229 @@
+# Detects when @parity/product-sdk-descriptors has drifted from the live
+# runtime of any chain it bundles. PAPI's bundled type bindings are a frozen
+# snapshot at regen time, so when a runtime upgrades the bindings can either
+# error with "Incompatible runtime entry" or silently mis-decode a
+# subscription. This job catches drift before E2E does.
+#
+# Mechanism: `papi update --skip-codegen` connects to each chain's RPC,
+# fetches the current metadata + codeHash, and rewrites
+# `.papi/polkadot-api.json` in place. A diff on `codeHash` (and `genesis`)
+# vs. what's checked in is the drift signal.
+name: "product-sdk: Descriptors drift"
+
+on:
+    schedule:
+        - cron: "0 8 * * *"
+    workflow_dispatch:
+
+concurrency:
+    group: descriptors-drift
+    cancel-in-progress: false
+
+defaults:
+    run:
+        working-directory: product-sdk
+
+permissions:
+    contents: read
+    issues: write
+
+jobs:
+    check:
+        name: "Check descriptor drift"
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+                  cache: "pnpm"
+                  cache-dependency-path: product-sdk/pnpm-lock.yaml
+
+            - run: pnpm install --frozen-lockfile
+
+            # For each chain dir under packages/descriptors/chains/, drop the
+            # cached .scale so `papi update` is forced to hit the network,
+            # then diff the rewritten polkadot-api.json against HEAD.
+            #
+            # Per-chain failures are isolated — a 60s wallclock timeout per
+            # chain means a flaky RPC doesn't poison the whole report.
+            #
+            # Output: drift-report.json with one entry per chain:
+            #   { chain, key, pinnedCodeHash, liveCodeHash, pinnedGenesis,
+            #     liveGenesis, status: "clean" | "drift" | "unreachable" }
+            - name: Probe every chain
+              id: probe
+              run: |
+                  set -euo pipefail
+                  cd packages/descriptors
+                  : > drift-report.jsonl
+                  for chain_dir in chains/*/; do
+                    chain=$(basename "$chain_dir")
+                    cfg="$chain_dir.papi/polkadot-api.json"
+                    key=$(jq -r '.entries | keys[0]' "$cfg")
+                    pinned_code=$(jq -r ".entries.\"$key\".codeHash" "$cfg")
+                    pinned_gen=$(jq -r ".entries.\"$key\".genesis" "$cfg")
+
+                    echo "::group::probe $chain (key=$key)"
+                    rm -f "$chain_dir.papi/metadata/"*.scale
+
+                    status="clean"
+                    live_code=""
+                    live_gen=""
+                    if timeout 60 npx papi update "$key" --config "$cfg" --skip-codegen; then
+                      live_code=$(jq -r ".entries.\"$key\".codeHash" "$cfg")
+                      live_gen=$(jq -r ".entries.\"$key\".genesis" "$cfg")
+                      if [[ "$pinned_code" != "$live_code" || "$pinned_gen" != "$live_gen" ]]; then
+                        status="drift"
+                      fi
+                    else
+                      status="unreachable"
+                    fi
+                    echo "::endgroup::"
+
+                    jq -n \
+                      --arg chain "$chain" --arg key "$key" \
+                      --arg pinnedCode "$pinned_code" --arg liveCode "$live_code" \
+                      --arg pinnedGen "$pinned_gen" --arg liveGen "$live_gen" \
+                      --arg status "$status" \
+                      '{chain:$chain, key:$key, pinnedCodeHash:$pinnedCode, liveCodeHash:$liveCode, pinnedGenesis:$pinnedGen, liveGenesis:$liveGen, status:$status}' \
+                      >> drift-report.jsonl
+                  done
+
+                  # Restore the working tree so the diff doesn't leak into
+                  # any subsequent step that reads chain configs.
+                  git checkout -- packages/descriptors/chains/ >/dev/null 2>&1 || true
+
+                  drift_count=$(jq -s '[.[] | select(.status=="drift")] | length' drift-report.jsonl)
+                  unreachable_count=$(jq -s '[.[] | select(.status=="unreachable")] | length' drift-report.jsonl)
+                  total=$(wc -l < drift-report.jsonl | tr -d ' ')
+                  echo "drift_count=$drift_count" >> "$GITHUB_OUTPUT"
+                  echo "unreachable_count=$unreachable_count" >> "$GITHUB_OUTPUT"
+                  echo "total=$total" >> "$GITHUB_OUTPUT"
+
+            # Single bad-network day shouldn't flap the tracking issue.
+            # If literally nothing was reachable, emit a warning and skip
+            # body-build / upsert / close — all of which are gated on this
+            # same condition.
+            - name: Warn on full-outage runs
+              if: steps.probe.outputs.unreachable_count == steps.probe.outputs.total
+              run: echo "::warning::all ${{ steps.probe.outputs.total }} chains unreachable — skipping issue update"
+
+            # Body is written to a file (not GITHUB_OUTPUT) so the backticks
+            # and ${{ }} substitutions don't get re-evaluated by the shell
+            # when passed to `gh issue ... --body`.
+            - name: Build issue body
+              if: steps.probe.outputs.unreachable_count != steps.probe.outputs.total
+              env:
+                  DRIFT_COUNT: ${{ steps.probe.outputs.drift_count }}
+                  UNREACHABLE_COUNT: ${{ steps.probe.outputs.unreachable_count }}
+                  TOTAL: ${{ steps.probe.outputs.total }}
+              run: |
+                  set -euo pipefail
+                  cd packages/descriptors
+                  clean=$((TOTAL - DRIFT_COUNT - UNREACHABLE_COUNT))
+                  {
+                    echo "_Auto-generated by [\`product-sdk-descriptors-drift.yml\`](../actions/workflows/product-sdk-descriptors-drift.yml). Last run: $(date -u +'%Y-%m-%d %H:%M UTC')._"
+                    echo
+                    echo "**Summary:** ${DRIFT_COUNT} drifting / ${UNREACHABLE_COUNT} unreachable / ${clean} clean (of ${TOTAL} chains)."
+                    echo
+                    echo "| Chain | Status | Pinned codeHash | Live codeHash |"
+                    echo "|---|---|---|---|"
+                    jq -r '
+                      def short: if . == "" then "n/a" else .[0:14] + "..." end;
+                      [.chain, .status, (.pinnedCodeHash | short), (.liveCodeHash | short)]
+                      | "| " + join(" | ") + " |"
+                    ' drift-report.jsonl
+                    echo
+                    echo "<details><summary>Full genesis + codeHash values</summary>"
+                    echo
+                    echo '```json'
+                    jq -s '.' drift-report.jsonl
+                    echo '```'
+                    echo
+                    echo "</details>"
+                    echo
+                    echo "## How to resolve"
+                    echo
+                    echo "When a chain drifts, the bundled PAPI descriptors are stale against the live runtime. Regenerate and republish:"
+                    echo
+                    echo '1. `cd product-sdk/packages/descriptors`'
+                    echo '2. `pnpm generate` — fetches fresh metadata from every chain RPC and rewrites `chains/*/.papi/polkadot-api.json` + the `.scale` metadata blobs.'
+                    echo '3. `pnpm build` — regenerates the TypeScript bindings under `chains/*/generated/dist/`.'
+                    echo '4. Verify nothing else changed unexpectedly: `git diff packages/descriptors/`.'
+                    echo '5. Add a changeset: `pnpm changeset` → `@parity/product-sdk-descriptors: patch` (or `minor` if a chain runtime added new pallets / breaking decode shape).'
+                    echo "6. Open a PR. Run \`pnpm test:e2e\` against the regenerated bindings before merging — drift sometimes hides a real consumer-side break (e.g. a pallet rename)."
+                    echo
+                    echo "## Why this issue stays open"
+                    echo
+                    echo "This is a single tracking issue keyed on the \`descriptors-drift\` label. The workflow runs daily and:"
+                    echo
+                    echo "- **updates this issue** while any chain is still drifting,"
+                    echo "- **closes it** automatically when every chain is clean."
+                    echo
+                    echo "Manually closing the issue while drift persists will cause the next scheduled run to re-open it."
+                  } > drift-issue-body.md
+
+            - name: Ensure descriptors-drift label exists
+              if: steps.probe.outputs.unreachable_count != steps.probe.outputs.total
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh label create descriptors-drift \
+                    --description "Tracks PAPI descriptor drift detected by product-sdk-descriptors-drift.yml" \
+                    --color FBCA04 \
+                    --force
+
+            # Upsert: find an open issue with the label; edit if found,
+            # otherwise create. Either action keeps the title stable so
+            # notifications don't churn.
+            - name: Upsert tracking issue
+              if: (steps.probe.outputs.drift_count != '0' || steps.probe.outputs.unreachable_count != '0') && steps.probe.outputs.unreachable_count != steps.probe.outputs.total
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  title="chore(descriptors): runtime drift detected"
+                  existing=$(gh issue list \
+                    --state open \
+                    --label descriptors-drift \
+                    --json number \
+                    --jq '.[0].number // empty')
+                  body_file=packages/descriptors/drift-issue-body.md
+                  if [[ -n "$existing" ]]; then
+                    echo "Editing #$existing"
+                    gh issue edit "$existing" \
+                      --title "$title" \
+                      --body-file "$body_file"
+                  else
+                    echo "Creating new tracking issue"
+                    gh issue create \
+                      --title "$title" \
+                      --label descriptors-drift \
+                      --body-file "$body_file"
+                  fi
+
+            # All chains clean — close any open tracking issue with a comment.
+            - name: Close tracking issue on clean run
+              if: steps.probe.outputs.drift_count == '0' && steps.probe.outputs.unreachable_count == '0'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  existing=$(gh issue list \
+                    --state open \
+                    --label descriptors-drift \
+                    --json number \
+                    --jq '.[0].number // empty')
+                  if [[ -n "$existing" ]]; then
+                    gh issue close "$existing" \
+                      --comment "All chains clean as of $(date -u +'%Y-%m-%d %H:%M UTC'). Closing — the workflow will reopen this if drift returns."
+                  else
+                    echo "No open drift issue — nothing to close."
+                  fi

--- a/product-sdk/packages/descriptors/README.md
+++ b/product-sdk/packages/descriptors/README.md
@@ -83,3 +83,22 @@ pnpm build
    ```
 
 5. Run `pnpm generate` to fetch metadata and generate descriptors
+
+## Detecting Drift
+
+PAPI's bundled type bindings are a frozen snapshot at the moment `pnpm generate` last ran. When a chain runtime upgrades, the bundled descriptors go stale — PAPI then either errors with `Incompatible runtime entry RuntimeCall(...)` or silently mis-decodes a subscription so it never emits an event.
+
+The [`product-sdk: Descriptors drift`](../../../.github/workflows/product-sdk-descriptors-drift.yml) workflow catches this before E2E does. It runs daily, connects to each chain's RPC via `papi update --skip-codegen`, and compares the live `codeHash` and `genesis` against what's pinned in `chains/*/.papi/polkadot-api.json`.
+
+On drift it opens (or updates in place) a single tracking issue labeled `descriptors-drift`. On a fully-clean run it closes the issue.
+
+### What to do when the auto-issue fires
+
+1. `cd packages/descriptors`
+2. `pnpm generate` — fetches fresh metadata from every chain RPC and rewrites `chains/*/.papi/polkadot-api.json` + the `.scale` metadata blobs
+3. `pnpm build` — regenerates the TypeScript bindings under `chains/*/generated/dist/`
+4. `git diff packages/descriptors/` — verify nothing else changed unexpectedly
+5. `pnpm changeset` — add a `@parity/product-sdk-descriptors: patch` entry (or `minor` if the runtime added new pallets or changed decode shape)
+6. Open a PR. Run `pnpm test:e2e` against the regenerated bindings before merging — drift sometimes hides a real consumer-side break (e.g. a pallet rename)
+
+The workflow will close the tracking issue automatically on the next scheduled run once every chain is clean.


### PR DESCRIPTION
closes: https://github.com/paritytech/product-sdk/issues/98

## Summary                                                                                                                                                                                                                                        
   
  Adds a daily scheduled GitHub Action that detects when bundled PAPI descriptors have drifted from the live runtime of any chain `@parity/product-sdk-descriptors` ships bindings for. Today we discover this through E2E failures — late, noisy, and after time has been spent on misdiagnosis. This is the cheap, early signal we asked for.

  ## What changed                                                                                                                                                                                                                                   
                                          
  - **`.github/workflows/product-sdk-descriptors-drift.yml`** — new daily workflow (`0 8 * * *` UTC + `workflow_dispatch`). For each chain under `packages/descriptors/chains/*/`:                                                                  
    - drops the cached `.scale` metadata blob,                                                                                                                                                                                                      
    - runs `npx papi update <key> --config .papi/polkadot-api.json --skip-codegen` with a 60s per-chain timeout,
    - extracts the live `codeHash` and `genesis` and compares against what's pinned,                                                                                                                                                                
    - restores the working tree so subsequent steps see a clean checkout.
                                                                                                                                                                                                                                                    
    Every chain is probed independently — no inference from shared-runtime assumptions. A flaky RPC for one chain doesn't poison the report for the others.                                                                                         
                                                                                                                                                                                                                                                    
  - **Tracking issue, deduplicated by label.** On drift (or partial unreachability), the workflow upserts a single open issue labeled `descriptors-drift` with title `chore(descriptors): runtime drift detected`. The body has a per-chain status  
  table, a collapsed JSON detail block, and step-by-step regen-and-PR instructions. On a fully-clean run the issue is auto-closed.                                                                                                                  
                                                                                                                                                                                                                                                    
  - **Failure-mode handling.** Full network outage (all chains unreachable) emits a `::warning::` and skips the issue update so a single bad-network day doesn't flap. Partial unreachability is reported in the issue alongside drift — a chain    
  unreachable for a week deserves visibility.               
                                                                                                                                                                                                                                                    
  - **`packages/descriptors/README.md`** — new "Detecting Drift" section explaining the mechanism and the regen-and-PR steps.                                                                                                                       
                                        