### PR TITLE
feat(keys, identity): sr25519 product-account derivation + identity rename

### DIFF
--- a/product-sdk/README.md
+++ b/product-sdk/README.md
@@ -13,7 +13,7 @@ TypeScript SDK for building products in the Polkadot ecosystem. Provides typed A
 | `@parity/product-sdk-contracts` | Typed contract interactions on Polkadot Asset Hub |
 | `@parity/product-sdk-bulletin` | Upload and retrieve data on the Polkadot Bulletin Chain |
 | `@parity/product-sdk-statement-store` | Publish/subscribe client for the Polkadot Statement Store |
-| `@parity/product-sdk-keys` | Hierarchical key derivation and session key management |
+| `@parity/product-sdk-keys` | Hierarchical key derivation, session keys, and sr25519 product-account derivation |
 | `@parity/product-sdk-storage` | Key-value storage with automatic host/browser backend detection |
 | `@parity/product-sdk-host` | Host container detection and storage access for Desktop/Mobile |
 | `@parity/product-sdk-address` | SS58/H160 address encoding, validation, and conversion |

--- a/product-sdk/packages/address/package.json
+++ b/product-sdk/packages/address/package.json
@@ -20,7 +20,7 @@
         "clean": "rm -rf dist"
     },
     "dependencies": {
-        "@noble/hashes": "^1.7.1",
+        "@noble/hashes": "^2.2.0",
         "@polkadot-api/substrate-bindings": "^0.12.0"
     },
     "devDependencies": {

--- a/product-sdk/packages/address/src/h160.ts
+++ b/product-sdk/packages/address/src/h160.ts
@@ -1,5 +1,5 @@
 import { AccountId, type SS58String } from "@polkadot-api/substrate-bindings";
-import { keccak_256 } from "@noble/hashes/sha3";
+import { keccak_256 } from "@noble/hashes/sha3.js";
 
 const EVM_DERIVED_MARKER = 0xee;
 const H160_BYTE_LEN = 20;

--- a/product-sdk/packages/crypto/package.json
+++ b/product-sdk/packages/crypto/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@noble/ciphers": "^1.2.1",
         "@noble/curves": "^1.8.0",
-        "@noble/hashes": "^1.7.1",
+        "@noble/hashes": "^2.2.0",
         "tweetnacl": "^1.0.3"
     },
     "devDependencies": {

--- a/product-sdk/packages/keys/package.json
+++ b/product-sdk/packages/keys/package.json
@@ -20,7 +20,6 @@
         "clean": "rm -rf dist"
     },
     "dependencies": {
-        "@noble/hashes": "^2.2.0",
         "@parity/product-sdk-address": "workspace:*",
         "@parity/product-sdk-crypto": "workspace:*",
         "@parity/product-sdk-storage": "workspace:*",

--- a/product-sdk/packages/keys/package.json
+++ b/product-sdk/packages/keys/package.json
@@ -20,12 +20,15 @@
         "clean": "rm -rf dist"
     },
     "dependencies": {
+        "@noble/hashes": "^2.2.0",
         "@parity/product-sdk-address": "workspace:*",
         "@parity/product-sdk-crypto": "workspace:*",
         "@parity/product-sdk-storage": "workspace:*",
         "@polkadot-labs/hdkd": "^0.0.28",
         "@polkadot-labs/hdkd-helpers": "^0.0.10",
-        "polkadot-api": "catalog:"
+        "@scure/sr25519": "^2.2.0",
+        "polkadot-api": "catalog:",
+        "scale-ts": "^1.6.1"
     },
     "devDependencies": {
         "typescript": "^5.7.0",

--- a/product-sdk/packages/keys/scripts/regenerate-fixtures.ts
+++ b/product-sdk/packages/keys/scripts/regenerate-fixtures.ts
@@ -1,0 +1,46 @@
+/**
+ * Maintenance tool: print the four hex vectors that lock
+ * deriveProductAccountPublicKey to its canonical output.
+ *
+ * Run if polkadot-desktop's productAccountService changes its derivation
+ * algorithm and we need to re-confirm parity:
+ *
+ *   npx tsx packages/keys/scripts/regenerate-fixtures.ts
+ *
+ * Then paste the printed hex values into
+ * packages/keys/src/product-account.test.ts and verify the test still
+ * passes against the new vectors. If parity has broken, surface that in
+ * a follow-up issue before committing.
+ *
+ * Parent public keys are derived from deterministic 32-byte seeds via
+ * @scure/sr25519's `secretFromSeed` + `getPublicKey`. Arbitrary 32-byte
+ * buffers do not work as parent keys: HDKD.publicSoft validates the
+ * Ristretto255 encoding at the entry point and rejects non-curve points.
+ *
+ * This script is NOT run in CI.
+ */
+
+import { getPublicKey, secretFromSeed } from "@scure/sr25519";
+import { deriveProductAccountPublicKey } from "../src/product-account.js";
+
+function toHex(bytes: Uint8Array): string {
+    return "0x" + Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function pubKeyFromSeedByte(byte: number): Uint8Array {
+    const seed = new Uint8Array(32).fill(byte);
+    return getPublicKey(secretFromSeed(seed));
+}
+
+const cases = [
+    { seedByte: 0, productId: "playground.dot", index: 0, label: "playground.dot/0, parent pubkey from seed byte 0x00" },
+    { seedByte: 1, productId: "playground.dot", index: 1, label: "playground.dot/1, parent pubkey from seed byte 0x01" },
+    { seedByte: 2, productId: "a-very-long-product.dot", index: 0, label: "a-very-long-product.dot/0, parent pubkey from seed byte 0x02" },
+    { seedByte: 3, productId: "this-name-is-deliberately-long-enough-to-trip-the-fallback.dot", index: 0, label: "long-fallback-name/0, parent pubkey from seed byte 0x03" },
+];
+
+for (const c of cases) {
+    const parent = pubKeyFromSeedByte(c.seedByte);
+    const out = deriveProductAccountPublicKey(parent, c.productId, c.index);
+    console.log(`${c.label}\n  productId: ${c.productId}\n  index:     ${c.index}\n  seedByte:  0x${c.seedByte.toString(16).padStart(2, "0")}\n  expected:  ${toHex(out)}\n`);
+}

--- a/product-sdk/packages/keys/scripts/regenerate-fixtures.ts
+++ b/product-sdk/packages/keys/scripts/regenerate-fixtures.ts
@@ -24,7 +24,9 @@ import { getPublicKey, secretFromSeed } from "@scure/sr25519";
 import { deriveProductAccountPublicKey } from "../src/product-account.js";
 
 function toHex(bytes: Uint8Array): string {
-    return "0x" + Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+    return `0x${Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("")}`;
 }
 
 function pubKeyFromSeedByte(byte: number): Uint8Array {
@@ -33,14 +35,36 @@ function pubKeyFromSeedByte(byte: number): Uint8Array {
 }
 
 const cases = [
-    { seedByte: 0, productId: "playground.dot", index: 0, label: "playground.dot/0, parent pubkey from seed byte 0x00" },
-    { seedByte: 1, productId: "playground.dot", index: 1, label: "playground.dot/1, parent pubkey from seed byte 0x01" },
-    { seedByte: 2, productId: "a-very-long-product.dot", index: 0, label: "a-very-long-product.dot/0, parent pubkey from seed byte 0x02" },
-    { seedByte: 3, productId: "this-name-is-deliberately-long-enough-to-trip-the-fallback.dot", index: 0, label: "long-fallback-name/0, parent pubkey from seed byte 0x03" },
+    {
+        seedByte: 0,
+        productId: "playground.dot",
+        index: 0,
+        label: "playground.dot/0, parent pubkey from seed byte 0x00",
+    },
+    {
+        seedByte: 1,
+        productId: "playground.dot",
+        index: 1,
+        label: "playground.dot/1, parent pubkey from seed byte 0x01",
+    },
+    {
+        seedByte: 2,
+        productId: "a-very-long-product.dot",
+        index: 0,
+        label: "a-very-long-product.dot/0, parent pubkey from seed byte 0x02",
+    },
+    {
+        seedByte: 3,
+        productId: "this-name-is-deliberately-long-enough-to-trip-the-fallback.dot",
+        index: 0,
+        label: "long-fallback-name/0, parent pubkey from seed byte 0x03",
+    },
 ];
 
 for (const c of cases) {
     const parent = pubKeyFromSeedByte(c.seedByte);
     const out = deriveProductAccountPublicKey(parent, c.productId, c.index);
-    console.log(`${c.label}\n  productId: ${c.productId}\n  index:     ${c.index}\n  seedByte:  0x${c.seedByte.toString(16).padStart(2, "0")}\n  expected:  ${toHex(out)}\n`);
+    console.log(
+        `${c.label}\n  productId: ${c.productId}\n  index:     ${c.index}\n  seedByte:  0x${c.seedByte.toString(16).padStart(2, "0")}\n  expected:  ${toHex(out)}\n`,
+    );
 }

--- a/product-sdk/packages/keys/src/index.ts
+++ b/product-sdk/packages/keys/src/index.ts
@@ -14,4 +14,5 @@
 export { KeyManager } from "./key-manager.js";
 export { SessionKeyManager } from "./session-key-manager.js";
 export { seedToAccount } from "./seed-to-account.js";
+export { createChainCode, deriveProductAccountPublicKey } from "./product-account.js";
 export type { DerivedAccount, DerivedKeypairs, SessionKeyInfo } from "./types.js";

--- a/product-sdk/packages/keys/src/product-account.test.ts
+++ b/product-sdk/packages/keys/src/product-account.test.ts
@@ -1,5 +1,6 @@
+import { getPublicKey, secretFromSeed } from "@scure/sr25519";
 import { describe, expect, it } from "vitest";
-import { createChainCode } from "./product-account.js";
+import { createChainCode, deriveProductAccountPublicKey } from "./product-account.js";
 
 describe("createChainCode", () => {
     it("encodes the numeric junction '0' as 32 zero bytes (u64 LE, zero-padded)", () => {
@@ -41,10 +42,71 @@ describe("createChainCode", () => {
         const longCode = "a".repeat(100);
         const result = createChainCode(longCode);
         expect(result.length).toBe(32);
-        const hex = "0x" + Array.from(result).map((b) => b.toString(16).padStart(2, "0")).join("");
+        const hex =
+            "0x" +
+            Array.from(result)
+                .map((b) => b.toString(16).padStart(2, "0"))
+                .join("");
         // Compute this once locally and paste below. To regenerate after a deliberate
         // algorithm change, run the assertion, copy the actual hex from the failure
         // diff, and update.
         expect(hex).toBe("0x0cc6ae1565611349f15a291549fc38c30273d4bf600eec3ec6dfffff6d5bb8d8");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers shared by the frozen-vector block below
+// ---------------------------------------------------------------------------
+
+function pubKeyFromSeedByte(byte: number): Uint8Array {
+    const seed = new Uint8Array(32).fill(byte);
+    const secretKey = secretFromSeed(seed);
+    return getPublicKey(secretKey);
+}
+
+function toHex(bytes: Uint8Array): string {
+    return (
+        "0x" +
+        Array.from(bytes)
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("")
+    );
+}
+
+describe("deriveProductAccountPublicKey (frozen vectors)", () => {
+    it("playground.dot / index 0, parent pubkey from seed byte 0x00", () => {
+        const root = pubKeyFromSeedByte(0);
+        const result = deriveProductAccountPublicKey(root, "playground.dot", 0);
+        expect(toHex(result)).toBe(
+            "0xc2beceb2dd5d6011d03647374c6f21fbab1132d2b7bc872de4edf249952fb525",
+        );
+    });
+
+    it("playground.dot / index 1, parent pubkey from seed byte 0x01 (non-zero u64 branch)", () => {
+        const root = pubKeyFromSeedByte(1);
+        const result = deriveProductAccountPublicKey(root, "playground.dot", 1);
+        expect(toHex(result)).toBe(
+            "0x886a3a296d26b4971e066631f5a1dbb7ad7db61468e1bd9429353ff93afac622",
+        );
+    });
+
+    it("near-boundary productId, parent pubkey from seed byte 0x02 (no blake2b fallback)", () => {
+        const root = pubKeyFromSeedByte(2);
+        const result = deriveProductAccountPublicKey(root, "a-very-long-product.dot", 0);
+        expect(toHex(result)).toBe(
+            "0xa04c8edbb5c77fd8bd934a1d0c60b7d9d2eeed870ac7d35a94a10a91451d8f04",
+        );
+    });
+
+    it("long productId triggers blake2b fallback for the second junction, parent from seed byte 0x03", () => {
+        const root = pubKeyFromSeedByte(3);
+        const result = deriveProductAccountPublicKey(
+            root,
+            "this-name-is-deliberately-long-enough-to-trip-the-fallback.dot",
+            0,
+        );
+        expect(toHex(result)).toBe(
+            "0x5cbabd54efcc45d1d4c1dc8b87b02ffd2ba5e70584ac005e7bd3484810054605",
+        );
     });
 });

--- a/product-sdk/packages/keys/src/product-account.test.ts
+++ b/product-sdk/packages/keys/src/product-account.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { createChainCode } from "./product-account.js";
+
+describe("createChainCode", () => {
+    it("encodes the numeric junction '0' as 32 zero bytes (u64 LE, zero-padded)", () => {
+        const result = createChainCode("0");
+        expect(result).toBeInstanceOf(Uint8Array);
+        expect(result.length).toBe(32);
+        expect(Array.from(result)).toEqual(new Array(32).fill(0));
+    });
+
+    it("encodes the numeric junction '1' as [1, 0×31] (u64 LE, zero-padded)", () => {
+        const result = createChainCode("1");
+        const expected = new Uint8Array(32);
+        expected[0] = 1;
+        expect(Array.from(result)).toEqual(Array.from(expected));
+    });
+
+    it("encodes a string junction 'product' as SCALE str + zero-padded to 32 bytes", () => {
+        const result = createChainCode("product");
+        expect(result.length).toBe(32);
+        expect(result[0]).toBe(0x1c); // compact-length: 7 << 2
+        expect(new TextDecoder().decode(result.slice(1, 8))).toBe("product");
+        expect(Array.from(result.slice(8))).toEqual(new Array(24).fill(0));
+    });
+
+    it("encodes a string junction near the 32-byte boundary without falling back to blake2b", () => {
+        const code = "a".repeat(30);
+        const result = createChainCode(code);
+        expect(result.length).toBe(32);
+        expect(result[0]).toBe(30 << 2);
+        expect(new TextDecoder().decode(result.slice(1, 31))).toBe(code);
+        expect(result[31]).toBe(0);
+    });
+
+    it("hashes a string junction whose SCALE encoding exceeds 32 bytes via blake2b", () => {
+        const longCode = "a".repeat(100);
+        const result = createChainCode(longCode);
+        expect(result.length).toBe(32);
+        const repeat = createChainCode(longCode);
+        expect(Array.from(result)).toEqual(Array.from(repeat));
+    });
+});

--- a/product-sdk/packages/keys/src/product-account.test.ts
+++ b/product-sdk/packages/keys/src/product-account.test.ts
@@ -33,11 +33,18 @@ describe("createChainCode", () => {
         expect(result[31]).toBe(0);
     });
 
-    it("hashes a string junction whose SCALE encoding exceeds 32 bytes via blake2b", () => {
+    it("hashes a string junction whose SCALE encoding exceeds 32 bytes via blake2b256", () => {
+        // The encoded form of "a".repeat(100) is compact-length(100) + 100 utf8 bytes
+        // = 2 + 100 = 102 bytes, which exceeds the 32-byte slot and triggers the
+        // blake2b fallback. The expected hex value below is the blake2b-256 hash
+        // of the SCALE-encoded bytes; locking it pins us to a specific hash function.
         const longCode = "a".repeat(100);
         const result = createChainCode(longCode);
         expect(result.length).toBe(32);
-        const repeat = createChainCode(longCode);
-        expect(Array.from(result)).toEqual(Array.from(repeat));
+        const hex = "0x" + Array.from(result).map((b) => b.toString(16).padStart(2, "0")).join("");
+        // Compute this once locally and paste below. To regenerate after a deliberate
+        // algorithm change, run the assertion, copy the actual hex from the failure
+        // diff, and update.
+        expect(hex).toBe("0x0cc6ae1565611349f15a291549fc38c30273d4bf600eec3ec6dfffff6d5bb8d8");
     });
 });

--- a/product-sdk/packages/keys/src/product-account.test.ts
+++ b/product-sdk/packages/keys/src/product-account.test.ts
@@ -42,11 +42,9 @@ describe("createChainCode", () => {
         const longCode = "a".repeat(100);
         const result = createChainCode(longCode);
         expect(result.length).toBe(32);
-        const hex =
-            "0x" +
-            Array.from(result)
-                .map((b) => b.toString(16).padStart(2, "0"))
-                .join("");
+        const hex = `0x${Array.from(result)
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("")}`;
         // Compute this once locally and paste below. To regenerate after a deliberate
         // algorithm change, run the assertion, copy the actual hex from the failure
         // diff, and update.
@@ -65,12 +63,9 @@ function pubKeyFromSeedByte(byte: number): Uint8Array {
 }
 
 function toHex(bytes: Uint8Array): string {
-    return (
-        "0x" +
-        Array.from(bytes)
-            .map((b) => b.toString(16).padStart(2, "0"))
-            .join("")
-    );
+    return `0x${Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("")}`;
 }
 
 describe("deriveProductAccountPublicKey (frozen vectors)", () => {

--- a/product-sdk/packages/keys/src/product-account.ts
+++ b/product-sdk/packages/keys/src/product-account.ts
@@ -1,0 +1,52 @@
+/**
+ * Canonical sr25519 product-account public-key derivation.
+ *
+ * Mirrored byte-for-byte by polkadot-desktop
+ * (`polkadot-desktop/src/domains/product/account/service.ts`) and conceptually
+ * by polkadot-app-android-v2
+ * (`feature/products/impl/.../ProductAccountDerivationUseCase.kt`).
+ *
+ * The function works on the parent *public* key alone: sr25519 soft derivation
+ * is composable on public keys, so the CLI / web host / any external client can
+ * compute the same derived address that the mobile wallet derives privately,
+ * without ever seeing the secret key.
+ *
+ * Junction path: ["product", productId, String(derivationIndex)], applied
+ * left-to-right. For each junction, a 32-byte chain code is built:
+ *   - numeric ("^\d+$") -> SCALE u64 (BigInt), zero-padded to 32 bytes
+ *   - string             -> SCALE str (compact-length + UTF-8), zero-padded
+ *   - if encoded > 32 bytes -> blake2b(encoded, dkLen=32)
+ */
+
+import { blake2b } from "@noble/hashes/blake2.js";
+import { HDKD } from "@scure/sr25519";
+import { str, u64 } from "scale-ts";
+
+const JUNCTION_ID_LEN = 32;
+const NON_NEGATIVE_INTEGER = /^\d+$/;
+
+export function createChainCode(code: string): Uint8Array {
+    const encoded = NON_NEGATIVE_INTEGER.test(code)
+        ? u64.enc(BigInt(code))
+        : str.enc(code);
+
+    if (encoded.length > JUNCTION_ID_LEN) {
+        return blake2b(encoded, { dkLen: JUNCTION_ID_LEN });
+    }
+
+    const chainCode = new Uint8Array(JUNCTION_ID_LEN);
+    chainCode.set(encoded);
+    return chainCode;
+}
+
+export function deriveProductAccountPublicKey(
+    parentPublicKey: Uint8Array,
+    productId: string,
+    derivationIndex: number,
+): Uint8Array {
+    const junctions = ["product", productId, String(derivationIndex)];
+    return junctions.reduce<Uint8Array>(
+        (pubkey, junction) => HDKD.publicSoft(pubkey, createChainCode(junction)),
+        parentPublicKey,
+    );
+}

--- a/product-sdk/packages/keys/src/product-account.ts
+++ b/product-sdk/packages/keys/src/product-account.ts
@@ -16,6 +16,18 @@
  *   - numeric ("^\d+$") -> SCALE u64 (BigInt), zero-padded to 32 bytes
  *   - string             -> SCALE str (compact-length + UTF-8), zero-padded
  *   - if encoded > 32 bytes -> blake2b256(encoded) (32-byte BLAKE2b digest)
+ *
+ * # productId constraint (cross-platform parity)
+ *
+ * `productId` MUST contain at least one non-hex character or be of odd
+ * length when serialized as a string. polkadot-app-android-v2's
+ * SubstrateJunctionDecoder tries to interpret a junction as hex BEFORE
+ * falling through to SCALE-string encoding; polkadot-desktop and this
+ * implementation skip that hex branch. For productIds that happen to be
+ * even-length all-hex strings (e.g. "deadbeef", "c0ffee01"), Android would
+ * derive a different public key than desktop or this implementation. In
+ * practice, productIds are always dotNS names (e.g. "playground.dot"),
+ * which contain "." and therefore never trip the hex branch on Android.
  */
 
 import { blake2b256 } from "@parity/product-sdk-crypto";

--- a/product-sdk/packages/keys/src/product-account.ts
+++ b/product-sdk/packages/keys/src/product-account.ts
@@ -26,9 +26,7 @@ const JUNCTION_ID_LEN = 32;
 const NON_NEGATIVE_INTEGER = /^\d+$/;
 
 export function createChainCode(code: string): Uint8Array {
-    const encoded = NON_NEGATIVE_INTEGER.test(code)
-        ? u64.enc(BigInt(code))
-        : str.enc(code);
+    const encoded = NON_NEGATIVE_INTEGER.test(code) ? u64.enc(BigInt(code)) : str.enc(code);
 
     if (encoded.length > JUNCTION_ID_LEN) {
         return blake2b256(encoded);

--- a/product-sdk/packages/keys/src/product-account.ts
+++ b/product-sdk/packages/keys/src/product-account.ts
@@ -15,10 +15,10 @@
  * left-to-right. For each junction, a 32-byte chain code is built:
  *   - numeric ("^\d+$") -> SCALE u64 (BigInt), zero-padded to 32 bytes
  *   - string             -> SCALE str (compact-length + UTF-8), zero-padded
- *   - if encoded > 32 bytes -> blake2b(encoded, dkLen=32)
+ *   - if encoded > 32 bytes -> blake2b256(encoded) (32-byte BLAKE2b digest)
  */
 
-import { blake2b } from "@noble/hashes/blake2.js";
+import { blake2b256 } from "@parity/product-sdk-crypto";
 import { HDKD } from "@scure/sr25519";
 import { str, u64 } from "scale-ts";
 
@@ -31,7 +31,7 @@ export function createChainCode(code: string): Uint8Array {
         : str.enc(code);
 
     if (encoded.length > JUNCTION_ID_LEN) {
-        return blake2b(encoded, { dkLen: JUNCTION_ID_LEN });
+        return blake2b256(encoded);
     }
 
     const chainCode = new Uint8Array(JUNCTION_ID_LEN);

--- a/product-sdk/packages/sdk/src/identity/index.ts
+++ b/product-sdk/packages/sdk/src/identity/index.ts
@@ -14,10 +14,10 @@ export {
     isDotNsAvailable,
 } from "./dotns.js";
 
-// Product account utilities
+// Context alias utilities
 export {
-    deriveProductAccount,
-    verifyProductAccount,
+    deriveContextAlias,
+    verifyContextAlias,
     deriveAnonymousAlias,
     createRingProof,
     verifyRingProof,
@@ -26,7 +26,7 @@ export {
 // Types
 export type {
     DotNsRecord,
-    ProductAccountInfo,
+    ContextAliasInfo,
     AnonymousAliasInfo,
     RingLocation,
     VerificationResult,

--- a/product-sdk/packages/sdk/src/identity/index.ts
+++ b/product-sdk/packages/sdk/src/identity/index.ts
@@ -1,8 +1,8 @@
 /**
  * @parity/product-sdk/identity
  *
- * Identity utilities including DotNS name resolution,
- * product account derivation, and Ring VRF anonymous aliases.
+ * Identity utilities: DotNS name resolution, context-alias derivation,
+ * and Ring VRF anonymous aliases.
  */
 
 // DotNS utilities

--- a/product-sdk/packages/sdk/src/identity/product-account.ts
+++ b/product-sdk/packages/sdk/src/identity/product-account.ts
@@ -1,56 +1,60 @@
 /**
- * Product account derivation
+ * Context alias derivation
  *
- * Derives product-scoped accounts from a parent account
+ * Derives a deterministic, context-bound alias from a parent account using blake2b-256.
+ *
+ * NOTE: this is NOT the canonical sr25519 product-account derivation used by
+ * mobile, desktop, and dotli hosts. For that, use
+ * `@parity/product-sdk-keys::deriveProductAccountPublicKey`.
  */
 
 import { createLogger } from "@parity/product-sdk-logger";
 import { blake2b256 } from "@parity/product-sdk-crypto";
 import { ss58Encode, ss58Decode, deriveH160 } from "@parity/product-sdk-address";
-import type { ProductAccountInfo, AnonymousAliasInfo, RingLocation } from "./types.js";
+import type { ContextAliasInfo, AnonymousAliasInfo, RingLocation } from "./types.js";
 
 const log = createLogger("identity");
 
 /**
- * Derive a product-scoped account from a parent account
+ * Derive a context-bound alias from a parent account.
  *
- * The product account is deterministically derived using:
- * productPublicKey = hash(parentPublicKey || productName)
+ * The alias is deterministically derived using:
+ * aliasPublicKey = blake2b256(parentPublicKey || context)
  *
  * @param parentAddress - Parent account SS58 address
- * @param productName - Product name for derivation
+ * @param context - Context string for derivation (e.g. an app id or scope label)
  * @param ss58Prefix - SS58 prefix (default: 42)
- * @returns Product account info
+ * @returns Context alias info
  *
  * @example
  * ```ts
- * const productAccount = deriveProductAccount(
+ * const alias = deriveContextAlias(
  *   '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
- *   'my-app'
+ *   'voting-round-1'
  * );
- * console.log('Product address:', productAccount.address);
+ * console.log('Alias address:', alias.address);
  * ```
  */
-export function deriveProductAccount(
+export function deriveContextAlias(
     parentAddress: string,
-    productName: string,
+    context: string,
     ss58Prefix = 42,
-): ProductAccountInfo {
+): ContextAliasInfo {
     const { publicKey: parentPublicKey } = ss58Decode(parentAddress);
 
-    // Derive product public key: blake2b-256(parentPublicKey || productName)
-    const productNameBytes = new TextEncoder().encode(productName);
-    const combined = new Uint8Array(parentPublicKey.length + productNameBytes.length);
+    // Derive alias public key: blake2b-256(parentPublicKey || context)
+    const contextBytes = new TextEncoder().encode(context);
+    const combined = new Uint8Array(parentPublicKey.length + contextBytes.length);
     combined.set(parentPublicKey, 0);
-    combined.set(productNameBytes, parentPublicKey.length);
+    combined.set(contextBytes, parentPublicKey.length);
 
-    const productPublicKey = blake2b256(combined);
-    const address = ss58Encode(productPublicKey, ss58Prefix);
-    const h160Address = deriveH160(productPublicKey);
+    const aliasPublicKey = blake2b256(combined);
+    const address = ss58Encode(aliasPublicKey, ss58Prefix);
+    const h160Address = deriveH160(aliasPublicKey);
 
-    log.debug("Derived product account", {
+    log.debug("Derived context alias", {
         parentAddress,
-        productName,
+        context,
         address,
     });
 
@@ -58,32 +62,32 @@ export function deriveProductAccount(
         address,
         h160Address,
         parentAddress,
-        productName,
+        context,
     };
 }
 
 /**
- * Verify that a product account was derived from a parent account
+ * Verify that a context alias was derived from a parent account.
  *
- * @param productAddress - Product account address
+ * @param aliasAddress - Context alias SS58 address
  * @param parentAddress - Claimed parent address
- * @param productName - Product name
+ * @param context - Context string used for derivation
  * @returns True if derivation is valid
  */
-export function verifyProductAccount(
-    productAddress: string,
+export function verifyContextAlias(
+    aliasAddress: string,
     parentAddress: string,
-    productName: string,
+    context: string,
 ): boolean {
     try {
-        const derived = deriveProductAccount(parentAddress, productName);
-        const { publicKey: productKey } = ss58Decode(productAddress);
+        const derived = deriveContextAlias(parentAddress, context);
+        const { publicKey: aliasKey } = ss58Decode(aliasAddress);
         const { publicKey: derivedKey } = ss58Decode(derived.address);
 
         // Compare public keys
-        if (productKey.length !== derivedKey.length) return false;
-        for (let i = 0; i < productKey.length; i++) {
-            if (productKey[i] !== derivedKey[i]) return false;
+        if (aliasKey.length !== derivedKey.length) return false;
+        for (let i = 0; i < aliasKey.length; i++) {
+            if (aliasKey[i] !== derivedKey[i]) return false;
         }
         return true;
     } catch {

--- a/product-sdk/packages/sdk/src/identity/types.ts
+++ b/product-sdk/packages/sdk/src/identity/types.ts
@@ -1,7 +1,7 @@
 /**
  * Identity module types
  *
- * Types for DotNS name resolution and product account derivation
+ * Types for DotNS name resolution and context-alias derivation
  */
 
 /** DotNS name resolution result */
@@ -16,16 +16,16 @@ export interface DotNsRecord {
     expiresAt?: number;
 }
 
-/** Product account info */
-export interface ProductAccountInfo {
-    /** Product-scoped SS58 address */
+/** Context alias info: a deterministic, context-bound alias derived from a parent account */
+export interface ContextAliasInfo {
+    /** Alias SS58 address */
     address: string;
     /** H160 EVM address */
     h160Address: `0x${string}`;
     /** Parent account address */
     parentAddress: string;
-    /** Product name used for derivation */
-    productName: string;
+    /** Context string used for derivation */
+    context: string;
 }
 
 /** Ring VRF alias info */

--- a/product-sdk/packages/terminal/package.json
+++ b/product-sdk/packages/terminal/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@noble/ciphers": "^2.1.0",
         "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
+        "@noble/hashes": "^2.2.0",
         "@novasamatech/host-papp": "^0.7.7",
         "@novasamatech/statement-store": "^0.7.7",
         "@novasamatech/storage-adapter": "^0.7.7",

--- a/product-sdk/packages/utils/package.json
+++ b/product-sdk/packages/utils/package.json
@@ -24,7 +24,7 @@
         "test:watch": "vitest"
     },
     "dependencies": {
-        "@noble/hashes": "^1.7.1",
+        "@noble/hashes": "^2.2.0",
         "@parity/product-sdk-logger": "workspace:*"
     },
     "devDependencies": {

--- a/product-sdk/pending-changesets/identity-rename-context-alias.md
+++ b/product-sdk/pending-changesets/identity-rename-context-alias.md
@@ -1,0 +1,66 @@
+---
+"@parity/product-sdk": minor
+---
+
+**Rename `@parity/product-sdk/identity`'s `deriveProductAccount` to `deriveContextAlias` (and `verifyProductAccount` to `verifyContextAlias`, `ProductAccountInfo` to `ContextAliasInfo`, field `productName` to `context`).**
+
+The identity-subpath helper is a blake2b256-based deterministic alias
+derivation: `aliasPublicKey = blake2b256(parentPublicKey || context)`.
+Used for scoping a parent account to a context label (an app id, a
+voting round, a channel name, etc.). The old `deriveProductAccount`
+naming collided with the *canonical* sr25519 product-account derivation
+shared with polkadot-desktop and polkadot-app-android-v2: two distinct
+algorithms that produce different outputs from the same inputs. The
+rename makes the algorithmic difference legible at the call site.
+
+For the canonical sr25519 product-account derivation, see the new
+`deriveProductAccountPublicKey` in `@parity/product-sdk-keys` (this
+release wave).
+
+### Breaking changes
+
+- `deriveProductAccount(parentAddress, productName, ss58Prefix?)` is
+  now `deriveContextAlias(parentAddress, context, ss58Prefix?)`. Same
+  algorithm, same output bytes, only the names changed.
+- `verifyProductAccount(productAddress, parentAddress, productName)`
+  is now `verifyContextAlias(aliasAddress, parentAddress, context)`.
+- Type `ProductAccountInfo` is now `ContextAliasInfo`. Field
+  `productName: string` is now `context: string`. Other fields
+  (`address`, `h160Address`, `parentAddress`) unchanged.
+
+Runtime behavior is unchanged on the success path: addresses derived
+under the old API are bit-identical to those derived under the new API
+for the same `(parentAddress, oldProductName === newContext)` pair.
+
+### Migration
+
+Mechanical find/replace across consumer code:
+
+```ts
+// Before:
+import {
+    deriveProductAccount,
+    verifyProductAccount,
+    type ProductAccountInfo,
+} from "@parity/product-sdk/identity";
+
+const acct: ProductAccountInfo = deriveProductAccount(parentAddress, "my-app");
+const ok = verifyProductAccount(acct.address, parentAddress, "my-app");
+console.log(acct.productName);
+
+// After:
+import {
+    deriveContextAlias,
+    verifyContextAlias,
+    type ContextAliasInfo,
+} from "@parity/product-sdk/identity";
+
+const alias: ContextAliasInfo = deriveContextAlias(parentAddress, "my-app");
+const ok = verifyContextAlias(alias.address, parentAddress, "my-app");
+console.log(alias.context);
+```
+
+### Why minor, not major
+
+Per `RELEASES.md`, pre-1.0 breaking changes go out as `minor` in this
+repo. `@parity/product-sdk` is on `0.5.0`; this rename ships at `0.6.0`.

--- a/product-sdk/pending-changesets/keys-product-account-derivation.md
+++ b/product-sdk/pending-changesets/keys-product-account-derivation.md
@@ -76,7 +76,7 @@ update the vectors.
 `-utils` to keep a single hash-library version in the dep tree.
 Consumers see no public-API change from the noble bump (one source
 file in `-address` adjusted an import path from `@noble/hashes/sha3` to
-`@noble/hashes/sha3.js`; both forms resolve to the same module on noble
-1.x and 2.x).
+`@noble/hashes/sha3.js`; the extensionless form worked on noble 1.x but
+noble 2.x's package exports require the explicit `.js` suffix).
 
 No breaking changes here. Purely additive.

--- a/product-sdk/pending-changesets/keys-product-account-derivation.md
+++ b/product-sdk/pending-changesets/keys-product-account-derivation.md
@@ -1,0 +1,82 @@
+---
+"@parity/product-sdk-keys": minor
+"@parity/product-sdk": minor
+---
+
+**Add `deriveProductAccountPublicKey` + `createChainCode` to `@parity/product-sdk-keys`.**
+
+The canonical sr25519 product-account derivation used by polkadot-desktop
+(`polkadot-desktop/src/domains/product/account/service.ts`) and
+polkadot-app-android-v2
+(`feature/products/impl/.../ProductAccountDerivationUseCase.kt`) is now
+exposed from the SDK. External clients (CLI, web hosts) can compute the
+same derived address the mobile wallet derives privately, without ever
+seeing the secret key. sr25519 soft derivation is composable on the
+parent *public* key alone.
+
+### New surface
+
+```ts
+import {
+    createChainCode,
+    deriveProductAccountPublicKey,
+} from "@parity/product-sdk-keys";
+
+// Canonical product-account derivation: junctions ["product", productId, "<index>"]
+const derivedPubKey = deriveProductAccountPublicKey(
+    parentPublicKey, // Uint8Array, 32-byte sr25519 public key
+    "playground.dot", // productId, typically a dotNS name
+    0,                // derivationIndex
+);
+
+// Lower-level helper if you need to build custom junction paths:
+const chainCode = createChainCode("product"); // Uint8Array(32)
+```
+
+`createChainCode(code)` encodes a junction the way Substrate does:
+
+- numeric `^\d+$` to SCALE `u64` (BigInt), zero-padded to 32 bytes
+- string to SCALE `str` (compact-length + UTF-8), zero-padded to 32 bytes
+- if the encoded form exceeds 32 bytes, `blake2b256(encoded)`
+
+`deriveProductAccountPublicKey(parentPubKey, productId, index)` applies
+`HDKD.publicSoft` left-to-right over the junctions `["product",
+productId, String(index)]`. Returns the derived 32-byte public key.
+
+### Cross-platform parity note
+
+`productId` MUST contain at least one non-hex character OR be of odd
+length when serialized as a string. polkadot-app-android-v2's
+`SubstrateJunctionDecoder` tries to interpret a junction as hex BEFORE
+falling through to SCALE-string encoding; polkadot-desktop and this
+implementation skip that hex branch. For productIds that happen to be
+even-length all-hex strings (e.g. `"deadbeef"`, `"c0ffee01"`), Android
+would derive a different public key. In practice, productIds are dotNS
+names like `"playground.dot"`, which contain `.` and never trip the hex
+branch.
+
+### Frozen vectors
+
+Output is locked by four byte-for-byte test vectors in
+`packages/keys/src/product-account.test.ts`, covering the production case
+(`playground.dot`/0), the non-zero u64 numeric branch, a near-boundary
+productId, and the blake2b fallback. Parent public keys in the vectors
+are derived from deterministic 32-byte seeds via `@scure/sr25519`'s
+`secretFromSeed` + `getPublicKey` (arbitrary 32-byte buffers do not work:
+`HDKD.publicSoft` validates the Ristretto255 encoding at the entry
+point). If polkadot-desktop's derivation algorithm ever changes, run
+`packages/keys/scripts/regenerate-fixtures.ts` to re-confirm parity and
+update the vectors.
+
+### Internal: `@noble/hashes` consolidated on ^2.2.0
+
+`@parity/product-sdk-keys` now depends on `@scure/sr25519@^2.2.0` and
+`scale-ts@^1.6.1`. The workspace is also consolidated on
+`@noble/hashes@^2.2.0` across `-address`, `-crypto`, `-terminal`, and
+`-utils` to keep a single hash-library version in the dep tree.
+Consumers see no public-API change from the noble bump (one source
+file in `-address` adjusted an import path from `@noble/hashes/sha3` to
+`@noble/hashes/sha3.js`; both forms resolve to the same module on noble
+1.x and 2.x).
+
+No breaking changes here. Purely additive.

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 0.7.8
       '@novasamatech/product-sdk':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-bulletin':
         specifier: workspace:*
         version: link:../../packages/bulletin
@@ -91,7 +91,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -113,7 +113,7 @@ importers:
         version: 0.7.8
       '@novasamatech/product-sdk':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -128,7 +128,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -150,7 +150,7 @@ importers:
         version: 0.7.8
       '@novasamatech/product-sdk':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -165,7 +165,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -249,7 +249,7 @@ importers:
         version: link:../../packages/contracts
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -265,13 +265,13 @@ importers:
         version: 0.7.8
       '@novasamatech/product-sdk':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -352,7 +352,7 @@ importers:
         version: 0.7.8
       '@novasamatech/product-sdk':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-address':
         specifier: workspace:*
         version: link:../../packages/address
@@ -370,7 +370,7 @@ importers:
         version: link:../../packages/tx
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -405,7 +405,7 @@ importers:
     dependencies:
       '@parity/bulletin-sdk':
         specifier: ^0.3.0
-        version: 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.2(esbuild@0.25.12)(rxjs@7.8.2))
+        version: 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2))
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../chain-client
@@ -426,7 +426,7 @@ importers:
         version: 13.4.2
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -448,7 +448,7 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -482,7 +482,7 @@ importers:
         version: 0.0.27
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
       viem:
         specifier: 'catalog:'
         version: 2.48.1(typescript@5.9.3)
@@ -523,7 +523,7 @@ importers:
     dependencies:
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.8.3
@@ -536,14 +536,14 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
       '@novasamatech/product-sdk':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -553,6 +553,9 @@ importers:
 
   packages/keys:
     dependencies:
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@parity/product-sdk-address':
         specifier: workspace:*
         version: link:../address
@@ -568,9 +571,15 @@ importers:
       '@polkadot-labs/hdkd-helpers':
         specifier: ^0.0.10
         version: 0.0.10
+      '@scure/sr25519':
+        specifier: ^2.2.0
+        version: 2.2.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      scale-ts:
+        specifier: ^1.6.1
+        version: 1.6.1
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -628,7 +637,7 @@ importers:
         version: link:../tx
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -662,7 +671,7 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -679,13 +688,13 @@ importers:
         version: 0.7.8
       '@novasamatech/product-sdk':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
 
   packages/statement-store:
     dependencies:
       '@novasamatech/sdk-statement':
         specifier: 'catalog:'
-        version: 0.6.0(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../host
@@ -700,11 +709,11 @@ importers:
         version: 0.7.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@novasamatech/product-sdk':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       tsup:
         specifier: 'catalog:'
         version: 8.5.0(postcss@8.5.10)(typescript@5.9.3)
@@ -744,10 +753,10 @@ importers:
         version: 2.2.0
       '@novasamatech/host-papp':
         specifier: ^0.7.7
-        version: 0.7.7(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.7(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/statement-store':
         specifier: ^0.7.7
-        version: 0.7.7(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.7(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/storage-adapter':
         specifier: ^0.7.7
         version: 0.7.7
@@ -771,7 +780,7 @@ importers:
         version: 8.2.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -805,7 +814,7 @@ importers:
         version: 0.0.10
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -3680,20 +3689,20 @@ snapshots:
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
-  '@novasamatech/host-papp@0.7.7(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/host-papp@0.7.7(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
       '@novasamatech/host-api': 0.7.7
       '@novasamatech/scale': 0.7.7
-      '@novasamatech/statement-store': 0.7.7(esbuild@0.25.12)(rxjs@7.8.2)
+      '@novasamatech/statement-store': 0.7.7(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/storage-adapter': 0.7.7
       '@polkadot-labs/hdkd-helpers': 0.0.30
       nanoevents: 9.1.0
       nanoid: 5.1.9
       neverthrow: 8.2.0
-      polkadot-api: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
       scale-ts: 1.6.1
       verifiablejs: 1.2.0
     transitivePeerDependencies:
@@ -3719,6 +3728,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@novasamatech/product-sdk@0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
+    dependencies:
+      '@novasamatech/host-api': 0.7.8
+      '@polkadot-api/json-rpc-provider-proxy': 0.4.0
+      '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
+      neverthrow: 8.2.0
+      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@polkadot/api'
+      - '@polkadot/util'
+      - bufferutil
+      - esbuild
+      - rxjs
+      - supports-color
+      - utf-8-validate
+
   '@novasamatech/scale@0.7.7':
     dependencies:
       '@polkadot-api/utils': 0.4.0
@@ -3734,11 +3759,11 @@ snapshots:
       '@polkadot-api/utils': 0.4.0
       scale-ts: 1.6.1
 
-  '@novasamatech/sdk-statement@0.6.0(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/sdk-statement@0.6.0(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@polkadot-api/substrate-bindings': 0.20.1
       '@polkadot-api/utils': 0.4.0
-      polkadot-api: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -3746,19 +3771,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/statement-store@0.7.7(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/statement-store@0.7.7(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
       '@novasamatech/scale': 0.7.7
-      '@novasamatech/sdk-statement': 0.6.0(esbuild@0.25.12)(rxjs@7.8.2)
+      '@novasamatech/sdk-statement': 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
       '@polkadot-api/substrate-bindings': 0.20.2
       '@polkadot-api/substrate-client': 0.7.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
       '@scure/sr25519': 2.2.0
       nanoid: 5.1.9
       neverthrow: 8.2.0
-      polkadot-api: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
       scale-ts: 1.6.1
     transitivePeerDependencies:
       - bufferutil
@@ -3772,14 +3797,14 @@ snapshots:
       nanoevents: 9.1.0
       neverthrow: 8.2.0
 
-  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.2(esbuild@0.25.12)(rxjs@7.8.2))':
+  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2))':
     dependencies:
       '@ipld/dag-pb': 4.1.5
       '@noble/hashes': 2.2.0
       '@polkadot-labs/hdkd-helpers': 0.0.29
       ipfs-unixfs: 12.0.2
       multiformats: 13.4.2
-      polkadot-api: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
 
   '@parity/host-api-test-sdk@0.8.2(@playwright/test@1.59.1)':
     dependencies:
@@ -3816,6 +3841,41 @@ snapshots:
       read-pkg: 10.1.0
       rollup: 4.60.3
       rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.60.3)
+      rxjs: 7.8.2
+      tsc-prog: 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+      write-package: 7.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - esbuild
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot-api/cli@0.21.1(esbuild@0.27.7)':
+    dependencies:
+      '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
+      '@polkadot-api/codegen': 0.22.4
+      '@polkadot-api/ink-contracts': 0.6.2
+      '@polkadot-api/json-rpc-provider': 0.2.0
+      '@polkadot-api/known-chains': 0.11.3
+      '@polkadot-api/metadata-compatibility': 0.6.2
+      '@polkadot-api/observable-client': 0.18.5(rxjs@7.8.2)
+      '@polkadot-api/sm-provider': 0.3.3(@polkadot-api/smoldot@0.4.2)
+      '@polkadot-api/smoldot': 0.4.2
+      '@polkadot-api/substrate-bindings': 0.20.2
+      '@polkadot-api/substrate-client': 0.7.0
+      '@polkadot-api/utils': 0.4.0
+      '@polkadot-api/wasm-executor': 0.2.3
+      '@polkadot-api/ws-middleware': 0.3.3(rxjs@7.8.2)
+      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
+      '@types/node': 25.6.0
+      commander: 14.0.3
+      execa: 9.6.1
+      fs.promises.exists: 1.1.4
+      ora: 9.4.0
+      read-pkg: 10.1.0
+      rollup: 4.60.3
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.7)(rollup@4.60.3)
       rxjs: 7.8.2
       tsc-prog: 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -5186,6 +5246,34 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2):
+    dependencies:
+      '@polkadot-api/cli': 0.21.1(esbuild@0.27.7)
+      '@polkadot-api/ink-contracts': 0.6.2
+      '@polkadot-api/json-rpc-provider': 0.2.0
+      '@polkadot-api/known-chains': 0.11.3
+      '@polkadot-api/logs-provider': 0.2.0
+      '@polkadot-api/metadata-builders': 0.14.2
+      '@polkadot-api/metadata-compatibility': 0.6.2
+      '@polkadot-api/observable-client': 0.18.5(rxjs@7.8.2)
+      '@polkadot-api/pjs-signer': 0.7.2
+      '@polkadot-api/polkadot-signer': 0.1.6
+      '@polkadot-api/signer': 0.3.2
+      '@polkadot-api/sm-provider': 0.3.3(@polkadot-api/smoldot@0.4.2)
+      '@polkadot-api/smoldot': 0.4.2
+      '@polkadot-api/substrate-bindings': 0.20.2
+      '@polkadot-api/substrate-client': 0.7.0
+      '@polkadot-api/utils': 0.4.0
+      '@polkadot-api/ws-middleware': 0.3.3(rxjs@7.8.2)
+      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
+      '@rx-state/core': 0.1.4(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - esbuild
+      - supports-color
+      - utf-8-validate
+
   postcss-load-config@6.0.1(postcss@8.5.10):
     dependencies:
       lilconfig: 3.1.3
@@ -5273,6 +5361,17 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       esbuild: 0.25.12
+      get-tsconfig: 4.14.0
+      rollup: 4.60.3
+      unplugin-utils: 0.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.3):
+    dependencies:
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      esbuild: 0.27.7
       get-tsconfig: 4.14.0
       rollup: 4.60.3
       unplugin-utils: 0.2.5

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -553,9 +553,6 @@ importers:
 
   packages/keys:
     dependencies:
-      '@noble/hashes':
-        specifier: ^2.2.0
-        version: 2.2.0
       '@parity/product-sdk-address':
         specifier: workspace:*
         version: link:../address

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -388,8 +388,8 @@ importers:
   packages/address:
     dependencies:
       '@noble/hashes':
-        specifier: ^1.7.1
-        version: 1.8.0
+        specifier: ^2.2.0
+        version: 2.2.0
       '@polkadot-api/substrate-bindings':
         specifier: ^0.12.0
         version: 0.12.0
@@ -506,8 +506,8 @@ importers:
         specifier: ^1.8.0
         version: 1.9.7
       '@noble/hashes':
-        specifier: ^1.7.1
-        version: 1.8.0
+        specifier: ^2.2.0
+        version: 2.2.0
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
@@ -746,7 +746,7 @@ importers:
         specifier: ^2.0.1
         version: 2.2.0
       '@noble/hashes':
-        specifier: ^2.0.1
+        specifier: ^2.2.0
         version: 2.2.0
       '@novasamatech/host-papp':
         specifier: ^0.7.7
@@ -823,8 +823,8 @@ importers:
   packages/utils:
     dependencies:
       '@noble/hashes':
-        specifier: ^1.7.1
-        version: 1.8.0
+        specifier: ^2.2.0
+        version: 2.2.0
       '@parity/product-sdk-logger':
         specifier: workspace:*
         version: link:../logger

--- a/product-sdk/skills/product-sdk-transactions/SKILL.md
+++ b/product-sdk/skills/product-sdk-transactions/SKILL.md
@@ -221,6 +221,21 @@ const info = await skm.getOrCreate();
 // info.account  - DerivedAccount with signer
 ```
 
+## deriveProductAccountPublicKey: Canonical sr25519 Product-Account Derivation
+
+```ts
+import { deriveProductAccountPublicKey } from "@parity/product-sdk-keys";
+
+// Derive the same product-account public key the mobile wallet derives privately
+const derivedPubKey = deriveProductAccountPublicKey(
+  parentPublicKey,    // 32-byte sr25519 public key
+  "playground.dot",   // productId (typically a dotNS name)
+  0,                  // derivationIndex
+);
+```
+
+Mirrors the algorithm used by polkadot-desktop and polkadot-app-android-v2. sr25519 soft derivation is composable on the parent *public* key alone, so external clients (CLI, web hosts) can compute the same address without seeing the secret key. See `references/keys-api.md` for the cross-platform parity constraint on `productId`.
+
 ## Common Mistakes
 
 1. **Using dev signers in production** - `createDevSigner` uses the well-known dev mnemonic. Use `SignerManager` for real users.

--- a/product-sdk/skills/product-sdk-transactions/references/keys-api.md
+++ b/product-sdk/skills/product-sdk-transactions/references/keys-api.md
@@ -147,6 +147,46 @@ function seedToAccount(
 
 ---
 
+## deriveProductAccountPublicKey
+
+Canonical sr25519 product-account public-key derivation. Mirrors the algorithm in polkadot-desktop (`productAccountService.deriveProductPublicKey`) and polkadot-app-android-v2 (`ProductAccountDerivationUseCase`), so an external client (CLI, web host) can compute the same derived address the mobile wallet derives privately, without ever seeing the secret key.
+
+```ts
+import { deriveProductAccountPublicKey } from "@parity/product-sdk-keys";
+
+function deriveProductAccountPublicKey(
+  parentPublicKey: Uint8Array,
+  productId: string,
+  derivationIndex: number,
+): Uint8Array
+```
+
+Applies sr25519 soft derivation (`HDKD.publicSoft`) left-to-right over the junctions `["product", productId, String(derivationIndex)]`. Returns the 32-byte derived public key.
+
+### productId constraint (cross-platform parity)
+
+`productId` MUST contain at least one non-hex character OR be of odd length when serialized as a string. polkadot-app-android-v2's `SubstrateJunctionDecoder` tries to interpret a junction as hex BEFORE falling through to SCALE-string encoding; polkadot-desktop and this implementation skip that hex branch. For productIds that happen to be even-length all-hex strings (e.g. `"deadbeef"`), Android would derive a different public key. dotNS names like `"playground.dot"` always contain `.` and never trip the hex branch.
+
+---
+
+## createChainCode
+
+Lower-level helper for building custom junction paths. Encodes a junction the way Substrate does:
+
+```ts
+import { createChainCode } from "@parity/product-sdk-keys";
+
+function createChainCode(code: string): Uint8Array  // 32-byte chain code
+```
+
+- `code` matching `^\d+$`: SCALE `u64` of `BigInt(code)`, zero-padded to 32 bytes.
+- Other strings: SCALE `str` (compact-length + UTF-8), zero-padded to 32 bytes.
+- If the encoded form exceeds 32 bytes: `blake2b256(encoded)`.
+
+Most consumers should use `deriveProductAccountPublicKey` instead; `createChainCode` is exported for callers that need to derive against non-`["product", ...]` junction paths.
+
+---
+
 ## Types
 
 ### DerivedAccount


### PR DESCRIPTION
## Summary

- **`@parity/product-sdk-keys`** gains `deriveProductAccountPublicKey` + `createChainCode`: the canonical sr25519 product-account derivation already used by polkadot-desktop (`productAccountService`) and polkadot-app-android-v2 (`ProductAccountDerivationUseCase`). sr25519 soft derivation is composable on the parent *public* key alone, so external clients (CLI, web hosts) can compute the same derived address the mobile wallet derives privately, without ever seeing the secret key. Output is locked by four frozen byte-for-byte test vectors in `packages/keys/src/product-account.test.ts`.
- **`@parity/product-sdk/identity`** renames `deriveProductAccount` -> `deriveContextAlias` (and siblings: `verifyProductAccount` -> `verifyContextAlias`, `ProductAccountInfo` -> `ContextAliasInfo`, field `productName` -> `context`). The old name collided with the canonical sr25519 derivation above (two distinct algorithms producing different outputs). The rename makes the algorithmic difference legible at the call site. Breaking, no deprecation alias (callsite investigation found zero external consumers).
- Workspace `@noble/hashes` direct deps consolidated on `^2.2.0` across `-address`, `-crypto`, `-terminal`, `-utils`. One source-file change in `-address` (`@noble/hashes/sha3` -> `@noble/hashes/sha3.js`).

## Cross-platform parity caveat

`productId` MUST contain at least one non-hex character or be of odd length. polkadot-app-android-v2's `SubstrateJunctionDecoder` tries hex BEFORE SCALE-string encoding; desktop and this implementation skip the hex branch. In practice productIds are dotNS names like `playground.dot` (always contain `.`), so this never trips on real input. Documented in JSDoc, the maintenance script, and the changeset.

## Bump levels

Both pending-changesets ship at `minor` per the pre-1.0 convention in `RELEASES.md`. `@parity/product-sdk` jumps from `0.5.0` to `0.6.0`; `@parity/product-sdk-keys` similarly minor-bumps for the new exports.

## Test plan

- [x] `pnpm test` in `packages/keys` -> 53/53 pass (9 new product-account tests + 44 existing).
- [x] `pnpm -r build` -> clean across the workspace.
- [x] `grep -rn "deriveProductAccount\b\|verifyProductAccount\b\|ProductAccountInfo\b" packages/` -> 0 hits (rename complete).
- [x] All 9 commits GPG-signed.
- [x] Cross-platform parity verified against polkadot-desktop (executable, byte-for-byte) and polkadot-app-android-v2 (code-read against substrate-sdk-android@2.11.5).
- [ ] Reviewer: confirm `pnpm install` resolves cleanly with the noble bump on a fresh clone.

## Heads-up for reviewers

`packages/chain-client/src/presets.ts` has 2 pre-existing test failures (genesis-hash drift between the test's `GENESIS` map and the bundled descriptors). This branch does not touch `chain-client/` or `descriptors/`; `presets.ts` blob SHA is identical at base and HEAD. Pre-existing, not introduced here.

Maintenance: if polkadot-desktop's derivation algorithm ever changes, run `packages/keys/scripts/regenerate-fixtures.ts` to re-confirm parity and update the locked vectors.

Filename `packages/sdk/src/identity/product-account.ts` is no longer descriptive (only context-alias + Ring VRF stubs live there now). Deferred rename to `context-alias.ts` as a follow-up PR (will likely split Ring VRF stubs into their own file at the same time).