### PR TITLE
ci(docs): deploy to GitHub Pages alongside Bulletin

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,4 +1,4 @@
-name: "docs: Deploy"
+name: "docs: Deploy (Bulletin + Pages)"
 
 on:
     workflow_run:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -97,7 +97,7 @@ jobs:
               if: steps.gate.outputs.skip != 'true'
               working-directory: docs
               env:
-                  PAGES_BASE_PATH: /product-sdk
+                  PAGES_BASE_PATH: /${{ github.event.repository.name }}
               run: pnpm build
 
             - name: Configure GitHub Pages

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,4 +1,4 @@
-name: "docs: Deploy to Bulletin"
+name: "docs: Deploy"
 
 on:
     workflow_run:
@@ -8,6 +8,8 @@ on:
 
 permissions:
     contents: read
+    pages: write
+    id-token: write
 
 concurrency:
     group: docs-deploy
@@ -17,6 +19,9 @@ jobs:
     deploy:
         if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
         runs-on: ubuntu-latest
+        environment:
+            name: github-pages
+            url: ${{ steps.pages-deploy.outputs.page_url }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -25,6 +30,10 @@ jobs:
             - name: Check for umbrella tag at HEAD
               id: gate
               run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    echo "skip=false" >> $GITHUB_OUTPUT
+                    exit 0
+                  fi
                   tag=$(git tag --points-at HEAD | grep -E '^@parity/product-sdk@[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
                   if [ -z "$tag" ]; then
                     echo "skip=true" >> $GITHUB_OUTPUT
@@ -83,3 +92,25 @@ jobs:
                   timeout_minutes: 10
                   max_attempts: 3
                   command: cd docs && bulletin-deploy ./out product-sdk.dot --js-merkle
+
+            - name: Rebuild static site for GitHub Pages
+              if: steps.gate.outputs.skip != 'true'
+              working-directory: docs
+              env:
+                  PAGES_BASE_PATH: /product-sdk
+              run: pnpm build
+
+            - name: Configure GitHub Pages
+              if: steps.gate.outputs.skip != 'true'
+              uses: actions/configure-pages@v5
+
+            - name: Upload Pages artifact
+              if: steps.gate.outputs.skip != 'true'
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: docs/out
+
+            - name: Deploy to GitHub Pages
+              id: pages-deploy
+              if: steps.gate.outputs.skip != 'true'
+              uses: actions/deploy-pages@v4

--- a/docs/app/_components/logo.tsx
+++ b/docs/app/_components/logo.tsx
@@ -10,16 +10,18 @@ const sdkPkg = JSON.parse(
   ),
 ) as { version: string };
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
 export function Logo() {
   return (
     <div className="flex items-center h-8">
       <img
-        src="/logo-symbol-wordmark_dark.svg"
+        src={`${basePath}/logo-symbol-wordmark_dark.svg`}
         alt="Polkadot"
         className="block dark:hidden h-7 w-auto"
       />
       <img
-        src="/logo-symbol-wordmark_light.svg"
+        src={`${basePath}/logo-symbol-wordmark_light.svg`}
         alt="Polkadot"
         className="hidden dark:block h-7 w-auto"
       />

--- a/docs/content/_components/hero.tsx
+++ b/docs/content/_components/hero.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export function Hero() {
   return (
     <div className="max-w-4xl pt-8 pb-12">
@@ -11,24 +13,24 @@ export function Hero() {
         packages handle chain clients, transactions, keys, and crypto.
       </div>
       <div className="mt-8 flex items-center gap-3">
-        <a
+        <Link
           href="/getting-started/installation"
           className="bg-action-primary text-primary-inverted font-medium text-sm px-4 py-2 rounded-small hover:bg-action-primary-hover transition-colors cursor-pointer"
         >
           Installation
-        </a>
-        <a
+        </Link>
+        <Link
           href="/getting-started/quickstart"
           className="bg-action-secondary text-primary font-medium text-sm px-4 py-2 rounded-small hover:bg-action-secondary-hover transition-colors cursor-pointer"
         >
           Quickstart
-        </a>
-        <a
+        </Link>
+        <Link
           href="/api"
           className="bg-action-secondary text-primary font-medium text-sm px-4 py-2 rounded-small hover:bg-action-secondary-hover transition-colors cursor-pointer"
         >
           API Reference
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -5,9 +5,16 @@ const withNextra = nextra({
   defaultShowCopyCode: true,
 });
 
+const basePath = process.env.PAGES_BASE_PATH ?? "";
+
 export default withNextra({
   reactStrictMode: true,
   output: "export",
   images: { unoptimized: true },
   trailingSlash: true,
+  basePath,
+  assetPrefix: basePath || undefined,
+  env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
+  },
 });


### PR DESCRIPTION
## Summary
- Extend `docs: Deploy` workflow to publish the static site to GitHub Pages in addition to Bulletin, using the same release-gated trigger.

Pages will live at `https://paritytech.github.io/product-sdk/` once "Source: GitHub Actions" is enabled in repo Settings → Pages.

@pgherveou @TarikGul could you enable it. Will hold back on merging this PR until we have confirmation that it is enabled.