### PR TITLE
fix: contracts revert flag

### DIFF
--- a/product-sdk/packages/contracts/src/errors.ts
+++ b/product-sdk/packages/contracts/src/errors.ts
@@ -1,3 +1,5 @@
+import type { HexString } from "polkadot-api";
+
 /** Base class for all contract errors. Use `instanceof ContractError` to catch any contract-related error. */
 export class ContractError extends Error {
     constructor(message: string, options?: ErrorOptions) {
@@ -55,6 +57,63 @@ export class ContractDryRunFailedError extends ContractError {
     }
 }
 
+/** viem-decoded standard or ABI-defined contract error. */
+export interface DecodedContractRevert {
+    errorName: string;
+    args: readonly unknown[] | undefined;
+}
+
+/**
+ * Tagged-enum value surfaced on `QueryResult.value` when a contract reverts
+ * via the REVERT flag. The discriminant is intentionally distinct from
+ * `pallet-revive`'s bare `{ type: "ContractReverted" }` dispatch-error variant,
+ * which is the other path that can populate `QueryResult.value` on failure.
+ */
+export interface ContractRevertInfo {
+    type: "ContractRevertedWithPayload";
+    data: HexString;
+    reason?: string;
+    decoded?: DecodedContractRevert;
+}
+
+// Top-level bigints stringify unquoted (`42`); bigints inside an object or
+// array stringify as JSON strings (`"42"`) because that's the only way a
+// JSON replacer can emit them. Tolerated since this string is only ever
+// read by humans in an error message, not parsed.
+function stringifyArg(arg: unknown): string {
+    if (typeof arg === "bigint") return arg.toString();
+    return JSON.stringify(arg, (_, v) => (typeof v === "bigint" ? v.toString() : v));
+}
+
+/** A contract call returned with the `REVERT` flag set on a dispatched-OK call. */
+export class ContractRevertedError extends ContractError {
+    readonly methodName: string;
+    readonly data: HexString;
+    readonly reason?: string;
+    readonly decoded?: DecodedContractRevert;
+
+    constructor(
+        methodName: string,
+        data: HexString,
+        info?: { reason?: string; decoded?: DecodedContractRevert },
+    ) {
+        // `Error(string)` is the canonical "revert with a message" path -
+        // print the bare reason rather than `Error("...")` for readability.
+        const suffix =
+            info?.decoded && info.decoded.errorName !== "Error"
+                ? `${info.decoded.errorName}(${(info.decoded.args ?? []).map(stringifyArg).join(", ")})`
+                : (info?.reason ?? data);
+        super(
+            `Contract reverted in "${methodName}": ${suffix}. The transaction was not submitted.`,
+        );
+        this.name = "ContractRevertedError";
+        this.methodName = methodName;
+        this.data = data;
+        this.reason = info?.reason;
+        this.decoded = info?.decoded;
+    }
+}
+
 if (import.meta.vitest) {
     const { test, expect, describe } = import.meta.vitest;
 
@@ -69,6 +128,9 @@ if (import.meta.vitest) {
             expect(new ContractSignerMissingError()).toBeInstanceOf(ContractError);
             expect(new ContractNotFoundError("@a/b", "abc")).toBeInstanceOf(ContractError);
             expect(new ContractDryRunFailedError("foo", "x")).toBeInstanceOf(ContractError);
+            expect(new ContractRevertedError("foo", "0x" as HexString)).toBeInstanceOf(
+                ContractError,
+            );
         });
     });
 
@@ -106,6 +168,57 @@ if (import.meta.vitest) {
             const err = new ContractDryRunFailedError("foo", "ContractReverted");
             expect(err.message).toContain("ContractReverted");
             expect(err.message).not.toContain('"ContractReverted"');
+        });
+    });
+
+    describe("ContractRevertedError", () => {
+        test("captures method, raw data, reason, and decoded payload", () => {
+            const data = "0x556e617574686f72697a6564" as HexString;
+            const err = new ContractRevertedError("transfer", data, {
+                reason: "Unauthorized",
+                decoded: { errorName: "Error", args: ["Unauthorized"] },
+            });
+            expect(err.name).toBe("ContractRevertedError");
+            expect(err.methodName).toBe("transfer");
+            expect(err.data).toBe(data);
+            expect(err.reason).toBe("Unauthorized");
+            expect(err.decoded?.errorName).toBe("Error");
+            expect(err.message).toContain("transfer");
+            expect(err.message).toContain("Unauthorized");
+            expect(err.message).toContain("not submitted");
+            // Error(string) prefers the bare reason over `Error("...")` form.
+            expect(err.message).not.toContain('Error("');
+        });
+
+        test("falls back to reason then to raw data when decoded is absent", () => {
+            const data = "0xdeadbeef" as HexString;
+            const withReason = new ContractRevertedError("foo", data, { reason: "Whoops" });
+            expect(withReason.message).toContain("Whoops");
+
+            const noInfo = new ContractRevertedError("foo", data);
+            expect(noInfo.message).toContain("0xdeadbeef");
+            expect(noInfo.reason).toBeUndefined();
+            expect(noInfo.decoded).toBeUndefined();
+        });
+
+        test("stringifies top-level bigint args without throwing", () => {
+            const err = new ContractRevertedError("bar", "0x" as HexString, {
+                decoded: { errorName: "InsufficientBalance", args: [42n, 100n] },
+            });
+            expect(err.message).toContain("InsufficientBalance(42, 100)");
+        });
+
+        test("stringifies nested bigint args inside a struct without throwing", () => {
+            // viem returns `[{ owed: 42n }]` for struct args; the default
+            // JSON.stringify replacer would throw on the nested bigint.
+            const err = new ContractRevertedError("redeem", "0x" as HexString, {
+                decoded: {
+                    errorName: "Bad",
+                    args: [{ owed: 42n, nested: { deeper: [7n, 9n] } }],
+                },
+            });
+            expect(err.message).toContain('"owed":"42"');
+            expect(err.message).toContain('"deeper":["7","9"]');
         });
     });
 }

--- a/product-sdk/packages/contracts/src/errors.ts
+++ b/product-sdk/packages/contracts/src/errors.ts
@@ -183,11 +183,10 @@ if (import.meta.vitest) {
             expect(err.data).toBe(data);
             expect(err.reason).toBe("Unauthorized");
             expect(err.decoded?.errorName).toBe("Error");
-            expect(err.message).toContain("transfer");
-            expect(err.message).toContain("Unauthorized");
-            expect(err.message).toContain("not submitted");
             // Error(string) prefers the bare reason over `Error("...")` form.
-            expect(err.message).not.toContain('Error("');
+            expect(err.message).toBe(
+                'Contract reverted in "transfer": Unauthorized. The transaction was not submitted.',
+            );
         });
 
         test("falls back to reason then to raw data when decoded is absent", () => {

--- a/product-sdk/packages/contracts/src/errors.ts
+++ b/product-sdk/packages/contracts/src/errors.ts
@@ -97,12 +97,13 @@ export class ContractRevertedError extends ContractError {
         data: HexString,
         info?: { reason?: string; decoded?: DecodedContractRevert },
     ) {
-        // `Error(string)` is the canonical "revert with a message" path -
-        // print the bare reason rather than `Error("...")` for readability.
+        // `reason` already carries the human-readable message for Error and Panic,
+        // so only fall back to `errorName(args...)` for ABI-defined custom errors.
         const suffix =
-            info?.decoded && info.decoded.errorName !== "Error"
+            info?.reason ??
+            (info?.decoded
                 ? `${info.decoded.errorName}(${(info.decoded.args ?? []).map(stringifyArg).join(", ")})`
-                : (info?.reason ?? data);
+                : data);
         super(
             `Contract reverted in "${methodName}": ${suffix}. The transaction was not submitted.`,
         );
@@ -218,6 +219,16 @@ if (import.meta.vitest) {
             });
             expect(err.message).toContain('"owed":"42"');
             expect(err.message).toContain('"deeper":["7","9"]');
+        });
+
+        test("uses the Panic reason instead of Panic(<code>) when decodeRevert provided one", () => {
+            // Regression: Panic reason used to be clobbered by the errorName(args) form.
+            const err = new ContractRevertedError("withdraw", "0x" as HexString, {
+                reason: "Panic: arithmetic overflow",
+                decoded: { errorName: "Panic", args: [17n] },
+            });
+            expect(err.message).toContain("Panic: arithmetic overflow");
+            expect(err.message).not.toContain("Panic(17)");
         });
     });
 }

--- a/product-sdk/packages/contracts/src/index.ts
+++ b/product-sdk/packages/contracts/src/index.ts
@@ -30,7 +30,9 @@ export {
     ContractSignerMissingError,
     ContractNotFoundError,
     ContractDryRunFailedError,
+    ContractRevertedError,
 } from "./errors.js";
+export type { ContractRevertInfo, DecodedContractRevert } from "./errors.js";
 export type {
     CdmJson,
     CdmJsonTarget,

--- a/product-sdk/packages/contracts/src/wrap.ts
+++ b/product-sdk/packages/contracts/src/wrap.ts
@@ -1,5 +1,6 @@
 import type { HexString, PolkadotSigner, SS58String } from "polkadot-api";
 import {
+    bytesToHex,
     decodeErrorResult,
     decodeFunctionResult,
     encodeFunctionData,
@@ -111,15 +112,6 @@ function hexToBytes(hex: HexString): Uint8Array {
     return out;
 }
 
-/** Convert a `Uint8Array` to a `0x`-prefixed hex string. */
-function bytesToHex(bytes: Uint8Array): HexString {
-    let hex = "0x";
-    for (let i = 0; i < bytes.byteLength; i++) {
-        hex += bytes[i].toString(16).padStart(2, "0");
-    }
-    return hex as HexString;
-}
-
 // Bit 0 of `pallet-revive`'s `ReturnFlags`. Other bits are reserved, so we
 // mask explicitly rather than checking `flags !== 0`.
 const REVERT_FLAG = 1;
@@ -138,10 +130,21 @@ const PANIC_REASONS: Record<string, string> = {
     "0x51": "call to uninitialized internal function",
 };
 
-/** Decode a revert payload via the ABI, falling back to UTF-8 for raw `revert(bytes)` strings. */
+/**
+ * Adapt viem's `decodeErrorResult` output into our tagged `ContractRevertInfo`.
+ * The core decode is viem's; this wrapper layers in a UTF-8 fallback for raw
+ * `revert(bytes)` payloads and the panic-code-to-string mapping. viem's own
+ * `panicReasons` and `ContractFunctionRevertedError` are unsuitable here:
+ * `panicReasons` sits at `viem/constants/solidity` and isn't surfaced by
+ * viem's `exports` map, and `ContractFunctionRevertedError` is shaped for
+ * viem's call pipeline and would need adapting back into this shape anyway.
+ */
 function decodeRevert(abi: AbiEntry[], data: Uint8Array): ContractRevertInfo {
     const hex = bytesToHex(data);
-    const info: ContractRevertInfo = { type: "ContractRevertedWithPayload", data: hex };
+    const info: ContractRevertInfo = {
+        type: "ContractRevertedWithPayload",
+        data: hex as HexString,
+    };
     if (data.byteLength === 0) return info;
     try {
         // The ABI path wins even if a raw `revert(bytes)` payload happens to
@@ -149,7 +152,7 @@ function decodeRevert(abi: AbiEntry[], data: Uint8Array): ContractRevertInfo {
         // chains, but worth flagging for anyone debugging an oddly-decoded revert.
         const decoded = decodeErrorResult({
             abi: abi as unknown as ViemAbi,
-            data: hex as `0x${string}`,
+            data: hex,
         });
         info.decoded = {
             errorName: decoded.errorName,
@@ -200,7 +203,7 @@ function decodeReturn(abi: AbiEntry[], methodName: string, returnData: Uint8Arra
     const decoded = decodeFunctionResult({
         abi: abi as unknown as ViemAbi,
         functionName: methodName,
-        data: bytesToHex(returnData) as `0x${string}`,
+        data: bytesToHex(returnData),
     });
 
     const entry = abi.find((e) => e.type === "function" && e.name === methodName);

--- a/product-sdk/packages/contracts/src/wrap.ts
+++ b/product-sdk/packages/contracts/src/wrap.ts
@@ -1,10 +1,20 @@
 import type { HexString, PolkadotSigner, SS58String } from "polkadot-api";
-import { encodeFunctionData, decodeFunctionResult, type Abi as ViemAbi } from "viem";
+import {
+    decodeErrorResult,
+    decodeFunctionResult,
+    encodeFunctionData,
+    type Abi as ViemAbi,
+} from "viem";
 import { submitAndWatch } from "@parity/product-sdk-tx";
 import { seedToAccount } from "@parity/product-sdk-keys";
 import { createLogger } from "@parity/product-sdk-logger";
 import { DEV_PHRASE, ss58Address } from "@polkadot-labs/hdkd-helpers";
-import { ContractSignerMissingError, ContractDryRunFailedError } from "./errors.js";
+import {
+    ContractDryRunFailedError,
+    ContractRevertedError,
+    ContractSignerMissingError,
+    type ContractRevertInfo,
+} from "./errors.js";
 import type { ContractRuntime } from "./runtime.js";
 import type { BatchableCall, SubmittableTransaction } from "@parity/product-sdk-tx";
 import type {
@@ -101,6 +111,67 @@ function hexToBytes(hex: HexString): Uint8Array {
     return out;
 }
 
+/** Convert a `Uint8Array` to a `0x`-prefixed hex string. */
+function bytesToHex(bytes: Uint8Array): HexString {
+    let hex = "0x";
+    for (let i = 0; i < bytes.byteLength; i++) {
+        hex += bytes[i].toString(16).padStart(2, "0");
+    }
+    return hex as HexString;
+}
+
+// Bit 0 of `pallet-revive`'s `ReturnFlags`. Other bits are reserved, so we
+// mask explicitly rather than checking `flags !== 0`.
+const REVERT_FLAG = 1;
+
+// Solidity panic codes that `Panic(uint256)` can carry. Stable across compiler
+// versions; mapping them to a human-readable name beats showing the raw hex.
+const PANIC_REASONS: Record<string, string> = {
+    "0x01": "assertion failed",
+    "0x11": "arithmetic overflow",
+    "0x12": "division by zero",
+    "0x21": "invalid enum value",
+    "0x22": "improperly encoded storage byte array",
+    "0x31": "pop on empty array",
+    "0x32": "array index out of bounds",
+    "0x41": "memory allocation overflow",
+    "0x51": "call to uninitialized internal function",
+};
+
+/** Decode a revert payload via the ABI, falling back to UTF-8 for raw `revert(bytes)` strings. */
+function decodeRevert(abi: AbiEntry[], data: Uint8Array): ContractRevertInfo {
+    const hex = bytesToHex(data);
+    const info: ContractRevertInfo = { type: "ContractRevertedWithPayload", data: hex };
+    if (data.byteLength === 0) return info;
+    try {
+        // The ABI path wins even if a raw `revert(bytes)` payload happens to
+        // start with `0x08c379a0` / `0x4e487b71` - astronomically rare on real
+        // chains, but worth flagging for anyone debugging an oddly-decoded revert.
+        const decoded = decodeErrorResult({
+            abi: abi as unknown as ViemAbi,
+            data: hex as `0x${string}`,
+        });
+        info.decoded = {
+            errorName: decoded.errorName,
+            args: decoded.args as readonly unknown[] | undefined,
+        };
+        if (decoded.errorName === "Error" && typeof decoded.args?.[0] === "string") {
+            info.reason = decoded.args[0];
+        } else if (decoded.errorName === "Panic" && typeof decoded.args?.[0] === "bigint") {
+            const code = `0x${decoded.args[0].toString(16).padStart(2, "0")}`;
+            info.reason = PANIC_REASONS[code] ? `Panic: ${PANIC_REASONS[code]}` : `Panic(${code})`;
+        }
+        return info;
+    } catch {
+        try {
+            info.reason = new TextDecoder("utf-8", { fatal: true }).decode(data);
+        } catch {
+            // Opaque bytes; expose only the raw hex.
+        }
+        return info;
+    }
+}
+
 /**
  * Encode the calldata for a contract method using the Solidity ABI codec.
  * Returns `selector ‖ head ‖ tail` as a `0x`-prefixed hex string.
@@ -126,14 +197,10 @@ function encodeCalldata(abi: AbiEntry[], methodName: string, args: unknown[]): `
  */
 function decodeReturn(abi: AbiEntry[], methodName: string, returnData: Uint8Array): unknown {
     if (returnData.byteLength === 0) return undefined;
-    let hex = "0x";
-    for (let i = 0; i < returnData.byteLength; i++) {
-        hex += returnData[i].toString(16).padStart(2, "0");
-    }
     const decoded = decodeFunctionResult({
         abi: abi as unknown as ViemAbi,
         functionName: methodName,
-        data: hex as `0x${string}`,
+        data: bytesToHex(returnData) as `0x${string}`,
     });
 
     const entry = abi.find((e) => e.type === "function" && e.name === methodName);
@@ -174,6 +241,9 @@ async function buildReviveCall(
 
     let weightLimit = overrides?.gasLimit;
     let storageDepositLimit = overrides?.storageDepositLimit;
+    // Passing both overrides skips the dry-run entirely - including the REVERT
+    // pre-check. Callers who supply both are accepting that a reverting tx
+    // would still be submitted and gas paid.
     if (weightLimit === undefined || storageDepositLimit === undefined) {
         const dryRun = await runtime.dryRunCall(
             origin,
@@ -185,6 +255,11 @@ async function buildReviveCall(
         );
         if (!dryRun.result.success) {
             throw new ContractDryRunFailedError(methodName, dryRun.result.value);
+        }
+        if ((dryRun.result.value.flags & REVERT_FLAG) !== 0) {
+            // Fail fast so callers don't pay gas on a call the chain already told us would revert.
+            const { data, reason, decoded } = decodeRevert(abi, dryRun.result.value.data);
+            throw new ContractRevertedError(methodName, data, { reason, decoded });
         }
         weightLimit = weightLimit ?? dryRun.weight_required;
         if (storageDepositLimit === undefined) {
@@ -257,6 +332,15 @@ export function wrapContract(
                         return {
                             success: false,
                             value: dryRun.result.value,
+                            gasRequired: dryRun.weight_required,
+                        };
+                    }
+
+                    if ((dryRun.result.value.flags & REVERT_FLAG) !== 0) {
+                        // Surface as a tagged value; decoding revert bytes as a normal return would throw.
+                        return {
+                            success: false,
+                            value: decodeRevert(abi, dryRun.result.value.data),
                             gasRequired: dryRun.weight_required,
                         };
                     }
@@ -1318,6 +1402,286 @@ if (import.meta.vitest) {
 
             expect(result.ok).toBe(true);
             expect(batchCalls).toEqual(decodedCalls);
+        });
+    });
+
+    describe("decodeRevert", () => {
+        const abi: AbiEntry[] = [
+            {
+                type: "error",
+                name: "InsufficientBalance",
+                inputs: [
+                    { name: "needed", type: "uint256" },
+                    { name: "available", type: "uint256" },
+                ],
+            },
+        ];
+
+        test("decodes a standard Error(string) revert and lifts the reason", () => {
+            // 0x08c379a0 selector + ABI-encoded "Whoops".
+            const hex =
+                "0x08c379a0" +
+                "0000000000000000000000000000000000000000000000000000000000000020" +
+                "0000000000000000000000000000000000000000000000000000000000000006" +
+                "57686f6f70730000000000000000000000000000000000000000000000000000";
+            const bytes = hexToBytes(hex as HexString);
+            const info = decodeRevert([], bytes);
+            expect(info.type).toBe("ContractRevertedWithPayload");
+            expect(info.reason).toBe("Whoops");
+            expect(info.decoded?.errorName).toBe("Error");
+        });
+
+        test("decodes Panic(uint256) and names well-known codes", () => {
+            // 0x4e487b71 selector + panic code 0x11 (arithmetic overflow).
+            const hex = `0x4e487b71${"00".repeat(31)}11`;
+            const info = decodeRevert([], hexToBytes(hex as HexString));
+            expect(info.decoded?.errorName).toBe("Panic");
+            expect(info.reason).toBe("Panic: arithmetic overflow");
+        });
+
+        test("decodes Panic(uint256) for unknown codes by falling back to the hex code", () => {
+            // 0x4e487b71 selector + panic code 0xff (not a Solidity-defined code).
+            const hex = `0x4e487b71${"00".repeat(31)}ff`;
+            const info = decodeRevert([], hexToBytes(hex as HexString));
+            expect(info.decoded?.errorName).toBe("Panic");
+            expect(info.reason).toBe("Panic(0xff)");
+        });
+
+        test("decodes an ABI-defined custom error", () => {
+            // InsufficientBalance(uint256,uint256) selector + (1, 2).
+            const hex =
+                "0xcf479181" +
+                "0000000000000000000000000000000000000000000000000000000000000001" +
+                "0000000000000000000000000000000000000000000000000000000000000002";
+            const info = decodeRevert(abi, hexToBytes(hex as HexString));
+            expect(info.decoded?.errorName).toBe("InsufficientBalance");
+            expect(info.decoded?.args).toEqual([1n, 2n]);
+            expect(info.reason).toBeUndefined();
+        });
+
+        test("falls back to a UTF-8 reason on raw revert(bytes) payloads", () => {
+            const bytes = hexToBytes("0x556e617574686f72697a6564" as HexString);
+            const info = decodeRevert([], bytes);
+            expect(info.decoded).toBeUndefined();
+            expect(info.reason).toBe("Unauthorized");
+            expect(info.data).toBe("0x556e617574686f72697a6564");
+        });
+
+        test("leaves reason undefined for opaque non-UTF8 bytes", () => {
+            const info = decodeRevert([], new Uint8Array([0xff, 0xfe, 0xfd]));
+            expect(info.decoded).toBeUndefined();
+            expect(info.reason).toBeUndefined();
+            expect(info.data).toBe("0xfffefd");
+        });
+
+        test("empty payload produces a bare ContractRevertedWithPayload with no extras", () => {
+            const info = decodeRevert([], new Uint8Array(0));
+            expect(info).toEqual({ type: "ContractRevertedWithPayload", data: "0x" });
+        });
+    });
+
+    describe("wrapContract — REVERT flag handling", () => {
+        const abi: AbiEntry[] = [
+            {
+                type: "function",
+                name: "transfer",
+                inputs: [
+                    { name: "to", type: "address" },
+                    { name: "amount", type: "uint256" },
+                ],
+                outputs: [{ name: "", type: "bool" }],
+                stateMutability: "nonpayable",
+            },
+            {
+                type: "function",
+                name: "ping",
+                inputs: [],
+                outputs: [],
+                stateMutability: "nonpayable",
+            },
+        ];
+        const ADDRESS = "0x0102030405060708090a0b0c0d0e0f1011121314";
+        const ORIGIN = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY" as SS58String;
+        const fakeSigner = {
+            publicKey: new Uint8Array(32),
+        } as unknown as PolkadotSigner;
+
+        const REVERT_PAYLOAD = hexToBytes("0x556e617574686f72697a6564" as HexString);
+
+        function revertingRuntime(data: Uint8Array = REVERT_PAYLOAD): ContractRuntime {
+            return {
+                api: {
+                    tx: {
+                        Revive: {
+                            call: () => {
+                                throw new Error(
+                                    "Revive.call must NOT be invoked when the dry-run reverts",
+                                );
+                            },
+                        },
+                    },
+                } as unknown as ContractRuntime["api"],
+                dryRunCall: async () => ({
+                    weight_consumed: { ref_time: 0n, proof_size: 0n },
+                    weight_required: { ref_time: 5n, proof_size: 5n },
+                    storage_deposit: { type: "Refund", value: 0n },
+                    max_storage_deposit: { type: "Refund", value: 0n },
+                    gas_consumed: 0n,
+                    result: {
+                        success: true,
+                        value: { flags: 1, data },
+                    },
+                }),
+            };
+        }
+
+        test("query() returns success:false with a ContractReverted value when REVERT bit is set", async () => {
+            const wrapped = wrapContract(revertingRuntime(), ADDRESS, abi, {
+                signer: fakeSigner,
+                origin: ORIGIN,
+            });
+
+            const result = await (
+                wrapped as unknown as {
+                    transfer: {
+                        query: (
+                            to: string,
+                            amount: bigint,
+                        ) => Promise<{ success: boolean; value: unknown; gasRequired: unknown }>;
+                    };
+                }
+            ).transfer.query("0x0000000000000000000000000000000000000001", 1n);
+
+            expect(result.success).toBe(false);
+            expect(result.value).toEqual({
+                type: "ContractRevertedWithPayload",
+                data: "0x556e617574686f72697a6564",
+                reason: "Unauthorized",
+            });
+            expect(result.gasRequired).toEqual({ ref_time: 5n, proof_size: 5n });
+        });
+
+        test("query() handles an empty revert payload end-to-end (revert with no message)", async () => {
+            const wrapped = wrapContract(revertingRuntime(new Uint8Array(0)), ADDRESS, abi, {
+                signer: fakeSigner,
+                origin: ORIGIN,
+            });
+            const result = await (
+                wrapped as unknown as {
+                    ping: {
+                        query: () => Promise<{ success: boolean; value: unknown }>;
+                    };
+                }
+            ).ping.query();
+
+            expect(result.success).toBe(false);
+            expect(result.value).toEqual({ type: "ContractRevertedWithPayload", data: "0x" });
+        });
+
+        test("tx() throws ContractRevertedError before signing when the dry-run reverts", async () => {
+            const wrapped = wrapContract(revertingRuntime(), ADDRESS, abi, {
+                signer: fakeSigner,
+                origin: ORIGIN,
+            });
+
+            await expect(
+                (
+                    wrapped as unknown as {
+                        transfer: {
+                            tx: (to: string, amount: bigint) => Promise<unknown>;
+                        };
+                    }
+                ).transfer.tx("0x0000000000000000000000000000000000000001", 1n),
+            ).rejects.toMatchObject({
+                name: "ContractRevertedError",
+                methodName: "transfer",
+                data: "0x556e617574686f72697a6564",
+                reason: "Unauthorized",
+            });
+        });
+
+        test("prepare() throws ContractRevertedError before constructing the extrinsic", async () => {
+            const wrapped = wrapContract(revertingRuntime(), ADDRESS, abi, {});
+
+            await expect(
+                (
+                    wrapped as unknown as {
+                        transfer: {
+                            prepare: (to: string, amount: bigint) => Promise<unknown>;
+                        };
+                    }
+                ).transfer.prepare("0x0000000000000000000000000000000000000001", 1n),
+            ).rejects.toMatchObject({
+                name: "ContractRevertedError",
+                methodName: "transfer",
+                reason: "Unauthorized",
+            });
+        });
+
+        test("revert with a standard Error(string) payload lifts the reason", async () => {
+            // Solidity `require(false, "nope")`.
+            const errorBytes = hexToBytes(
+                ("0x08c379a0" +
+                    "0000000000000000000000000000000000000000000000000000000000000020" +
+                    "0000000000000000000000000000000000000000000000000000000000000004" +
+                    "6e6f706500000000000000000000000000000000000000000000000000000000") as HexString,
+            );
+            const runtime: ContractRuntime = {
+                api: {} as unknown as ContractRuntime["api"],
+                dryRunCall: async () => ({
+                    weight_consumed: { ref_time: 0n, proof_size: 0n },
+                    weight_required: { ref_time: 1n, proof_size: 1n },
+                    storage_deposit: { type: "Refund", value: 0n },
+                    max_storage_deposit: { type: "Refund", value: 0n },
+                    gas_consumed: 0n,
+                    result: { success: true, value: { flags: 1, data: errorBytes } },
+                }),
+            };
+            const wrapped = wrapContract(runtime, ADDRESS, abi, {
+                signer: fakeSigner,
+                origin: ORIGIN,
+            });
+            const result = await (
+                wrapped as unknown as {
+                    transfer: {
+                        query: (
+                            to: string,
+                            amount: bigint,
+                        ) => Promise<{ success: boolean; value: { reason?: string } }>;
+                    };
+                }
+            ).transfer.query("0x0000000000000000000000000000000000000001", 1n);
+            expect(result.success).toBe(false);
+            expect(result.value.reason).toBe("nope");
+        });
+
+        test("REVERT bit cleared stays on the happy path - normal return value is decoded", async () => {
+            const returnBytes = new Uint8Array(32);
+            returnBytes[31] = 1; // bool true
+            const runtime: ContractRuntime = {
+                api: {} as unknown as ContractRuntime["api"],
+                dryRunCall: async () => ({
+                    weight_consumed: { ref_time: 0n, proof_size: 0n },
+                    weight_required: { ref_time: 1n, proof_size: 1n },
+                    storage_deposit: { type: "Refund", value: 0n },
+                    max_storage_deposit: { type: "Refund", value: 0n },
+                    gas_consumed: 0n,
+                    result: { success: true, value: { flags: 0, data: returnBytes } },
+                }),
+            };
+            const wrapped = wrapContract(runtime, ADDRESS, abi, { origin: ORIGIN });
+            const result = await (
+                wrapped as unknown as {
+                    transfer: {
+                        query: (
+                            to: string,
+                            amount: bigint,
+                        ) => Promise<{ success: boolean; value: unknown }>;
+                    };
+                }
+            ).transfer.query("0x0000000000000000000000000000000000000001", 1n);
+            expect(result.success).toBe(true);
+            expect(result.value).toBe(true);
         });
     });
 }

--- a/product-sdk/packages/contracts/src/wrap.ts
+++ b/product-sdk/packages/contracts/src/wrap.ts
@@ -262,6 +262,7 @@ async function buildReviveCall(
         if ((dryRun.result.value.flags & REVERT_FLAG) !== 0) {
             // Fail fast so callers don't pay gas on a call the chain already told us would revert.
             const { data, reason, decoded } = decodeRevert(abi, dryRun.result.value.data);
+            log.debug("Contract reverted", { methodName, reason, errorName: decoded?.errorName });
             throw new ContractRevertedError(methodName, data, { reason, decoded });
         }
         weightLimit = weightLimit ?? dryRun.weight_required;
@@ -341,9 +342,15 @@ export function wrapContract(
 
                     if ((dryRun.result.value.flags & REVERT_FLAG) !== 0) {
                         // Surface as a tagged value; decoding revert bytes as a normal return would throw.
+                        const info = decodeRevert(abi, dryRun.result.value.data);
+                        log.debug("Contract reverted", {
+                            methodName,
+                            reason: info.reason,
+                            errorName: info.decoded?.errorName,
+                        });
                         return {
                             success: false,
-                            value: decodeRevert(abi, dryRun.result.value.data),
+                            value: info,
                             gasRequired: dryRun.weight_required,
                         };
                     }

--- a/product-sdk/skills/product-sdk-contracts/SKILL.md
+++ b/product-sdk/skills/product-sdk-contracts/SKILL.md
@@ -87,7 +87,7 @@ Each method on a contract handle has two variants:
 
 ```typescript
 const result = await counter.getCount.query();
-// result.value contains the return value
+// result.value contains the return value on success
 // No transaction, no gas cost
 ```
 
@@ -98,6 +98,18 @@ const result = await counter.getCount.query({
     origin: "0x...",  // Override caller address
 });
 ```
+
+**Reverts.** `query()` does NOT throw on a contract revert — it returns
+`{ success: false, value, gasRequired }`. Two failure shapes are possible:
+
+- Dispatch-level failures from the chain (e.g. `{ type: "ContractReverted" }`,
+  `{ type: "AccountNotMapped" }`, `{ type: "Module", ... }`) — passed through
+  on `value` as-is.
+- Contract-level reverts (REVERT flag set on a dispatched-OK call) — surfaced
+  as a tagged payload: `{ type: "ContractRevertedWithPayload", data, reason?, decoded? }`.
+  `reason` is the decoded `Error(string)` message or a mapped `Panic` description;
+  `decoded` carries the viem-decoded `{ errorName, args }` for ABI-defined custom
+  errors. Discriminate on `value.type` to tell the two failure paths apart.
 
 ### tx() — State-Changing Transactions
 
@@ -116,6 +128,13 @@ const result = await counter.increment.tx({
     onStatus: (status) => console.log(status),
 });
 ```
+
+**Pre-flight revert detection.** Before submitting, `tx()` runs a dry-run. If
+the chain reports the REVERT flag is set, `tx()` throws `ContractRevertedError`
+and the extrinsic is NOT submitted (no gas paid). The error carries `methodName`,
+the raw `data`, and the same `reason` / `decoded` fields as the query payload.
+Passing both `gasLimit` AND `storageDepositLimit` in options skips the dry-run
+entirely — including this revert pre-check.
 
 ## SignerManager Integration
 
@@ -236,6 +255,10 @@ const counter = createContract(runtime, "0x...", abi, { signerManager });
 3. **Wrong signer type** — Contract transactions need a `PolkadotSigner`. Don't confuse with `StatementSignerWithKey` (for statement-store).
 
 4. **Forgetting await** — Both `ContractManager.fromClient()` and `createContractFromClient()` return Promises.
+
+5. **Assuming `tx()` only fails for signer/dispatch reasons** — `tx()` also throws `ContractRevertedError` when the dry-run shows the contract would revert. Catch it (or its base `ContractError`) if you're surfacing revert reasons to users.
+
+6. **Assuming `query()` throws on revert** — It doesn't. Reverts come back as `{ success: false, value: { type: "ContractRevertedWithPayload", ... } }`. Always check `success` before reading `value` as the return type.
 
 ## Reference Files
 


### PR DESCRIPTION
## Summary

Fixes #111. `@parity/product-sdk-contracts` was ignoring the `REVERT` bit on `ReviveApi.call`'s success payload, so a contract-level revert looked like a normal return to the SDK:

- `.query()` handed the revert bytes to viem's ABI decoder, which usually threw `AbiDecodingDataSizeTooSmallError` rather than reporting the revert.
- `.tx()` / `.prepare()` built and submitted the extrinsic, letting users pay gas on a call the chain had already simulated as reverting.

Both code paths now check `(flags & REVERT_FLAG) !== 0` after the existing `success: false` branch and surface the revert as a structured result.

## What changed

- **`.query()`** returns `{ success: false, value: { type: "ContractRevertedWithPayload", data, reason?, decoded? }, gasRequired }` on a revert. The discriminant is intentionally distinct from `pallet-revive`'s existing bare `{ type: "ContractReverted" }` dispatch-error variant (which can also land on `QueryResult.value` on failure) so callers can narrow on `value.type` without ambiguity between the two failure modes.
- **`.tx()` / `.prepare()`** throw a new `ContractRevertedError` from the same pre-flight dry-run that already throws `ContractDryRunFailedError`. The transaction is never submitted. *Caveat:* if a caller passes both `gasLimit` and `storageDepositLimit` overrides, the dry-run (and thus the REVERT pre-check) is skipped entirely — preserving the pre-existing behavior that override-everything callers accept the gas cost of a potentially-reverting tx.
- **Revert decoding** tries viem's `decodeErrorResult` against the contract's ABI first — recovers `Error(string)`, `Panic(uint256)`, and custom ABI errors. Well-known Solidity panic codes (`0x01` assertion, `0x11` overflow, `0x12` div-by-zero, …) are mapped to readable strings — error messages read `Panic: arithmetic overflow` instead of `Panic(0x11)`. Falls back to a strict UTF-8 decode for raw `revert(bytes)` payloads (the issue's `0x556e617574686f72697a6564` → `"Unauthorized"`). Raw bytes are always exposed via `data` regardless.
- **Error message ergonomics.** When the decoded error is the canonical `Error(string)`, `ContractRevertedError.message` prints the bare reason (`Contract reverted in "transfer": Unauthorized`) rather than the redundant `Error("Unauthorized")` form. Custom errors keep the `Name(args)` form.
- **Flag check is masked, not `!== 0`.** Only bit 0 of `ReturnFlags` is the REVERT signal; other bits are reserved. A bare `!== 0` would false-positive a successful return if `pallet-revive` ever sets a non-revert bit.

## New exports

- `ContractRevertedError` (extends `ContractError`) — `methodName` / `data: HexString` / `reason?: string` / `decoded?: { errorName, args }`
- `ContractRevertInfo` type — the `value` shape on a reverted query result (`type: "ContractRevertedWithPayload"`)
- `DecodedContractRevert` type — viem-decoded error info

## Tests

120 tests pass in `@parity/product-sdk-contracts` — up from 103 on `main`, **+17 new tests:**
- `decodeRevert` (7): `Error(string)`, `Panic(uint256)` for both well-known and unknown codes, ABI-defined custom errors, raw UTF-8 (the issue's exact payload), opaque non-UTF-8 bytes, and empty payload
- `wrapContract — REVERT flag handling` (6): `.query()` returning the tagged value (with the issue's payload and end-to-end through an empty-payload revert), `.tx()` and `.prepare()` throwing `ContractRevertedError`, `Error(string)` payload via `.query()`, and a regression guard for `flags === 0` staying on the happy path
- `ContractRevertedError` message builder (4): top-level and nested bigint args (`[{ owed: 42n }]`), `Error(string)`-prefers-bare-reason

## Local CI sweep

- `pnpm check` clean (biome)
- `pnpm build` clean across all 14 packages (ESM + DTS)
- `pnpm test` — 842 tests passing across the workspace

## Migration

Callers that wrap `.query()` in `if (result.success)` already work — the failure branch just gains a richer `value`. Existing `.tx()` / `.prepare()` call sites that catch `ContractDryRunFailedError` should add a `ContractRevertedError` branch (or catch the shared `ContractError` base) to distinguish a contract-level revert from a dispatch error.

```ts
try {
  await contract.transfer.tx(to, amount);
} catch (err) {
  if (err instanceof ContractRevertedError) {
    // err.reason / err.decoded / err.data
  } else if (err instanceof ContractDryRunFailedError) {
    // dispatch error (Module / AccountNotMapped / etc.)
  }
}
```


## Test plan
-  CI passes (lint / build / test / bundle-size / e2e / docs-verify)
-  117 tests pass