### PR TITLE
chore(deps): rename @novasamatech/product-sdk to host-api-wrapper

### DIFF
--- a/product-sdk/examples/bulletin-demo/package.json
+++ b/product-sdk/examples/bulletin-demo/package.json
@@ -18,7 +18,7 @@
         "@parity/product-sdk-descriptors": "workspace:*",
         "@parity/product-sdk-signer": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "polkadot-api": "catalog:"
     },
     "devDependencies": {

--- a/product-sdk/examples/chain-client-demo/package.json
+++ b/product-sdk/examples/chain-client-demo/package.json
@@ -18,7 +18,7 @@
         "@parity/product-sdk-host": "workspace:*",
         "@parity/product-sdk-signer": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "polkadot-api": "catalog:"
     },
     "devDependencies": {

--- a/product-sdk/examples/contracts-demo/e2e/submit.spec.ts
+++ b/product-sdk/examples/contracts-demo/e2e/submit.spec.ts
@@ -20,7 +20,7 @@ import { waitForAppReady } from "./helpers";
  */
 // TODO(truapi-migration): Unskip once `@parity/product-sdk-signer`'s host
 // provider routes through TrUAPI's `signing.createTransaction` instead of
-// `@novasamatech/product-sdk@0.7.8`'s PJS bridge, which throws on Paseo v2's
+// `@novasamatech/host-api-wrapper`'s PJS bridge, which throws on Paseo v2's
 // `AsPgas` signed extension. Also depends on `@t3rminal/bulletin-index` being
 // redeployed on paseo v2 — see the contract-redeploy tracker.
 test.describe.skip("@parity/product-sdk-contracts via Host API — submit", () => {

--- a/product-sdk/examples/contracts-demo/package.json
+++ b/product-sdk/examples/contracts-demo/package.json
@@ -18,7 +18,7 @@
         "@parity/product-sdk-descriptors": "workspace:*",
         "@parity/product-sdk-signer": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "polkadot-api": "catalog:"
     },
     "devDependencies": {

--- a/product-sdk/examples/host-demo/package.json
+++ b/product-sdk/examples/host-demo/package.json
@@ -16,7 +16,7 @@
         "@parity/product-sdk-host": "workspace:*",
         "@parity/product-sdk-signer": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:"
+        "@novasamatech/host-api-wrapper": "catalog:"
     },
     "devDependencies": {
         "@parity/host-api-test-sdk": "catalog:",

--- a/product-sdk/examples/keys-demo/package.json
+++ b/product-sdk/examples/keys-demo/package.json
@@ -18,7 +18,7 @@
         "@parity/product-sdk-signer": "workspace:*",
         "@parity/product-sdk-storage": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:"
+        "@novasamatech/host-api-wrapper": "catalog:"
     },
     "devDependencies": {
         "@parity/host-api-test-sdk": "catalog:",

--- a/product-sdk/examples/signer-demo/package.json
+++ b/product-sdk/examples/signer-demo/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@parity/product-sdk-signer": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "polkadot-api": "catalog:"
     },
     "devDependencies": {

--- a/product-sdk/examples/statement-store-demo/package.json
+++ b/product-sdk/examples/statement-store-demo/package.json
@@ -16,7 +16,7 @@
         "@parity/product-sdk-signer": "workspace:*",
         "@parity/product-sdk-statement-store": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:"
+        "@novasamatech/host-api-wrapper": "catalog:"
     },
     "devDependencies": {
         "@parity/host-api-test-sdk": "catalog:",

--- a/product-sdk/examples/storage-demo/package.json
+++ b/product-sdk/examples/storage-demo/package.json
@@ -17,7 +17,7 @@
         "@parity/product-sdk-signer": "workspace:*",
         "@parity/product-sdk-storage": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:"
+        "@novasamatech/host-api-wrapper": "catalog:"
     },
     "devDependencies": {
         "@parity/host-api-test-sdk": "catalog:",

--- a/product-sdk/examples/tx-demo/e2e/dispatch-error.spec.ts
+++ b/product-sdk/examples/tx-demo/e2e/dispatch-error.spec.ts
@@ -13,7 +13,7 @@ import { waitForAppReady } from "./helpers";
  */
 // TODO(truapi-migration): Unskip once `@parity/product-sdk-signer`'s host
 // provider routes through TrUAPI's `signing.createTransaction` instead of
-// `@novasamatech/product-sdk@0.7.8`'s PJS bridge, which throws on Paseo v2's
+// `@novasamatech/host-api-wrapper`'s PJS bridge, which throws on Paseo v2's
 // `AsPgas` signed extension. See the tracking issue for the migration plan.
 test.describe.skip("@parity/product-sdk-tx via Host API — dispatch error", () => {
     test("root-only call surfaces TxDispatchError after block inclusion", async ({

--- a/product-sdk/examples/tx-demo/e2e/finalized.spec.ts
+++ b/product-sdk/examples/tx-demo/e2e/finalized.spec.ts
@@ -12,7 +12,7 @@ import { waitForAppReady } from "./helpers";
  */
 // TODO(truapi-migration): Unskip once `@parity/product-sdk-signer`'s host
 // provider routes through TrUAPI's `signing.createTransaction` instead of
-// `@novasamatech/product-sdk@0.7.8`'s PJS bridge, which throws on Paseo v2's
+// `@novasamatech/host-api-wrapper`'s PJS bridge, which throws on Paseo v2's
 // `AsPgas` signed extension. See the tracking issue for the migration plan.
 test.describe.skip("@parity/product-sdk-tx via Host API — finalized", () => {
     test("waitFor=finalized resolves only after finalization", async ({ testHost }) => {

--- a/product-sdk/examples/tx-demo/e2e/on-status.spec.ts
+++ b/product-sdk/examples/tx-demo/e2e/on-status.spec.ts
@@ -14,7 +14,7 @@ import { waitForAppReady } from "./helpers";
  */
 // TODO(truapi-migration): Unskip once `@parity/product-sdk-signer`'s host
 // provider routes through TrUAPI's `signing.createTransaction` instead of
-// `@novasamatech/product-sdk@0.7.8`'s PJS bridge, which throws on Paseo v2's
+// `@novasamatech/host-api-wrapper`'s PJS bridge, which throws on Paseo v2's
 // `AsPgas` signed extension. See the tracking issue for the migration plan.
 test.describe.skip("@parity/product-sdk-tx via Host API — onStatus ordering", () => {
     test("signing → broadcasting → in-block transitions fire in order", async ({

--- a/product-sdk/examples/tx-demo/e2e/submit-remark.spec.ts
+++ b/product-sdk/examples/tx-demo/e2e/submit-remark.spec.ts
@@ -17,7 +17,7 @@ test.describe("@parity/product-sdk-tx via Host API", () => {
 
     // TODO(truapi-migration): Unskip once `@parity/product-sdk-signer`'s host
     // provider routes through TrUAPI's `signing.createTransaction` instead of
-    // `@novasamatech/product-sdk@0.7.8`'s PJS bridge, which throws on Paseo v2's
+    // `@novasamatech/host-api-wrapper`'s PJS bridge, which throws on Paseo v2's
     // `AsPgas` signed extension.
     test.skip("submitAndWatch: single remark is signed via the host and lands on-chain", async ({
         testHost,
@@ -49,7 +49,7 @@ test.describe("@parity/product-sdk-tx via Host API", () => {
 
     // TODO(truapi-migration): Unskip once `@parity/product-sdk-signer`'s host
     // provider routes through TrUAPI's `signing.createTransaction` instead of
-    // `@novasamatech/product-sdk@0.7.8`'s PJS bridge, which throws on Paseo v2's
+    // `@novasamatech/host-api-wrapper`'s PJS bridge, which throws on Paseo v2's
     // `AsPgas` signed extension.
     test.skip("batchSubmitAndWatch: three remarks land in a single extrinsic", async ({
         testHost,

--- a/product-sdk/examples/tx-demo/package.json
+++ b/product-sdk/examples/tx-demo/package.json
@@ -19,7 +19,7 @@
         "@parity/product-sdk-signer": "workspace:*",
         "@parity/product-sdk-tx": "workspace:*",
         "@novasamatech/host-api": "catalog:",
-        "@novasamatech/product-sdk": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "polkadot-api": "catalog:"
     },
     "devDependencies": {

--- a/product-sdk/packages/bulletin/tsup.config.ts
+++ b/product-sdk/packages/bulletin/tsup.config.ts
@@ -13,5 +13,5 @@ export default defineConfig({
     },
     // Mark product-sdk as external since it's an optional peer dependency
     // that's dynamically imported
-    external: ["@novasamatech/product-sdk"],
+    external: ["@novasamatech/host-api-wrapper"],
 });

--- a/product-sdk/packages/host/package.json
+++ b/product-sdk/packages/host/package.json
@@ -24,11 +24,11 @@
         "polkadot-api": "catalog:"
     },
     "peerDependencies": {
-        "@novasamatech/product-sdk": ">=0.1.0",
+        "@novasamatech/host-api-wrapper": ">=0.1.0",
         "@novasamatech/host-api": ">=0.6.0"
     },
     "peerDependenciesMeta": {
-        "@novasamatech/product-sdk": {
+        "@novasamatech/host-api-wrapper": {
             "optional": true
         },
         "@novasamatech/host-api": {
@@ -36,7 +36,7 @@
         }
     },
     "devDependencies": {
-        "@novasamatech/product-sdk": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "@novasamatech/host-api": "catalog:",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"

--- a/product-sdk/packages/host/src/container.ts
+++ b/product-sdk/packages/host/src/container.ts
@@ -15,7 +15,7 @@ export async function isInsideContainer(): Promise<boolean> {
     if (typeof window === "undefined") return false;
 
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.sandboxProvider.isCorrectEnvironment();
     } catch {
         return isInsideContainerSync();
@@ -30,7 +30,7 @@ export async function getHostLocalStorage(): Promise<HostLocalStorage | null> {
     if (!(await isInsideContainer())) return null;
 
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.hostLocalStorage as HostLocalStorage;
     } catch {
         return null;
@@ -42,14 +42,14 @@ export async function getHostLocalStorage(): Promise<HostLocalStorage | null> {
  *
  * When running inside a Polkadot container, this wraps the chain connection via the
  * host's `createPapiProvider`, enabling shared connections and efficient routing.
- * Returns `null` when `@novasamatech/product-sdk` is unavailable.
+ * Returns `null` when `@novasamatech/host-api-wrapper` is unavailable.
  *
  * @param genesisHash - Genesis hash of the target chain (`0x`-prefixed hex string).
  * @returns A host-routed `JsonRpcProvider`, or `null` if unavailable.
  */
 export async function getHostProvider(genesisHash: `0x${string}`): Promise<JsonRpcProvider | null> {
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createPapiProvider(genesisHash);
     } catch {
         return null;
@@ -90,13 +90,13 @@ export function isInsideContainerSync(): boolean {
  *
  * Returns a statement store with `subscribe`, `createProof`, and `submit` methods
  * that communicate through the host's native binary protocol — bypassing JSON-RPC
- * entirely. Returns `null` when `@novasamatech/product-sdk` is unavailable.
+ * entirely. Returns `null` when `@novasamatech/host-api-wrapper` is unavailable.
  *
  * @returns The host statement store, or `null` if unavailable.
  */
 export async function getStatementStore(): Promise<HostStatementStore | null> {
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createStatementStore() as HostStatementStore;
     } catch {
         return null;

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -24,7 +24,7 @@ export type {
 } from "./types.js";
 export { BULLETIN_RPCS, DEFAULT_BULLETIN_ENDPOINT } from "./chains.js";
 
-// TruAPI - re-exports from @novasamatech/product-sdk and @novasamatech/host-api
+// TruAPI - re-exports from @novasamatech/host-api-wrapper and @novasamatech/host-api
 export {
     getTruApi,
     getPreimageManager,

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -1,7 +1,7 @@
 /**
  * TruAPI - the protocol for communicating between apps and the Polkadot host container.
  *
- * This module centralizes access to @novasamatech/product-sdk and @novasamatech/host-api,
+ * This module centralizes access to @novasamatech/host-api-wrapper and @novasamatech/host-api,
  * allowing other @parity/product-sdk-* packages to import from here rather than depending
  * directly on novasama packages.
  *
@@ -116,7 +116,7 @@ let cachedTruApi: TruApi | null = null;
 /**
  * Get the TruAPI instance for direct low-level access.
  *
- * Returns the `hostApi` object from `@novasamatech/product-sdk` which provides
+ * Returns the `hostApi` object from `@novasamatech/host-api-wrapper` which provides
  * methods for communicating directly with the host container. Returns `null`
  * when running outside a container or when the SDK is unavailable.
  *
@@ -149,7 +149,7 @@ export async function getTruApi(): Promise<TruApi | null> {
     if (cachedTruApi) return cachedTruApi;
 
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         cachedTruApi = sdk.hostApi;
         log.debug("TruAPI loaded");
         return cachedTruApi;
@@ -185,7 +185,7 @@ export async function getTruApi(): Promise<TruApi | null> {
  */
 export async function getPreimageManager(): Promise<PreimageManager | null> {
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.preimageManager;
     } catch {
         return null;
@@ -222,7 +222,7 @@ export interface PreimageManager {
  */
 export async function getAccountsProvider(): Promise<AccountsProvider | null> {
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createAccountsProvider() as unknown as AccountsProvider;
     } catch {
         return null;
@@ -431,7 +431,7 @@ export interface ResultAsync<T, E> {
 }
 
 /**
- * Accounts provider interface from @novasamatech/product-sdk.
+ * Accounts provider interface from @novasamatech/host-api-wrapper.
  *
  * Provides methods for accessing host wallet accounts, product accounts,
  * and Ring VRF operations.
@@ -440,7 +440,7 @@ export interface AccountsProvider {
     /**
      * Get legacy accounts (user's external wallets connected to the host).
      *
-     * Renamed from `getNonProductAccounts` in @novasamatech/product-sdk 0.7.
+     * Renamed from `getNonProductAccounts` in @novasamatech/host-api-wrapper 0.7.
      *
      * @returns ResultAsync resolving to array of accounts.
      */
@@ -449,7 +449,7 @@ export interface AccountsProvider {
     /**
      * Get a signer for a legacy account.
      *
-     * Renamed from `getNonProductAccountSigner` in @novasamatech/product-sdk 0.7.
+     * Renamed from `getNonProductAccountSigner` in @novasamatech/host-api-wrapper 0.7.
      *
      * @param account - The product account (used for public key lookup).
      * @returns A PolkadotSigner for signing transactions.

--- a/product-sdk/packages/host/src/types.ts
+++ b/product-sdk/packages/host/src/types.ts
@@ -22,7 +22,7 @@ export interface HostLocalStorage {
  * signature schemes — `Sr25519`, `Ed25519`, `Ecdsa`, and `OnChain` (chain-
  * attestation-based proofs).
  *
- * Mirrors `@novasamatech/product-sdk@0.7`'s proof shape.
+ * Mirrors `@novasamatech/host-api-wrapper@0.7`'s proof shape.
  */
 export type StatementProof =
     | { tag: "Sr25519"; value: { signature: Uint8Array; signer: Uint8Array } }
@@ -35,7 +35,7 @@ export type StatementProof =
 
 /**
  * Topic-based subscription filter. Mirrors `StatementTopicFilter` from
- * `@novasamatech/product-sdk` — the host delivers statements that match
+ * `@novasamatech/host-api-wrapper` — the host delivers statements that match
  * either *all* of the listed topics (`matchAll`) or *any* of them
  * (`matchAny`).
  */
@@ -64,7 +64,7 @@ export interface HostSubscription {
  * host's native binary protocol; the `statement-store` package layers a
  * higher-level client on top.
  *
- * Shape matches `@novasamatech/product-sdk@0.7`'s `createStatementStore()`.
+ * Shape matches `@novasamatech/host-api-wrapper@0.7`'s `createStatementStore()`.
  */
 export interface HostStatementStore {
     /**

--- a/product-sdk/packages/host/tsup.config.ts
+++ b/product-sdk/packages/host/tsup.config.ts
@@ -13,5 +13,5 @@ export default defineConfig({
     },
     // Mark novasama packages as external since they're optional peer dependencies
     // that are dynamically imported or re-exported
-    external: ["@novasamatech/product-sdk", "@novasamatech/host-api"],
+    external: ["@novasamatech/host-api-wrapper", "@novasamatech/host-api"],
 });

--- a/product-sdk/packages/signer/package.json
+++ b/product-sdk/packages/signer/package.json
@@ -27,7 +27,7 @@
         "polkadot-api": "catalog:"
     },
     "optionalDependencies": {
-        "@novasamatech/product-sdk": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "@novasamatech/host-api": "catalog:"
     },
     "devDependencies": {

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -23,7 +23,7 @@ export interface HostProviderOptions {
     /** Initial retry delay in ms. Default: 500 */
     retryDelay?: number;
     /**
-     * Custom SDK loader. Defaults to `import("@novasamatech/product-sdk")`.
+     * Custom SDK loader. Defaults to `import("@novasamatech/host-api-wrapper")`.
      * Override this for testing or custom SDK setups.
      * @internal
      */
@@ -148,7 +148,7 @@ export interface ProductSdkModule {
 
 /* @integration */
 async function defaultLoadSdk(): Promise<ProductSdkModule> {
-    return (await import("@novasamatech/product-sdk")) as unknown as ProductSdkModule;
+    return (await import("@novasamatech/host-api-wrapper")) as unknown as ProductSdkModule;
 }
 
 /* @integration */
@@ -159,7 +159,7 @@ async function defaultLoadHostApiEnum(): Promise<HostApiEnumHelper> {
 /**
  * Provider for the Host API (Polkadot Desktop / Android).
  *
- * Dynamically imports `@novasamatech/product-sdk` at runtime so it remains
+ * Dynamically imports `@novasamatech/host-api-wrapper` at runtime so it remains
  * an optional peer dependency. Apps running outside a host container will
  * gracefully get a `HOST_UNAVAILABLE` error.
  *

--- a/product-sdk/packages/signer/tsup.config.ts
+++ b/product-sdk/packages/signer/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     clean: true,
     target: "es2022",
     treeshake: true,
-    external: ["@novasamatech/product-sdk", "@novasamatech/host-api"],
+    external: ["@novasamatech/host-api-wrapper", "@novasamatech/host-api"],
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/packages/statement-store/package.json
+++ b/product-sdk/packages/statement-store/package.json
@@ -30,15 +30,15 @@
         "polkadot-api": "catalog:"
     },
     "peerDependencies": {
-        "@novasamatech/product-sdk": ">=0.6.0"
+        "@novasamatech/host-api-wrapper": ">=0.6.0"
     },
     "peerDependenciesMeta": {
-        "@novasamatech/product-sdk": {
+        "@novasamatech/host-api-wrapper": {
             "optional": true
         }
     },
     "devDependencies": {
-        "@novasamatech/product-sdk": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:"

--- a/product-sdk/packages/statement-store/src/transport.ts
+++ b/product-sdk/packages/statement-store/src/transport.ts
@@ -12,7 +12,7 @@ import type { Statement, TopicFilter as SdkTopicFilter } from "@novasamatech/sdk
 import type {
     Statement as HostStatement,
     SignedStatement as HostSignedStatement,
-} from "@novasamatech/product-sdk";
+} from "@novasamatech/host-api-wrapper";
 
 const log = createLogger("statement-store:transport");
 

--- a/product-sdk/packages/statement-store/tsup.config.ts
+++ b/product-sdk/packages/statement-store/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     clean: true,
     target: "es2022",
     treeshake: true,
-    external: ["@novasamatech/sdk-statement", "@novasamatech/product-sdk"],
+    external: ["@novasamatech/sdk-statement", "@novasamatech/host-api-wrapper"],
     define: {
         "import.meta.vitest": "undefined",
     },

--- a/product-sdk/pending-changesets/novasama-product-sdk-rename.md
+++ b/product-sdk/pending-changesets/novasama-product-sdk-rename.md
@@ -1,0 +1,31 @@
+---
+"@parity/product-sdk": minor
+"@parity/product-sdk-host": minor
+"@parity/product-sdk-signer": minor
+"@parity/product-sdk-statement-store": minor
+---
+
+**Track upstream rename: `@novasamatech/product-sdk` → `@novasamatech/host-api-wrapper`.**
+
+Novasama renamed their host-API wrapper package from `@novasamatech/product-sdk` to `@novasamatech/host-api-wrapper`. The first release under the new name is `0.7.9-6` (a prerelease).
+
+### What changed for consumers
+
+If you install `@parity/product-sdk-host`, `@parity/product-sdk-signer`, or `@parity/product-sdk-statement-store` and were previously satisfying their optional peer dependency on `@novasamatech/product-sdk` manually, switch your direct install to `@novasamatech/host-api-wrapper` instead:
+
+```diff
+- "@novasamatech/product-sdk": "^0.7.8"
++ "@novasamatech/host-api-wrapper": "0.7.9-6"
+```
+
+Same upstream package, same exports (`hostApi`, `createAccountsProvider`, `preimageManager`, `hostLocalStorage`, etc.) — only the npm package name changed.
+
+If you don't install the peer directly (i.e. your bundle ships without the host-side wrapper), no action needed.
+
+### Catalog pin rationale
+
+The new package is currently only published as `0.7.9-6` (a prerelease). The catalog is pinned to exactly `0.7.9-6` rather than `^0.7.9-6` because prerelease ranges have surprising semver semantics and prereleases can be republished. The pin will move to `^0.7.9` once a stable lands; the catalog auto-bumper (`product-sdk-deps-check.yml`) will pick that up automatically.
+
+### Why minor
+
+Renaming an optional peer dependency is a consumer-visible change: anyone who satisfies our peer manually needs to update their own install. Per `RELEASES.md`'s pre-1.0 convention, that ships as `minor`.

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -9,9 +9,9 @@ catalogs:
     '@novasamatech/host-api':
       specifier: ^0.7.8
       version: 0.7.8
-    '@novasamatech/product-sdk':
-      specifier: ^0.7.8
-      version: 0.7.8
+    '@novasamatech/host-api-wrapper':
+      specifier: 0.7.9-6
+      version: 0.7.9-6
     '@novasamatech/sdk-statement':
       specifier: ^0.6.0
       version: 0.6.0
@@ -74,9 +74,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-bulletin':
         specifier: workspace:*
         version: link:../../packages/bulletin
@@ -111,9 +111,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -148,9 +148,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -185,9 +185,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -213,9 +213,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -263,9 +263,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
@@ -291,9 +291,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
@@ -319,9 +319,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -350,9 +350,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-address':
         specifier: workspace:*
         version: link:../../packages/address
@@ -541,9 +541,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -683,9 +683,9 @@ importers:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.7.8
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
 
   packages/statement-store:
     dependencies:
@@ -708,9 +708,9 @@ importers:
         specifier: 'catalog:'
         version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
-      '@novasamatech/product-sdk':
+      '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       tsup:
         specifier: 'catalog:'
         version: 8.5.0(postcss@8.5.10)(typescript@5.9.3)
@@ -1424,6 +1424,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@novasamatech/host-api-wrapper@0.7.9-6':
+    resolution: {integrity: sha512-iMVQ8WMF/olE7J7CdwEGmM1etTRFafulbZFIZXYe3z9A4vW8kEAw62jg8h2ybu+tzNlsTBOsFRamm6+80Q1h8Q==}
+
   '@novasamatech/host-api@0.7.7':
     resolution: {integrity: sha512-2aU6ZIZrfYkdRj39PP9+Rsg+hl5KlzjyC7dUsbcV4mepWtyHFYCCkt621Zg3TmCrT4oDJoY107DOxankB4UV3Q==}
 
@@ -1433,11 +1436,11 @@ packages:
   '@novasamatech/host-api@0.7.9-4':
     resolution: {integrity: sha512-bwDUWWGKgb4BUuVFjUOqNXLXfXjzO4+cwlZD7TXvVLSmd9DQnELjig4i5//hD8/a+jdgrnXa9loO2hfc/i05Jw==}
 
+  '@novasamatech/host-api@0.7.9-6':
+    resolution: {integrity: sha512-g6S7L9NuaNfb/2cxFOlm5TlcTGK9nErnqtmUzSnj3WDKeGlh5SzK2Iaw+0iLzJ8hQ1paQOdG+4DJu89NX8m9MA==}
+
   '@novasamatech/host-papp@0.7.7':
     resolution: {integrity: sha512-MhjJlnriKal5bDMEIk4SZsp4GKFZuK4IsPAvLnziQ2lwRJBnXIuPIut/OQDPB6IiBQVvFWQO8mKmZF9PX4EJ+A==}
-
-  '@novasamatech/product-sdk@0.7.8':
-    resolution: {integrity: sha512-oTuCJs4v9iig6nLxhfNewzJfcD9/iUjAQm0rSQF8p4G0ryMVQgDlezlW9AQd3AIn80mwwJKLdfa2nToSuqo1+Q==}
 
   '@novasamatech/scale@0.7.7':
     resolution: {integrity: sha512-t4qdnp9gsG8B0LoxKUWpOHB3JAy7/jS7n2vUn3ynPJDDBsKgbqg5GKfWD6QCRdDhtilzR6k9H0LpDS5yCLFvog==}
@@ -1447,6 +1450,9 @@ packages:
 
   '@novasamatech/scale@0.7.9-4':
     resolution: {integrity: sha512-wBBapBLskrRaKVMmRmzhn8SJl8gEifqxWdKL0eOmTFR/6GPl4EY5MjYO+5WLARFvLdFqQ4PBegx3TjZBBFNeYA==}
+
+  '@novasamatech/scale@0.7.9-6':
+    resolution: {integrity: sha512-QhsrCcMaWQj9VTt1JIoGlHQ0BlZwYs7BfVfCgaELRfq8GZ4WzmedLTjfJCPsl2SrawDlxkizON5AfEqgF3bs7w==}
 
   '@novasamatech/sdk-statement@0.6.0':
     resolution: {integrity: sha512-NTqM+yS45iHgy87lVSWIpFozrTfCUWb7r4ZpsDtN1eFnfixXpDKpPXDWQsvPs+nh18r/jmoMgtlTjUltrS6mYQ==}
@@ -3662,6 +3668,23 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@novasamatech/host-api-wrapper@0.7.9-6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
+    dependencies:
+      '@novasamatech/host-api': 0.7.9-6
+      '@polkadot-api/json-rpc-provider-proxy': 0.4.0
+      '@polkadot-api/substrate-bindings': 0.20.2
+      '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
+      neverthrow: 8.2.0
+      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@polkadot/api'
+      - '@polkadot/util'
+      - bufferutil
+      - esbuild
+      - rxjs
+      - supports-color
+      - utf-8-validate
+
   '@novasamatech/host-api@0.7.7':
     dependencies:
       '@novasamatech/scale': 0.7.7
@@ -3681,6 +3704,14 @@ snapshots:
   '@novasamatech/host-api@0.7.9-4':
     dependencies:
       '@novasamatech/scale': 0.7.9-4
+      nanoevents: 9.1.0
+      nanoid: 5.1.9
+      neverthrow: 8.2.0
+      scale-ts: 1.6.1
+
+  '@novasamatech/host-api@0.7.9-6':
+    dependencies:
+      '@novasamatech/scale': 0.7.9-6
       nanoevents: 9.1.0
       nanoid: 5.1.9
       neverthrow: 8.2.0
@@ -3709,38 +3740,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/product-sdk@0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)':
-    dependencies:
-      '@novasamatech/host-api': 0.7.8
-      '@polkadot-api/json-rpc-provider-proxy': 0.4.0
-      '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
-      neverthrow: 8.2.0
-      polkadot-api: 2.1.2(esbuild@0.25.12)(rxjs@7.8.2)
-    transitivePeerDependencies:
-      - '@polkadot/api'
-      - '@polkadot/util'
-      - bufferutil
-      - esbuild
-      - rxjs
-      - supports-color
-      - utf-8-validate
-
-  '@novasamatech/product-sdk@0.7.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
-    dependencies:
-      '@novasamatech/host-api': 0.7.8
-      '@polkadot-api/json-rpc-provider-proxy': 0.4.0
-      '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
-      neverthrow: 8.2.0
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
-    transitivePeerDependencies:
-      - '@polkadot/api'
-      - '@polkadot/util'
-      - bufferutil
-      - esbuild
-      - rxjs
-      - supports-color
-      - utf-8-validate
-
   '@novasamatech/scale@0.7.7':
     dependencies:
       '@polkadot-api/utils': 0.4.0
@@ -3752,6 +3751,11 @@ snapshots:
       scale-ts: 1.6.1
 
   '@novasamatech/scale@0.7.9-4':
+    dependencies:
+      '@polkadot-api/utils': 0.4.0
+      scale-ts: 1.6.1
+
+  '@novasamatech/scale@0.7.9-6':
     dependencies:
       '@polkadot-api/utils': 0.4.0
       scale-ts: 1.6.1
@@ -3812,41 +3816,6 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
-
-  '@polkadot-api/cli@0.21.1(esbuild@0.25.12)':
-    dependencies:
-      '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
-      '@polkadot-api/codegen': 0.22.4
-      '@polkadot-api/ink-contracts': 0.6.2
-      '@polkadot-api/json-rpc-provider': 0.2.0
-      '@polkadot-api/known-chains': 0.11.3
-      '@polkadot-api/metadata-compatibility': 0.6.2
-      '@polkadot-api/observable-client': 0.18.5(rxjs@7.8.2)
-      '@polkadot-api/sm-provider': 0.3.3(@polkadot-api/smoldot@0.4.2)
-      '@polkadot-api/smoldot': 0.4.2
-      '@polkadot-api/substrate-bindings': 0.20.2
-      '@polkadot-api/substrate-client': 0.7.0
-      '@polkadot-api/utils': 0.4.0
-      '@polkadot-api/wasm-executor': 0.2.3
-      '@polkadot-api/ws-middleware': 0.3.3(rxjs@7.8.2)
-      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
-      '@types/node': 25.6.0
-      commander: 14.0.3
-      execa: 9.6.1
-      fs.promises.exists: 1.1.4
-      ora: 9.4.0
-      read-pkg: 10.1.0
-      rollup: 4.60.3
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.60.3)
-      rxjs: 7.8.2
-      tsc-prog: 2.3.0(typescript@6.0.3)
-      typescript: 6.0.3
-      write-package: 7.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - esbuild
-      - supports-color
-      - utf-8-validate
 
   '@polkadot-api/cli@0.21.1(esbuild@0.27.7)':
     dependencies:
@@ -5215,34 +5184,6 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  polkadot-api@2.1.2(esbuild@0.25.12)(rxjs@7.8.2):
-    dependencies:
-      '@polkadot-api/cli': 0.21.1(esbuild@0.25.12)
-      '@polkadot-api/ink-contracts': 0.6.2
-      '@polkadot-api/json-rpc-provider': 0.2.0
-      '@polkadot-api/known-chains': 0.11.3
-      '@polkadot-api/logs-provider': 0.2.0
-      '@polkadot-api/metadata-builders': 0.14.2
-      '@polkadot-api/metadata-compatibility': 0.6.2
-      '@polkadot-api/observable-client': 0.18.5(rxjs@7.8.2)
-      '@polkadot-api/pjs-signer': 0.7.2
-      '@polkadot-api/polkadot-signer': 0.1.6
-      '@polkadot-api/signer': 0.3.2
-      '@polkadot-api/sm-provider': 0.3.3(@polkadot-api/smoldot@0.4.2)
-      '@polkadot-api/smoldot': 0.4.2
-      '@polkadot-api/substrate-bindings': 0.20.2
-      '@polkadot-api/substrate-client': 0.7.0
-      '@polkadot-api/utils': 0.4.0
-      '@polkadot-api/ws-middleware': 0.3.3(rxjs@7.8.2)
-      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
-      '@rx-state/core': 0.1.4(rxjs@7.8.2)
-      rxjs: 7.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - esbuild
-      - supports-color
-      - utf-8-validate
-
   polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2):
     dependencies:
       '@polkadot-api/cli': 0.21.1(esbuild@0.27.7)
@@ -5352,17 +5293,6 @@ snapshots:
       signal-exit: 4.1.0
 
   reusify@1.1.0: {}
-
-  rollup-plugin-esbuild@6.2.1(esbuild@0.25.12)(rollup@4.60.3):
-    dependencies:
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      esbuild: 0.25.12
-      get-tsconfig: 4.14.0
-      rollup: 4.60.3
-      unplugin-utils: 0.2.5
-    transitivePeerDependencies:
-      - supports-color
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.3):
     dependencies:

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   polkadot-api: ^2.1.2
-  "@novasamatech/product-sdk": ^0.7.8
+  "@novasamatech/host-api-wrapper": 0.7.9-6
   "@novasamatech/sdk-statement": ^0.6.0
   "@novasamatech/host-api": ^0.7.8
   "@polkadot-api/substrate-bindings": ^0.12.0


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  Upstream renamed `@novasamatech/product-sdk` → `@novasamatech/host-api-wrapper`. First release under the new name is `0.7.9-6` (prerelease). Catalog pinned exactly to `0.7.9-6` (no caret) — prerelease ranges have surprising semver semantics. 
  Will move to `^0.7.9` once a stable lands; auto-bumper picks that up.
                                                                                                                                                                                                                                                    
  Same upstream surface (`hostApi`, `createAccountsProvider`, `preimageManager`, `hostLocalStorage`) — only the npm name changed.                                                                                                                   
  
  Touches: catalog, all `package.json`s with the dep, dynamic imports, tsup externals, JSDoc, and skipped-spec TODO comments. CHANGELOGs left as historical records.                                                                                
                                                            
  Changeset bumps `-host`, `-signer`, `-statement-store`, and the umbrella as `minor` (peer-dep rename is consumer-visible). 