### PR TITLE
feat: host playground migration support

### DIFF
--- a/product-sdk/packages/chain-client/src/index.ts
+++ b/product-sdk/packages/chain-client/src/index.ts
@@ -20,5 +20,9 @@ export type { Environment, PresetChains } from "./presets.js";
 // Types
 export type { ChainClient, ChainClientConfig, ChainEntry } from "./types.js";
 
+// Well-known chain genesis hashes
+export { WellKnownChain } from "./well-known-chain.js";
+export type { WellKnownChainHash } from "./well-known-chain.js";
+
 // Re-export from host
 export { isInsideContainer, isInsideContainerSync } from "@parity/product-sdk-host";

--- a/product-sdk/packages/chain-client/src/well-known-chain.ts
+++ b/product-sdk/packages/chain-client/src/well-known-chain.ts
@@ -1,0 +1,29 @@
+/**
+ * Genesis hashes of well-known chains.
+ *
+ * Mirrors `WellKnownChain` from `@novasamatech/product-sdk`. Hand-copied
+ * (not re-exported) so chain-client doesn't pick up a direct Novasama
+ * runtime dependency; genesis hashes are immutable so drift is impossible.
+ */
+export const WellKnownChain = {
+    polkadotRelay: "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
+    polkadotAssetHub: "0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f",
+    kusamaRelay: "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
+    kusamaAssetHub: "0x48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+    westendRelay: "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e",
+    westendAssetHub: "0x67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9",
+    rococo: "0x6408de7737c59c238890533af25896a2c20608d8b380bb01029acb392781063e",
+} as const;
+
+/** Genesis hash of a well-known chain - the value type of {@link WellKnownChain}. */
+export type WellKnownChainHash = (typeof WellKnownChain)[keyof typeof WellKnownChain];
+
+if (import.meta.vitest) {
+    const { test, expect } = import.meta.vitest;
+
+    test("WellKnownChain entries are 0x-prefixed 32-byte hex strings", () => {
+        for (const hash of Object.values(WellKnownChain)) {
+            expect(hash).toMatch(/^0x[0-9a-f]{64}$/);
+        }
+    });
+}

--- a/product-sdk/packages/chain-client/src/well-known-chain.ts
+++ b/product-sdk/packages/chain-client/src/well-known-chain.ts
@@ -1,7 +1,7 @@
 /**
  * Genesis hashes of well-known chains.
  *
- * Mirrors `WellKnownChain` from `@novasamatech/product-sdk`. Hand-copied
+ * Mirrors `WellKnownChain` from `@novasamatech/host-api-wrapper`. Hand-copied
  * (not re-exported) so chain-client doesn't pick up a direct Novasama
  * runtime dependency; genesis hashes are immutable so drift is impossible.
  */

--- a/product-sdk/packages/host/src/chat.ts
+++ b/product-sdk/packages/host/src/chat.ts
@@ -12,6 +12,8 @@
  * @module
  */
 
+import { createLogger } from "@parity/product-sdk-logger";
+
 import type {
     ChatBotRegistrationResult as NovasamaChatBotRegistrationResult,
     ChatCustomMessageRenderer as NovasamaChatCustomMessageRenderer,
@@ -22,6 +24,8 @@ import type {
     ChatRoomRegistrationResult as NovasamaChatRoomRegistrationResult,
     createProductChatManager,
 } from "@novasamatech/product-sdk";
+
+const log = createLogger("host:chat");
 
 /** Chat message payload variants. Re-exported from `@novasamatech/product-sdk`. */
 export type ChatMessageContent = NovasamaChatMessageContent;
@@ -79,7 +83,8 @@ export async function getChatManager(): Promise<ChatManager | null> {
     try {
         const sdk = await import("@novasamatech/product-sdk");
         return sdk.createProductChatManager();
-    } catch {
+    } catch (err) {
+        log.debug("getChatManager unavailable", err);
         return null;
     }
 }

--- a/product-sdk/packages/host/src/chat.ts
+++ b/product-sdk/packages/host/src/chat.ts
@@ -23,29 +23,29 @@ import type {
     ChatRoom as NovasamaChatRoom,
     ChatRoomRegistrationResult as NovasamaChatRoomRegistrationResult,
     createProductChatManager,
-} from "@novasamatech/product-sdk";
+} from "@novasamatech/host-api-wrapper";
 
 const log = createLogger("host:chat");
 
-/** Chat message payload variants. Re-exported from `@novasamatech/product-sdk`. */
+/** Chat message payload variants. Re-exported from `@novasamatech/host-api-wrapper`. */
 export type ChatMessageContent = NovasamaChatMessageContent;
 
-/** Action received via {@link ChatManager.subscribeAction}. Re-exported from `@novasamatech/product-sdk`. */
+/** Action received via {@link ChatManager.subscribeAction}. Re-exported from `@novasamatech/host-api-wrapper`. */
 export type ChatReceivedAction = NovasamaChatReceivedAction;
 
-/** Room metadata delivered to {@link ChatManager.subscribeChatList}. Re-exported from `@novasamatech/product-sdk`. */
+/** Room metadata delivered to {@link ChatManager.subscribeChatList}. Re-exported from `@novasamatech/host-api-wrapper`. */
 export type ChatRoom = NovasamaChatRoom;
 
-/** Result of registering a chat room (`"New" | "Exists"`). Re-exported from `@novasamatech/product-sdk`. */
+/** Result of registering a chat room (`"New" | "Exists"`). Re-exported from `@novasamatech/host-api-wrapper`. */
 export type ChatRoomRegistrationResult = NovasamaChatRoomRegistrationResult;
 
-/** Result of registering a bot (`"New" | "Exists"`). Re-exported from `@novasamatech/product-sdk`. */
+/** Result of registering a bot (`"New" | "Exists"`). Re-exported from `@novasamatech/host-api-wrapper`. */
 export type ChatBotRegistrationResult = NovasamaChatBotRegistrationResult;
 
-/** Renderer callback for custom message types. Re-exported from `@novasamatech/product-sdk`. */
+/** Renderer callback for custom message types. Re-exported from `@novasamatech/host-api-wrapper`. */
 export type ChatCustomMessageRenderer = NovasamaChatCustomMessageRenderer;
 
-/** Parameters passed to a {@link ChatCustomMessageRenderer}. Re-exported from `@novasamatech/product-sdk`. */
+/** Parameters passed to a {@link ChatCustomMessageRenderer}. Re-exported from `@novasamatech/host-api-wrapper`. */
 export type ChatCustomMessageRendererParams<T = Uint8Array> =
     NovasamaChatCustomMessageRendererParams<T>;
 
@@ -55,14 +55,14 @@ export type ChatCustomMessageRendererParams<T = Uint8Array> =
  * registration.
  *
  * Type identical to `createProductChatManager()` from
- * `@novasamatech/product-sdk`.
+ * `@novasamatech/host-api-wrapper`.
  */
 export type ChatManager = ReturnType<typeof createProductChatManager>;
 
 /**
  * Get the host chat manager.
  *
- * Returns the chat manager from `@novasamatech/product-sdk`, or `null` if
+ * Returns the chat manager from `@novasamatech/host-api-wrapper`, or `null` if
  * the package is unavailable (running outside a host container or the
  * optional peer dep isn't installed).
  *
@@ -81,7 +81,7 @@ export type ChatManager = ReturnType<typeof createProductChatManager>;
  */
 export async function getChatManager(): Promise<ChatManager | null> {
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createProductChatManager();
     } catch (err) {
         log.debug("getChatManager unavailable", err);
@@ -93,7 +93,7 @@ export async function getChatManager(): Promise<ChatManager | null> {
  * Dispatch helper that composes multiple custom-message renderers into a
  * single {@link ChatCustomMessageRenderer} keyed by `messageType`.
  *
- * Mirrors `matchChatCustomRenderers` from `@novasamatech/product-sdk`
+ * Mirrors `matchChatCustomRenderers` from `@novasamatech/host-api-wrapper`
  * inline (the upstream implementation is pure dispatch logic with no
  * transport / runtime dependency on Novasama), so callers get the same
  * sync signature instead of an async-with-null wrapper.

--- a/product-sdk/packages/host/src/chat.ts
+++ b/product-sdk/packages/host/src/chat.ts
@@ -1,0 +1,119 @@
+/**
+ * Wrapper for the host's chat surface (`host_chat_*` family).
+ *
+ * Shipped flat-in-host rather than as `getTruApi().chat.*` (the shape
+ * sketched in issue #93) because the upstream JS `hostApi` is itself a
+ * flat object - there is no `.chat` accessor to mirror. A flat
+ * `getChatManager()` matches the pattern already used by
+ * {@link getThemeProvider}, {@link getAccountsProvider}, and
+ * {@link getStatementStore}; if a namespaced view is desirable later, it
+ * can be layered on top without breaking this surface.
+ *
+ * @module
+ */
+
+import type {
+    ChatBotRegistrationResult as NovasamaChatBotRegistrationResult,
+    ChatCustomMessageRenderer as NovasamaChatCustomMessageRenderer,
+    ChatCustomMessageRendererParams as NovasamaChatCustomMessageRendererParams,
+    ChatMessageContent as NovasamaChatMessageContent,
+    ChatReceivedAction as NovasamaChatReceivedAction,
+    ChatRoom as NovasamaChatRoom,
+    ChatRoomRegistrationResult as NovasamaChatRoomRegistrationResult,
+    createProductChatManager,
+} from "@novasamatech/product-sdk";
+
+/** Chat message payload variants. Re-exported from `@novasamatech/product-sdk`. */
+export type ChatMessageContent = NovasamaChatMessageContent;
+
+/** Action received via {@link ChatManager.subscribeAction}. Re-exported from `@novasamatech/product-sdk`. */
+export type ChatReceivedAction = NovasamaChatReceivedAction;
+
+/** Room metadata delivered to {@link ChatManager.subscribeChatList}. Re-exported from `@novasamatech/product-sdk`. */
+export type ChatRoom = NovasamaChatRoom;
+
+/** Result of registering a chat room (`"New" | "Exists"`). Re-exported from `@novasamatech/product-sdk`. */
+export type ChatRoomRegistrationResult = NovasamaChatRoomRegistrationResult;
+
+/** Result of registering a bot (`"New" | "Exists"`). Re-exported from `@novasamatech/product-sdk`. */
+export type ChatBotRegistrationResult = NovasamaChatBotRegistrationResult;
+
+/** Renderer callback for custom message types. Re-exported from `@novasamatech/product-sdk`. */
+export type ChatCustomMessageRenderer = NovasamaChatCustomMessageRenderer;
+
+/** Parameters passed to a {@link ChatCustomMessageRenderer}. Re-exported from `@novasamatech/product-sdk`. */
+export type ChatCustomMessageRendererParams<T = Uint8Array> =
+    NovasamaChatCustomMessageRendererParams<T>;
+
+/**
+ * Chat manager handle. Exposes room/bot registration, message sending,
+ * subscription to room list and incoming actions, and custom-renderer
+ * registration.
+ *
+ * Type identical to `createProductChatManager()` from
+ * `@novasamatech/product-sdk`.
+ */
+export type ChatManager = ReturnType<typeof createProductChatManager>;
+
+/**
+ * Get the host chat manager.
+ *
+ * Returns the chat manager from `@novasamatech/product-sdk`, or `null` if
+ * the package is unavailable (running outside a host container or the
+ * optional peer dep isn't installed).
+ *
+ * @returns The chat manager, or `null` if unavailable.
+ *
+ * @example
+ * ```ts
+ * import { getChatManager } from "@parity/product-sdk-host";
+ *
+ * const chat = await getChatManager();
+ * if (chat) {
+ *   await chat.registerBot({ botId: "echo", name: "Echo Bot", icon: "" });
+ *   chat.subscribeAction((action) => { ... });
+ * }
+ * ```
+ */
+export async function getChatManager(): Promise<ChatManager | null> {
+    try {
+        const sdk = await import("@novasamatech/product-sdk");
+        return sdk.createProductChatManager();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Dispatch helper that composes multiple custom-message renderers into a
+ * single {@link ChatCustomMessageRenderer} keyed by `messageType`.
+ *
+ * Mirrors `matchChatCustomRenderers` from `@novasamatech/product-sdk`
+ * inline (the upstream implementation is pure dispatch logic with no
+ * transport / runtime dependency on Novasama), so callers get the same
+ * sync signature instead of an async-with-null wrapper.
+ *
+ * @param map - Object mapping `messageType` strings to renderers.
+ * @returns A composed renderer that dispatches to the entry matching
+ *          `params.messageType`, or throws if no renderer is registered.
+ */
+export function matchChatCustomRenderers(
+    map: Record<string, ChatCustomMessageRenderer>,
+): ChatCustomMessageRenderer {
+    return (params, render) => {
+        const renderer = map[params.messageType];
+        if (!renderer) {
+            throw new Error(`Renderer for message type ${params.messageType} is not defined`);
+        }
+        return renderer(params, render);
+    };
+}
+
+if (import.meta.vitest) {
+    const { test, expect } = import.meta.vitest;
+
+    test("getChatManager returns manager when SDK is available", async () => {
+        const chat = await getChatManager();
+        expect(chat === null || typeof chat === "object").toBe(true);
+    });
+}

--- a/product-sdk/packages/host/src/container.ts
+++ b/product-sdk/packages/host/src/container.ts
@@ -1,7 +1,10 @@
 import type { JsonRpcProvider } from "polkadot-api";
+import { createLogger } from "@parity/product-sdk-logger";
 import type { Transport } from "@novasamatech/host-api";
 
 import type { HostLocalStorage, HostStatementStore } from "./types.js";
+
+const log = createLogger("host:container");
 
 /**
  * Detect if running inside a Host container (Polkadot Browser / Polkadot Desktop).
@@ -33,7 +36,8 @@ export async function getHostLocalStorage(): Promise<HostLocalStorage | null> {
     try {
         const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.hostLocalStorage as HostLocalStorage;
-    } catch {
+    } catch (err) {
+        log.debug("getHostLocalStorage unavailable", err);
         return null;
     }
 }
@@ -52,10 +56,13 @@ export async function getHostLocalStorage(): Promise<HostLocalStorage | null> {
 export async function createHostLocalStorage(
     transport?: Transport,
 ): Promise<HostLocalStorage | null> {
+    if (!(await isInsideContainer())) return null;
+
     try {
         const sdk = await import("@novasamatech/product-sdk");
         return sdk.createLocalStorage(transport);
-    } catch {
+    } catch (err) {
+        log.debug("createHostLocalStorage unavailable", err);
         return null;
     }
 }
@@ -74,7 +81,8 @@ export async function getHostProvider(genesisHash: `0x${string}`): Promise<JsonR
     try {
         const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createPapiProvider(genesisHash);
-    } catch {
+    } catch (err) {
+        log.debug("getHostProvider unavailable", err);
         return null;
     }
 }
@@ -121,7 +129,8 @@ export async function getStatementStore(): Promise<HostStatementStore | null> {
     try {
         const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createStatementStore() as HostStatementStore;
-    } catch {
+    } catch (err) {
+        log.debug("getStatementStore unavailable", err);
         return null;
     }
 }
@@ -187,6 +196,10 @@ if (import.meta.vitest) {
 
     test("getHostLocalStorage returns null outside container", async () => {
         expect(await getHostLocalStorage()).toBeNull();
+    });
+
+    test("createHostLocalStorage returns null outside container", async () => {
+        expect(await createHostLocalStorage()).toBeNull();
     });
 
     test("getHostProvider returns null when product-sdk unavailable", async () => {

--- a/product-sdk/packages/host/src/container.ts
+++ b/product-sdk/packages/host/src/container.ts
@@ -1,4 +1,5 @@
 import type { JsonRpcProvider } from "polkadot-api";
+import type { Transport } from "@novasamatech/host-api";
 
 import type { HostLocalStorage, HostStatementStore } from "./types.js";
 
@@ -32,6 +33,28 @@ export async function getHostLocalStorage(): Promise<HostLocalStorage | null> {
     try {
         const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.hostLocalStorage as HostLocalStorage;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Construct a fresh host-backed `HostLocalStorage` instance with an optional
+ * custom transport. Use this when you need a non-default transport (e.g.
+ * for tests); otherwise prefer {@link getHostLocalStorage}, which returns
+ * the shared singleton.
+ *
+ * Mirrors `createLocalStorage` from `@novasamatech/product-sdk`.
+ *
+ * @param transport - Optional transport; defaults to the sandbox transport.
+ * @returns A new `HostLocalStorage` instance, or `null` if unavailable.
+ */
+export async function createHostLocalStorage(
+    transport?: Transport,
+): Promise<HostLocalStorage | null> {
+    try {
+        const sdk = await import("@novasamatech/product-sdk");
+        return sdk.createLocalStorage(transport);
     } catch {
         return null;
     }

--- a/product-sdk/packages/host/src/container.ts
+++ b/product-sdk/packages/host/src/container.ts
@@ -48,7 +48,7 @@ export async function getHostLocalStorage(): Promise<HostLocalStorage | null> {
  * for tests); otherwise prefer {@link getHostLocalStorage}, which returns
  * the shared singleton.
  *
- * Mirrors `createLocalStorage` from `@novasamatech/product-sdk`.
+ * Mirrors `createLocalStorage` from `@novasamatech/host-api-wrapper`.
  *
  * @param transport - Optional transport; defaults to the sandbox transport.
  * @returns A new `HostLocalStorage` instance, or `null` if unavailable.
@@ -59,7 +59,7 @@ export async function createHostLocalStorage(
     if (!(await isInsideContainer())) return null;
 
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createLocalStorage(transport);
     } catch (err) {
         log.debug("createHostLocalStorage unavailable", err);

--- a/product-sdk/packages/host/src/entropy.ts
+++ b/product-sdk/packages/host/src/entropy.ts
@@ -12,7 +12,7 @@
 
 import { createLogger } from "@parity/product-sdk-logger";
 
-import { enumValue, getTruApi } from "./truapi.js";
+import { enumValue, formatHostError, getTruApi } from "./truapi.js";
 
 const log = createLogger("host:entropy");
 
@@ -44,10 +44,7 @@ export async function deriveEntropy(key: Uint8Array): Promise<Uint8Array> {
     return await truApi.deriveEntropy(enumValue("v1", key)).match(
         (envelope: { tag: "v1"; value: Uint8Array }) => envelope.value,
         (err: unknown) => {
-            throw new Error(
-                `deriveEntropy failed: ${err instanceof Error ? err.message : String(err)}`,
-                { cause: err },
-            );
+            throw new Error(`deriveEntropy failed: ${formatHostError(err)}`, { cause: err });
         },
     );
 }

--- a/product-sdk/packages/host/src/entropy.ts
+++ b/product-sdk/packages/host/src/entropy.ts
@@ -1,0 +1,68 @@
+/**
+ * Higher-level wrapper for the host's entropy derivation (RFC-0007).
+ *
+ * `hostApi.deriveEntropy` is reachable via {@link getTruApi}, but consumers
+ * have to wrap the value in the versioned envelope (`enumValue("v1", ...)`)
+ * and unwrap the neverthrow `ResultAsync` themselves. `deriveEntropy`
+ * collapses that to a throw-on-error Promise that matches the shape of
+ * {@link requestPermission} and {@link requestResourceAllocation}.
+ *
+ * @module
+ */
+
+import { createLogger } from "@parity/product-sdk-logger";
+
+import { enumValue, getTruApi } from "./truapi.js";
+
+const log = createLogger("host:entropy");
+
+/**
+ * Derive deterministic entropy from a context key (RFC-0007).
+ *
+ * The host derives entropy from the user's wallet + the provided context
+ * key. Calling with the same key on the same wallet yields the same bytes;
+ * different keys (or different wallets) yield uncorrelated entropy.
+ *
+ * @param key - Context key bytes (typically a SCALE-encoded discriminator).
+ * @returns The derived entropy bytes.
+ * @throws If the host is unavailable or the host-side derivation fails.
+ *
+ * @example
+ * ```ts
+ * import { deriveEntropy } from "@parity/product-sdk-host";
+ *
+ * const seed = await deriveEntropy(new TextEncoder().encode("my-app:seed-v1"));
+ * ```
+ */
+export async function deriveEntropy(key: Uint8Array): Promise<Uint8Array> {
+    const truApi = await getTruApi();
+    if (!truApi) {
+        throw new Error("deriveEntropy: TruAPI unavailable");
+    }
+    log.debug("deriveEntropy", { keyLen: key.length });
+
+    return await truApi.deriveEntropy(enumValue("v1", key)).match(
+        (envelope: { tag: "v1"; value: Uint8Array }) => envelope.value,
+        (err: unknown) => {
+            throw new Error(
+                `deriveEntropy failed: ${err instanceof Error ? err.message : String(err)}`,
+                { cause: err },
+            );
+        },
+    );
+}
+
+if (import.meta.vitest) {
+    const { test, expect } = import.meta.vitest;
+
+    test("deriveEntropy throws when TruAPI is unavailable", async () => {
+        const api = await getTruApi();
+        if (api === null) {
+            await expect(deriveEntropy(new Uint8Array([1, 2, 3]))).rejects.toThrow(
+                /TruAPI unavailable/,
+            );
+        } else {
+            expect(typeof deriveEntropy).toBe("function");
+        }
+    });
+}

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -37,6 +37,7 @@ export {
     getAccountsProvider,
     requestResourceAllocation,
     createProofAuthorized,
+    formatHostError,
     // Helpers from @novasamatech/host-api
     enumValue,
     isEnumVariant,

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -18,9 +18,13 @@ export type {
     HostLocalStorage,
     HostStatementStore,
     HostSubscription,
+    ProductAccountId,
+    SignedStatement,
+    Statement,
     StatementProof,
     StatementTopicFilter,
     StatementsPage,
+    Topic,
 } from "./types.js";
 export { BULLETIN_RPCS, DEFAULT_BULLETIN_ENDPOINT } from "./chains.js";
 
@@ -56,7 +60,6 @@ export type {
     AllocationOutcomeTag,
     RemotePermission,
     RemotePermissionTag,
-    Statement,
 } from "./truapi.js";
 
 // Higher-level permission wrapper

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -11,6 +11,7 @@ export {
     isInsideContainer,
     isInsideContainerSync,
     getHostLocalStorage,
+    createHostLocalStorage,
     getHostProvider,
     getStatementStore,
 } from "./container.js";
@@ -32,6 +33,7 @@ export { BULLETIN_RPCS, DEFAULT_BULLETIN_ENDPOINT } from "./chains.js";
 export {
     getTruApi,
     getPreimageManager,
+    createHostPreimageManager,
     getAccountsProvider,
     requestResourceAllocation,
     createProofAuthorized,
@@ -62,5 +64,26 @@ export type {
     RemotePermissionTag,
 } from "./truapi.js";
 
-// Higher-level permission wrapper
-export { requestPermission } from "./permissions.js";
+// Higher-level permission wrappers
+export { requestPermission, requestDevicePermission } from "./permissions.js";
+export type { DevicePermissionKind, RemotePermissionItem } from "./permissions.js";
+
+// Theme provider
+export { getThemeProvider } from "./theme.js";
+export type { ThemeMode, ThemeProvider } from "./theme.js";
+
+// Entropy derivation (RFC-0007)
+export { deriveEntropy } from "./entropy.js";
+
+// Chat
+export { getChatManager, matchChatCustomRenderers } from "./chat.js";
+export type {
+    ChatManager,
+    ChatMessageContent,
+    ChatReceivedAction,
+    ChatRoom,
+    ChatRoomRegistrationResult,
+    ChatBotRegistrationResult,
+    ChatCustomMessageRenderer,
+    ChatCustomMessageRendererParams,
+} from "./chat.js";

--- a/product-sdk/packages/host/src/permissions.ts
+++ b/product-sdk/packages/host/src/permissions.ts
@@ -17,7 +17,7 @@ import { createLogger } from "@parity/product-sdk-logger";
 import type { CodecType } from "@novasamatech/host-api";
 import type { DevicePermission as DevicePermissionCodec } from "@novasamatech/host-api";
 
-import { enumValue, getTruApi, type RemotePermission } from "./truapi.js";
+import { enumValue, formatHostError, getTruApi, type RemotePermission } from "./truapi.js";
 
 const log = createLogger("host:permissions");
 
@@ -64,10 +64,7 @@ export async function requestPermission(permission: RemotePermission): Promise<b
     return await truApi.permission(enumValue("v1", permission)).match(
         (envelope: { tag: "v1"; value: boolean }) => envelope.value,
         (err: unknown) => {
-            throw new Error(
-                `requestPermission failed: ${err instanceof Error ? err.message : String(err)}`,
-                { cause: err },
-            );
+            throw new Error(`requestPermission failed: ${formatHostError(err)}`, { cause: err });
         },
     );
 }
@@ -101,10 +98,9 @@ export async function requestDevicePermission(permission: DevicePermissionKind):
     return await truApi.devicePermission(enumValue("v1", permission)).match(
         (envelope: { tag: "v1"; value: boolean }) => envelope.value,
         (err: unknown) => {
-            throw new Error(
-                `requestDevicePermission failed: ${err instanceof Error ? err.message : String(err)}`,
-                { cause: err },
-            );
+            throw new Error(`requestDevicePermission failed: ${formatHostError(err)}`, {
+                cause: err,
+            });
         },
     );
 }
@@ -120,10 +116,14 @@ if (import.meta.vitest) {
         fn: (mod: typeof import("./permissions.js")) => Promise<T>,
     ): Promise<T> {
         vi.resetModules();
-        vi.doMock("./truapi.js", () => ({
-            getTruApi: async () => bridge,
-            enumValue: (version: string, value: unknown) => ({ tag: version, value }),
-        }));
+        vi.doMock("./truapi.js", async (importOriginal) => {
+            const original = await importOriginal<typeof import("./truapi.js")>();
+            return {
+                ...original,
+                getTruApi: async () => bridge,
+                enumValue: (version: string, value: unknown) => ({ tag: version, value }),
+            };
+        });
         try {
             const mod = await import("./permissions.js");
             return await fn(mod);
@@ -177,7 +177,7 @@ if (import.meta.vitest) {
                 async (mod) => {
                     await expect(
                         mod.requestPermission({ tag: "ChainSubmit", value: undefined }),
-                    ).rejects.toThrow(/requestPermission failed/);
+                    ).rejects.toThrow(/requestPermission failed: GenericError: boom/);
                 },
             );
         });
@@ -223,7 +223,7 @@ if (import.meta.vitest) {
                 },
                 async (mod) => {
                     await expect(mod.requestDevicePermission("Camera")).rejects.toThrow(
-                        /requestDevicePermission failed/,
+                        /requestDevicePermission failed: GenericError: boom/,
                     );
                 },
             );

--- a/product-sdk/packages/host/src/permissions.ts
+++ b/product-sdk/packages/host/src/permissions.ts
@@ -15,7 +15,7 @@
 import { createLogger } from "@parity/product-sdk-logger";
 
 import type { CodecType } from "@novasamatech/host-api";
-import { DevicePermission as DevicePermissionCodec } from "@novasamatech/host-api";
+import type { DevicePermission as DevicePermissionCodec } from "@novasamatech/host-api";
 
 import { enumValue, getTruApi, type RemotePermission } from "./truapi.js";
 
@@ -91,9 +91,7 @@ export async function requestPermission(permission: RemotePermission): Promise<b
  * }
  * ```
  */
-export async function requestDevicePermission(
-    permission: DevicePermissionKind,
-): Promise<boolean> {
+export async function requestDevicePermission(permission: DevicePermissionKind): Promise<boolean> {
     const truApi = await getTruApi();
     if (!truApi) {
         throw new Error("requestDevicePermission: TruAPI unavailable");
@@ -188,9 +186,9 @@ if (import.meta.vitest) {
     describe("requestDevicePermission", () => {
         test("throws when TruAPI is unavailable", async () => {
             await withMockedTruApi(null, async (mod) => {
-                await expect(
-                    mod.requestDevicePermission("Camera"),
-                ).rejects.toThrow(/TruAPI unavailable/);
+                await expect(mod.requestDevicePermission("Camera")).rejects.toThrow(
+                    /TruAPI unavailable/,
+                );
             });
         });
 
@@ -224,9 +222,9 @@ if (import.meta.vitest) {
                     }),
                 },
                 async (mod) => {
-                    await expect(
-                        mod.requestDevicePermission("Camera"),
-                    ).rejects.toThrow(/requestDevicePermission failed/);
+                    await expect(mod.requestDevicePermission("Camera")).rejects.toThrow(
+                        /requestDevicePermission failed/,
+                    );
                 },
             );
         });

--- a/product-sdk/packages/host/src/permissions.ts
+++ b/product-sdk/packages/host/src/permissions.ts
@@ -32,7 +32,7 @@ export type DevicePermissionKind = CodecType<typeof DevicePermissionCodec>;
 
 /**
  * Alias of {@link RemotePermission} matching the upstream
- * `@novasamatech/product-sdk` name. Use either freely.
+ * `@novasamatech/host-api-wrapper` name. Use either freely.
  */
 export type RemotePermissionItem = RemotePermission;
 

--- a/product-sdk/packages/host/src/permissions.ts
+++ b/product-sdk/packages/host/src/permissions.ts
@@ -1,21 +1,40 @@
 /**
- * Higher-level wrapper for the host's single-permission flow.
+ * Higher-level wrappers for the host's single-permission flows.
  *
- * `hostApi.permission` takes a versioned envelope (`enumValue("v1", ...)`)
- * and returns a neverthrow `ResultAsync` of an unwrapped versioned response.
- * Consumers rebuild that wrap/unwrap dance every time. `requestPermission`
- * collapses it to a one-liner that matches the shape of
- * {@link requestResourceAllocation} (throws on error, returns the unwrapped
- * payload on success).
+ * `hostApi.permission` / `hostApi.devicePermission` take a versioned
+ * envelope (`enumValue("v1", ...)`) and return a neverthrow `ResultAsync`
+ * of an unwrapped versioned response. Consumers rebuild that wrap/unwrap
+ * dance every time. {@link requestPermission} and
+ * {@link requestDevicePermission} collapse it to one-liners that match the
+ * shape of {@link requestResourceAllocation} (throws on error, returns
+ * the unwrapped payload on success).
  *
  * @module
  */
 
 import { createLogger } from "@parity/product-sdk-logger";
 
+import type { CodecType } from "@novasamatech/host-api";
+import { DevicePermission as DevicePermissionCodec } from "@novasamatech/host-api";
+
 import { enumValue, getTruApi, type RemotePermission } from "./truapi.js";
 
 const log = createLogger("host:permissions");
+
+/**
+ * Device permission the dapp can ask the host to grant via
+ * {@link requestDevicePermission}.
+ *
+ * Derived from the upstream codec so variant renames surface as compile
+ * errors, not runtime failures.
+ */
+export type DevicePermissionKind = CodecType<typeof DevicePermissionCodec>;
+
+/**
+ * Alias of {@link RemotePermission} matching the upstream
+ * `@novasamatech/product-sdk` name. Use either freely.
+ */
+export type RemotePermissionItem = RemotePermission;
 
 /**
  * Request a single remote permission from the host.
@@ -53,11 +72,53 @@ export async function requestPermission(permission: RemotePermission): Promise<b
     );
 }
 
+/**
+ * Request a single device permission (camera, microphone, etc.) from the
+ * host.
+ *
+ * Builds the `v1` envelope, calls `hostApi.devicePermission`, unwraps the
+ * response, and returns the host's boolean granted/denied outcome.
+ *
+ * @param permission - The device permission to request.
+ * @returns `true` if the host granted the permission, `false` if denied.
+ * @throws If the host is unavailable or the request fails.
+ *
+ * @example
+ * ```ts
+ * const granted = await requestDevicePermission("Camera");
+ * if (!granted) {
+ *   showCameraDeniedMessage();
+ * }
+ * ```
+ */
+export async function requestDevicePermission(
+    permission: DevicePermissionKind,
+): Promise<boolean> {
+    const truApi = await getTruApi();
+    if (!truApi) {
+        throw new Error("requestDevicePermission: TruAPI unavailable");
+    }
+    log.debug("requestDevicePermission", { permission });
+
+    return await truApi.devicePermission(enumValue("v1", permission)).match(
+        (envelope: { tag: "v1"; value: boolean }) => envelope.value,
+        (err: unknown) => {
+            throw new Error(
+                `requestDevicePermission failed: ${err instanceof Error ? err.message : String(err)}`,
+                { cause: err },
+            );
+        },
+    );
+}
+
 if (import.meta.vitest) {
     const { test, expect, describe, vi } = import.meta.vitest;
 
     async function withMockedTruApi<T>(
-        bridge: { permission?: (req: unknown) => unknown } | null,
+        bridge: {
+            permission?: (req: unknown) => unknown;
+            devicePermission?: (req: unknown) => unknown;
+        } | null,
         fn: (mod: typeof import("./permissions.js")) => Promise<T>,
     ): Promise<T> {
         vi.resetModules();
@@ -119,6 +180,53 @@ if (import.meta.vitest) {
                     await expect(
                         mod.requestPermission({ tag: "ChainSubmit", value: undefined }),
                     ).rejects.toThrow(/requestPermission failed/);
+                },
+            );
+        });
+    });
+
+    describe("requestDevicePermission", () => {
+        test("throws when TruAPI is unavailable", async () => {
+            await withMockedTruApi(null, async (mod) => {
+                await expect(
+                    mod.requestDevicePermission("Camera"),
+                ).rejects.toThrow(/TruAPI unavailable/);
+            });
+        });
+
+        test("unwraps the v1 boolean outcome", async () => {
+            await withMockedTruApi(
+                {
+                    devicePermission: vi.fn().mockReturnValue({
+                        match: async (onOk: (v: unknown) => unknown) =>
+                            onOk({ tag: "v1", value: true }),
+                    }),
+                },
+                async (mod) => {
+                    const granted = await mod.requestDevicePermission("Camera");
+                    expect(granted).toBe(true);
+                },
+            );
+        });
+
+        test("wraps host errors with a diagnostic message", async () => {
+            await withMockedTruApi(
+                {
+                    devicePermission: vi.fn().mockReturnValue({
+                        match: async (
+                            _onOk: (v: unknown) => unknown,
+                            onErr: (e: unknown) => unknown,
+                        ) =>
+                            onErr({
+                                tag: "v1",
+                                value: { name: "GenericError", message: "boom" },
+                            }),
+                    }),
+                },
+                async (mod) => {
+                    await expect(
+                        mod.requestDevicePermission("Camera"),
+                    ).rejects.toThrow(/requestDevicePermission failed/);
                 },
             );
         });

--- a/product-sdk/packages/host/src/theme.ts
+++ b/product-sdk/packages/host/src/theme.ts
@@ -1,0 +1,74 @@
+/**
+ * Higher-level wrapper for the host's theme subscription.
+ *
+ * `hostApi.themeSubscribe` is reachable via {@link getTruApi}, but consumers
+ * have to wire the subscription envelope themselves. `getThemeProvider`
+ * returns the `@novasamatech/product-sdk` theme provider object directly,
+ * giving callers a `subscribeTheme(cb)` method that resolves to a typed
+ * `ThemeMode` ("Light" | "Dark") and yields a `Subscription<void>` handle.
+ *
+ * @module
+ */
+
+import type { createThemeProvider, ThemeMode as NovasamaThemeMode } from "@novasamatech/product-sdk";
+
+/**
+ * Host theme provider handle. Exposes `subscribeTheme(callback)` which
+ * receives a typed `ThemeMode` on every change and returns a
+ * `Subscription<void>` (`unsubscribe` + `onInterrupt`).
+ *
+ * Type identical to `createThemeProvider()` from
+ * `@novasamatech/product-sdk`.
+ */
+export type ThemeProvider = ReturnType<typeof createThemeProvider>;
+
+/** Host theme mode value. Re-exported from `@novasamatech/product-sdk`. */
+export type ThemeMode = NovasamaThemeMode;
+
+/**
+ * Get the host theme provider.
+ *
+ * Returns the theme-subscription handle exported by
+ * `@novasamatech/product-sdk`, or `null` if the package is unavailable
+ * (running outside a host container or the optional peer dep isn't
+ * installed).
+ *
+ * Implementation note: upstream `@novasamatech/product-sdk` exports only
+ * the `createThemeProvider` factory and no `themeProvider` singleton, so
+ * this getter constructs a fresh instance on each call (unlike
+ * {@link getPreimageManager} or {@link getHostLocalStorage}, which return
+ * upstream singletons). The constructed provider is cheap to allocate; it
+ * only opens a subscription when `subscribeTheme` is called.
+ *
+ * @returns The theme provider, or `null` if unavailable.
+ *
+ * @example
+ * ```ts
+ * import { getThemeProvider } from "@parity/product-sdk-host";
+ *
+ * const provider = await getThemeProvider();
+ * if (provider) {
+ *   const sub = provider.subscribeTheme((mode) => {
+ *     document.documentElement.dataset.theme = mode.toLowerCase();
+ *   });
+ *   // sub.unsubscribe() to stop listening
+ * }
+ * ```
+ */
+export async function getThemeProvider(): Promise<ThemeProvider | null> {
+    try {
+        const sdk = await import("@novasamatech/product-sdk");
+        return sdk.createThemeProvider();
+    } catch {
+        return null;
+    }
+}
+
+if (import.meta.vitest) {
+    const { test, expect } = import.meta.vitest;
+
+    test("getThemeProvider returns provider when SDK is available", async () => {
+        const provider = await getThemeProvider();
+        expect(provider === null || typeof provider === "object").toBe(true);
+    });
+}

--- a/product-sdk/packages/host/src/theme.ts
+++ b/product-sdk/packages/host/src/theme.ts
@@ -3,7 +3,7 @@
  *
  * `hostApi.themeSubscribe` is reachable via {@link getTruApi}, but consumers
  * have to wire the subscription envelope themselves. `getThemeProvider`
- * returns the `@novasamatech/product-sdk` theme provider object directly,
+ * returns the `@novasamatech/host-api-wrapper` theme provider object directly,
  * giving callers a `subscribeTheme(cb)` method that resolves to a typed
  * `ThemeMode` ("Light" | "Dark") and yields a `Subscription<void>` handle.
  *
@@ -15,7 +15,7 @@ import { createLogger } from "@parity/product-sdk-logger";
 import type {
     createThemeProvider,
     ThemeMode as NovasamaThemeMode,
-} from "@novasamatech/product-sdk";
+} from "@novasamatech/host-api-wrapper";
 
 const log = createLogger("host:theme");
 
@@ -25,22 +25,22 @@ const log = createLogger("host:theme");
  * `Subscription<void>` (`unsubscribe` + `onInterrupt`).
  *
  * Type identical to `createThemeProvider()` from
- * `@novasamatech/product-sdk`.
+ * `@novasamatech/host-api-wrapper`.
  */
 export type ThemeProvider = ReturnType<typeof createThemeProvider>;
 
-/** Host theme mode value. Re-exported from `@novasamatech/product-sdk`. */
+/** Host theme mode value. Re-exported from `@novasamatech/host-api-wrapper`. */
 export type ThemeMode = NovasamaThemeMode;
 
 /**
  * Get the host theme provider.
  *
  * Returns the theme-subscription handle exported by
- * `@novasamatech/product-sdk`, or `null` if the package is unavailable
+ * `@novasamatech/host-api-wrapper`, or `null` if the package is unavailable
  * (running outside a host container or the optional peer dep isn't
  * installed).
  *
- * Implementation note: upstream `@novasamatech/product-sdk` exports only
+ * Implementation note: upstream `@novasamatech/host-api-wrapper` exports only
  * the `createThemeProvider` factory and no `themeProvider` singleton, so
  * this getter constructs a fresh instance on each call (unlike
  * {@link getPreimageManager} or {@link getHostLocalStorage}, which return
@@ -64,7 +64,7 @@ export type ThemeMode = NovasamaThemeMode;
  */
 export async function getThemeProvider(): Promise<ThemeProvider | null> {
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createThemeProvider();
     } catch (err) {
         log.debug("getThemeProvider unavailable", err);

--- a/product-sdk/packages/host/src/theme.ts
+++ b/product-sdk/packages/host/src/theme.ts
@@ -10,10 +10,14 @@
  * @module
  */
 
+import { createLogger } from "@parity/product-sdk-logger";
+
 import type {
     createThemeProvider,
     ThemeMode as NovasamaThemeMode,
 } from "@novasamatech/product-sdk";
+
+const log = createLogger("host:theme");
 
 /**
  * Host theme provider handle. Exposes `subscribeTheme(callback)` which
@@ -62,7 +66,8 @@ export async function getThemeProvider(): Promise<ThemeProvider | null> {
     try {
         const sdk = await import("@novasamatech/product-sdk");
         return sdk.createThemeProvider();
-    } catch {
+    } catch (err) {
+        log.debug("getThemeProvider unavailable", err);
         return null;
     }
 }

--- a/product-sdk/packages/host/src/theme.ts
+++ b/product-sdk/packages/host/src/theme.ts
@@ -10,7 +10,10 @@
  * @module
  */
 
-import type { createThemeProvider, ThemeMode as NovasamaThemeMode } from "@novasamatech/product-sdk";
+import type {
+    createThemeProvider,
+    ThemeMode as NovasamaThemeMode,
+} from "@novasamatech/product-sdk";
 
 /**
  * Host theme provider handle. Exposes `subscribeTheme(callback)` which

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -134,11 +134,11 @@ export type { HexString } from "@novasamatech/host-api";
  * - `themeSubscribe()` - Subscribe to host theme changes
  * - And many more...
  *
- * Type identical to `hostApi` from `@novasamatech/product-sdk` so that
+ * Type identical to `hostApi` from `@novasamatech/host-api-wrapper` so that
  * `truApi.X(...)` calls keep their full inference (return types, method
  * names, parameter shapes) instead of decaying to `any`.
  */
-export type TruApi = typeof import("@novasamatech/product-sdk").hostApi;
+export type TruApi = typeof import("@novasamatech/host-api-wrapper").hostApi;
 
 /** Cached TruApi instance */
 let cachedTruApi: TruApi | null = null;
@@ -237,7 +237,7 @@ export type PreimageManager = typeof preimageManager;
  * transport. Use this when you need a non-default transport; otherwise
  * prefer {@link getPreimageManager}, which returns the shared singleton.
  *
- * Mirrors `createPreimageManager` from `@novasamatech/product-sdk`.
+ * Mirrors `createPreimageManager` from `@novasamatech/host-api-wrapper`.
  *
  * @param transport - Optional transport; defaults to the sandbox transport.
  * @returns A new `PreimageManager` instance, or `null` if unavailable.
@@ -247,7 +247,7 @@ export async function createHostPreimageManager(
 ): Promise<PreimageManager | null> {
     if (!(await isInsideContainer())) return null;
     try {
-        const sdk = await import("@novasamatech/product-sdk");
+        const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createPreimageManager(transport);
     } catch (err) {
         log.debug("createHostPreimageManager unavailable", err);

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -102,16 +102,19 @@ export type { HexString } from "@novasamatech/host-api";
  * The TruApi type - provides low-level methods for communicating with the host.
  *
  * Methods include:
- * - `navigateTo(url)` — Navigate to a URL within the host
- * - `permission(permissions)` — Request permissions from the host
- * - `localStorageRead/Write/Clear` — Host-backed storage
- * - `sign(payload)` — Request transaction signing
- * - `deriveEntropy(context)` — Derive deterministic entropy
- * - `themeSubscribe()` — Subscribe to host theme changes
+ * - `navigateTo(url)` - Navigate to a URL within the host
+ * - `permission(permissions)` - Request permissions from the host
+ * - `localStorageRead/Write/Clear` - Host-backed storage
+ * - `sign(payload)` - Request transaction signing
+ * - `deriveEntropy(context)` - Derive deterministic entropy
+ * - `themeSubscribe()` - Subscribe to host theme changes
  * - And many more...
+ *
+ * Type identical to `hostApi` from `@novasamatech/product-sdk` so that
+ * `truApi.X(...)` calls keep their full inference (return types, method
+ * names, parameter shapes) instead of decaying to `any`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type TruApi = any;
+export type TruApi = typeof import("@novasamatech/product-sdk").hostApi;
 
 /** Cached TruApi instance */
 let cachedTruApi: TruApi | null = null;
@@ -203,6 +206,27 @@ export async function getPreimageManager(): Promise<PreimageManager | null> {
  * Type identical to `preimageManager` from `@novasamatech/host-api-wrapper`.
  */
 export type PreimageManager = typeof preimageManager;
+
+/**
+ * Construct a fresh `PreimageManager` instance with an optional custom
+ * transport. Use this when you need a non-default transport; otherwise
+ * prefer {@link getPreimageManager}, which returns the shared singleton.
+ *
+ * Mirrors `createPreimageManager` from `@novasamatech/product-sdk`.
+ *
+ * @param transport - Optional transport; defaults to the sandbox transport.
+ * @returns A new `PreimageManager` instance, or `null` if unavailable.
+ */
+export async function createHostPreimageManager(
+    transport?: import("@novasamatech/host-api").Transport,
+): Promise<PreimageManager | null> {
+    try {
+        const sdk = await import("@novasamatech/product-sdk");
+        return sdk.createPreimageManager(transport);
+    } catch {
+        return null;
+    }
+}
 
 /**
  * Get the accounts provider for managing host accounts.

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -16,10 +16,13 @@ import type {
     AllocationOutcome as AllocationOutcomeCodec,
     CodecType,
     RemotePermission as RemotePermissionCodec,
-    Statement as StatementCodec,
 } from "@novasamatech/host-api";
+import type {
+    createAccountsProvider,
+    preimageManager,
+} from "@novasamatech/host-api-wrapper";
 
-import type { StatementProof } from "./types.js";
+import type { Statement, StatementProof } from "./types.js";
 
 const log = createLogger("host");
 
@@ -193,27 +196,13 @@ export async function getPreimageManager(): Promise<PreimageManager | null> {
 }
 
 /**
- * Preimage manager interface for bulletin chain operations.
+ * Preimage manager handle for bulletin chain operations. `lookup` returns a
+ * `Subscription<void>` (`unsubscribe` + `onInterrupt`); `submit` returns a
+ * `0x`-prefixed hex preimage key.
+ *
+ * Type identical to `preimageManager` from `@novasamatech/host-api-wrapper`.
  */
-export interface PreimageManager {
-    /**
-     * Submit a preimage to the bulletin chain.
-     * @param data - The data to submit.
-     * @returns The preimage key (hex string).
-     */
-    submit(data: Uint8Array): Promise<string>;
-
-    /**
-     * Look up a preimage by key.
-     * @param key - The preimage key (hex string).
-     * @param callback - Called with the data when found, or null if not yet available.
-     * @returns Subscription handle with unsubscribe method.
-     */
-    lookup(
-        key: string,
-        callback: (preimage: Uint8Array | null) => void,
-    ): { unsubscribe: () => void; onInterrupt: (cb: () => void) => () => void };
-}
+export type PreimageManager = typeof preimageManager;
 
 /**
  * Get the accounts provider for managing host accounts.
@@ -223,7 +212,7 @@ export interface PreimageManager {
 export async function getAccountsProvider(): Promise<AccountsProvider | null> {
     try {
         const sdk = await import("@novasamatech/host-api-wrapper");
-        return sdk.createAccountsProvider() as unknown as AccountsProvider;
+        return sdk.createAccountsProvider();
     } catch {
         return null;
     }
@@ -306,22 +295,6 @@ export async function requestResourceAllocation(
 // ─────────────────────────────────────────────────────────────────────────────
 // Authorized Statement Store proof creation (RFC-10 §"Statement Store allowance")
 // ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * A Statement payload destined for the Statement Store. Matches the
- * `pallet-statement` Statement structure.
- *
- * The optional `proof` field is the same {@link StatementProof} shape that
- * {@link createProofAuthorized} returns: pass `undefined` here, call
- * `createProofAuthorized` to obtain the proof, then attach it before
- * submitting via `HostStatementStore.submit`. The `OnChain` variant of
- * `StatementProof` is a chain-attestation reference; the `Sr25519` /
- * `Ed25519` / `Ecdsa` variants are signing proofs.
- *
- * Derived from the upstream codec so structural changes surface as compile
- * errors here, not runtime decode failures.
- */
-export type Statement = CodecType<typeof StatementCodec>;
 
 /**
  * Have the host sign a Statement using an allowance-bearing account it
@@ -431,99 +404,16 @@ export interface ResultAsync<T, E> {
 }
 
 /**
- * Accounts provider interface from @novasamatech/host-api-wrapper.
+ * Accounts provider handle from `@novasamatech/host-api-wrapper`. Surfaces the
+ * full upstream API - host wallet accounts, app-scoped product accounts,
+ * Ring VRF, user identity (`getUserId`, `requestLogin`), and connection
+ * status subscription.
  *
- * Provides methods for accessing host wallet accounts, product accounts,
- * and Ring VRF operations.
+ * Type identical to `createAccountsProvider()` from
+ * `@novasamatech/host-api-wrapper`; methods return neverthrow `ResultAsync`
+ * values with typed `CodecError` variants in the error channel.
  */
-export interface AccountsProvider {
-    /**
-     * Get legacy accounts (user's external wallets connected to the host).
-     *
-     * Renamed from `getNonProductAccounts` in @novasamatech/host-api-wrapper 0.7.
-     *
-     * @returns ResultAsync resolving to array of accounts.
-     */
-    getLegacyAccounts: () => ResultAsync<HostAccount[], unknown>;
-
-    /**
-     * Get a signer for a legacy account.
-     *
-     * Renamed from `getNonProductAccountSigner` in @novasamatech/host-api-wrapper 0.7.
-     *
-     * @param account - The product account (used for public key lookup).
-     * @returns A PolkadotSigner for signing transactions.
-     */
-    getLegacyAccountSigner: (account: ProductAccount) => import("polkadot-api").PolkadotSigner;
-
-    /**
-     * Get an app-scoped product account from the host.
-     *
-     * Product accounts are derived by the host wallet for each app, identified
-     * by `dotNsIdentifier` (e.g., "mark3t.dot"). The user controls these accounts
-     * but they are scoped to the requesting app.
-     *
-     * @param dotNsIdentifier - App identifier (e.g., "mark3t.dot").
-     * @param derivationIndex - Derivation index within the app scope. Default: 0
-     * @returns ResultAsync resolving to the account.
-     */
-    getProductAccount: (
-        dotNsIdentifier: string,
-        derivationIndex?: number,
-    ) => ResultAsync<HostAccount, unknown>;
-
-    /**
-     * Get a signer for a product account.
-     *
-     * @param account - The product account.
-     * @returns A PolkadotSigner for signing transactions.
-     */
-    getProductAccountSigner: (account: ProductAccount) => import("polkadot-api").PolkadotSigner;
-
-    /**
-     * Get a contextual alias for a product account via Ring VRF.
-     *
-     * Aliases prove account membership in a ring without revealing which
-     * account produced the alias.
-     *
-     * @param dotNsIdentifier - App identifier.
-     * @param derivationIndex - Derivation index. Default: 0
-     * @returns ResultAsync resolving to the contextual alias.
-     */
-    getProductAccountAlias: (
-        dotNsIdentifier: string,
-        derivationIndex?: number,
-    ) => ResultAsync<ContextualAlias, unknown>;
-
-    /**
-     * Create a Ring VRF proof for anonymous operations.
-     *
-     * Proves that the signer is a member of the ring at the given location
-     * without revealing which member.
-     *
-     * @param dotNsIdentifier - App identifier.
-     * @param derivationIndex - Derivation index.
-     * @param location - Ring location on-chain.
-     * @param message - Message to sign.
-     * @returns ResultAsync resolving to the proof bytes.
-     */
-    createRingVRFProof: (
-        dotNsIdentifier: string,
-        derivationIndex: number,
-        location: unknown,
-        message: Uint8Array,
-    ) => ResultAsync<Uint8Array, unknown>;
-
-    /**
-     * Subscribe to account connection status changes.
-     *
-     * @param callback - Called with status string ("connected" | "disconnected").
-     * @returns Unsubscribe handle.
-     */
-    subscribeAccountConnectionStatus: (
-        callback: (status: string) => void,
-    ) => { unsubscribe: () => void } | (() => void);
-}
+export type AccountsProvider = ReturnType<typeof createAccountsProvider>;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -17,10 +17,7 @@ import type {
     CodecType,
     RemotePermission as RemotePermissionCodec,
 } from "@novasamatech/host-api";
-import type {
-    createAccountsProvider,
-    preimageManager,
-} from "@novasamatech/host-api-wrapper";
+import type { createAccountsProvider, preimageManager } from "@novasamatech/host-api-wrapper";
 
 import type { Statement, StatementProof } from "./types.js";
 

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -19,24 +19,51 @@ import type {
 } from "@novasamatech/host-api";
 import type { createAccountsProvider, preimageManager } from "@novasamatech/host-api-wrapper";
 
+import { isInsideContainer } from "./container.js";
 import type { Statement, StatementProof } from "./types.js";
 
 const log = createLogger("host");
 
 /**
- * Extract a human-readable message from an unknown error. `JSON.stringify`
- * on `Error` returns `"{}"` because `message` and `stack` are non-enumerable
- * — without this helper, wire failures surface as `"... failed: {}"` with
- * zero diagnostic context.
+ * Extract a human-readable message from a host-side error. Hosts wrap
+ * errors in versioned envelopes (`{ tag: "v1", value: CodecError }`); this
+ * helper unwraps the envelope and renders the inner error's `name`/`message`
+ * so callers see the host's actual diagnostic instead of `"[object Object]"`
+ * (from `String(err)`) or a JSON-stringified envelope.
+ *
+ * Exported for the higher-level wrappers (`requestPermission`,
+ * `deriveEntropy`, etc.) that build their `throw new Error(...)` messages.
  */
-function formatError(err: unknown): string {
-    if (err instanceof Error) return err.message;
-    if (typeof err === "string") return err;
-    try {
-        return JSON.stringify(err);
-    } catch {
-        return String(err);
+export function formatHostError(err: unknown): string {
+    // Single-level unwrap only; nested envelopes fall through to JSON.stringify.
+    const inner = isVersionedEnvelope(err) ? err.value : err;
+
+    if (inner instanceof Error) return inner.message;
+    if (typeof inner === "string") return inner;
+    if (
+        inner != null &&
+        typeof inner === "object" &&
+        "message" in inner &&
+        typeof (inner as { message: unknown }).message === "string"
+    ) {
+        const named = inner as { name?: unknown; message: string };
+        return typeof named.name === "string" ? `${named.name}: ${named.message}` : named.message;
     }
+    try {
+        return JSON.stringify(inner);
+    } catch {
+        return String(inner);
+    }
+}
+
+function isVersionedEnvelope(value: unknown): value is { tag: string; value: unknown } {
+    return (
+        value != null &&
+        typeof value === "object" &&
+        "tag" in value &&
+        "value" in value &&
+        typeof (value as { tag: unknown }).tag === "string"
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -190,7 +217,8 @@ export async function getPreimageManager(): Promise<PreimageManager | null> {
     try {
         const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.preimageManager;
-    } catch {
+    } catch (err) {
+        log.debug("getPreimageManager unavailable", err);
         return null;
     }
 }
@@ -217,10 +245,12 @@ export type PreimageManager = typeof preimageManager;
 export async function createHostPreimageManager(
     transport?: import("@novasamatech/host-api").Transport,
 ): Promise<PreimageManager | null> {
+    if (!(await isInsideContainer())) return null;
     try {
         const sdk = await import("@novasamatech/product-sdk");
         return sdk.createPreimageManager(transport);
-    } catch {
+    } catch (err) {
+        log.debug("createHostPreimageManager unavailable", err);
         return null;
     }
 }
@@ -234,7 +264,8 @@ export async function getAccountsProvider(): Promise<AccountsProvider | null> {
     try {
         const sdk = await import("@novasamatech/host-api-wrapper");
         return sdk.createAccountsProvider();
-    } catch {
+    } catch (err) {
+        log.debug("getAccountsProvider unavailable", err);
         return null;
     }
 }
@@ -306,7 +337,7 @@ export async function requestResourceAllocation(
     return await truApi.requestResourceAllocation(enumValue("v1", resources)).match(
         (envelope: { tag: "v1"; value: AllocationOutcome[] }) => envelope.value,
         (err: unknown) => {
-            throw new Error(`requestResourceAllocation failed: ${formatError(err)}`, {
+            throw new Error(`requestResourceAllocation failed: ${formatHostError(err)}`, {
                 cause: err,
             });
         },
@@ -372,7 +403,9 @@ export async function createProofAuthorized(statement: Statement): Promise<State
     return await truApi.statementStoreCreateProofAuthorized(enumValue("v1", statement)).match(
         (envelope: { tag: "v1"; value: StatementProof }) => envelope.value,
         (err: unknown) => {
-            throw new Error(`createProofAuthorized failed: ${formatError(err)}`, { cause: err });
+            throw new Error(`createProofAuthorized failed: ${formatHostError(err)}`, {
+                cause: err,
+            });
         },
     );
 }
@@ -455,6 +488,22 @@ if (import.meta.vitest) {
         const manager = await getPreimageManager();
         // In dev/test mode, product-sdk is installed
         expect(manager === null || typeof manager === "object").toBe(true);
+    });
+
+    test("createHostPreimageManager returns null outside container", async () => {
+        expect(await createHostPreimageManager()).toBeNull();
+    });
+
+    test("formatHostError unwraps versioned envelopes and renders CodecError", () => {
+        expect(
+            formatHostError({
+                tag: "v1",
+                value: { name: "GenericError", message: "boom" },
+            }),
+        ).toBe("GenericError: boom");
+        expect(formatHostError(new Error("plain"))).toBe("plain");
+        expect(formatHostError("string err")).toBe("string err");
+        expect(formatHostError({ tag: "v1", value: { message: "no-name" } })).toBe("no-name");
     });
 
     test("getAccountsProvider returns provider when SDK is available", async () => {

--- a/product-sdk/packages/host/src/types.ts
+++ b/product-sdk/packages/host/src/types.ts
@@ -1,62 +1,83 @@
 /**
- * Persistent string and JSON storage exposed by the host container. Most
- * apps reach it indirectly through the Storage package's `LocalKvStore`; reach for
- * it directly via {@link getHostLocalStorage} when you need raw host storage
- * without the KV abstraction.
+ * Public types for the host wrappers.
+ *
+ * These are re-exported from `@novasamatech/host-api-wrapper` (the runtime
+ * objects the host getters cast to) rather than hand-mirrored, so the
+ * Parity surface stays in lockstep with the upstream codec types.
  */
-export interface HostLocalStorage {
-    readString(key: string): Promise<string | null>;
-    writeString(key: string, value: string): Promise<void>;
-    readJSON<T>(key: string): Promise<T | null>;
-    writeJSON<T>(key: string, value: T): Promise<void>;
-    /**
-     * Clear a specific key from storage.
-     * @param key - The key to clear
-     */
-    clear(key: string): Promise<void>;
-}
+
+import type {
+    hostLocalStorage,
+    createStatementStore,
+    ProductAccountId as NovasamaProductAccountId,
+    SignedStatement as NovasamaSignedStatement,
+    Statement as NovasamaStatement,
+    StatementTopicFilter as NovasamaStatementTopicFilter,
+    StatementsPage as NovasamaStatementsPage,
+    Topic as NovasamaTopic,
+} from "@novasamatech/host-api-wrapper";
+import type { Subscription } from "@novasamatech/host-api";
+
+/**
+ * Persistent storage exposed by the host container, including string, JSON
+ * and raw byte (`readBytes`/`writeBytes`) accessors. Most apps reach it
+ * indirectly through the Storage package's `KvStore`; reach for it directly
+ * via {@link getHostLocalStorage} when you need raw host storage without the
+ * KV abstraction.
+ *
+ * Type identical to `hostLocalStorage` from `@novasamatech/host-api-wrapper`.
+ */
+export type HostLocalStorage = typeof hostLocalStorage;
 
 /**
  * Cryptographic proof attached to a statement before submission, returned by
  * {@link HostStatementStore.createProof}. Variants cover the supported
- * signature schemes — `Sr25519`, `Ed25519`, `Ecdsa`, and `OnChain` (chain-
+ * signature schemes - `Sr25519`, `Ed25519`, `Ecdsa`, and `OnChain` (chain-
  * attestation-based proofs).
  *
- * Mirrors `@novasamatech/host-api-wrapper@0.7`'s proof shape.
+ * Inferred from `createStatementStore().createProof`'s return type so codec
+ * changes surface here as compile errors, not runtime decode failures.
  */
-export type StatementProof =
-    | { tag: "Sr25519"; value: { signature: Uint8Array; signer: Uint8Array } }
-    | { tag: "Ed25519"; value: { signature: Uint8Array; signer: Uint8Array } }
-    | { tag: "Ecdsa"; value: { signature: Uint8Array; signer: Uint8Array } }
-    | {
-          tag: "OnChain";
-          value: { who: Uint8Array; blockHash: Uint8Array; event: bigint };
-      };
+export type StatementProof = Awaited<
+    ReturnType<ReturnType<typeof createStatementStore>["createProof"]>
+>;
 
 /**
- * Topic-based subscription filter. Mirrors `StatementTopicFilter` from
- * `@novasamatech/host-api-wrapper` — the host delivers statements that match
+ * Topic-based subscription filter. The host delivers statements that match
  * either *all* of the listed topics (`matchAll`) or *any* of them
- * (`matchAny`).
+ * (`matchAny`). Re-exported from `@novasamatech/host-api-wrapper`.
  */
-export type StatementTopicFilter = { matchAll: Uint8Array[] } | { matchAny: Uint8Array[] };
+export type StatementTopicFilter = NovasamaStatementTopicFilter;
+
+/** A single topic value used inside a {@link StatementTopicFilter}. Re-exported from `@novasamatech/host-api-wrapper`. */
+export type Topic = NovasamaTopic;
+
+/** `[ss58Address, chainPrefix]` tuple identifying a product account at the codec layer. Re-exported from `@novasamatech/host-api-wrapper`. */
+export type ProductAccountId = NovasamaProductAccountId;
+
+/** Unsigned statement payload. Re-exported from `@novasamatech/host-api-wrapper`. */
+export type Statement = NovasamaStatement;
+
+/** Statement bundled with its {@link StatementProof}. Re-exported from `@novasamatech/host-api-wrapper`. */
+export type SignedStatement = NovasamaSignedStatement;
 
 /**
  * A page of signed statements delivered by {@link HostStatementStore.subscribe}.
  *
  * Pages arrive sequentially. `isComplete` is `true` on the final page of a
  * subscription's initial backfill; subsequent pages contain new statements
- * as they appear on chain.
+ * as they appear on chain. `statements` is `SignedStatement[]` (typed,
+ * not `unknown[]`).
  */
-export interface StatementsPage {
-    statements: unknown[];
-    isComplete: boolean;
-}
+export type StatementsPage = NovasamaStatementsPage;
 
-/** Subscription handle returned by the host. */
-export interface HostSubscription {
-    unsubscribe: () => void;
-}
+/**
+ * Subscription handle returned by the host - equivalent to
+ * `Subscription<void>` from `@novasamatech/host-api`. Exposes
+ * `unsubscribe()` plus an `onInterrupt` hook that fires if the host
+ * interrupts the subscription server-side.
+ */
+export type HostSubscription = Subscription<void>;
 
 /**
  * Statement Store handle exposed by the host container. Provides
@@ -64,37 +85,7 @@ export interface HostSubscription {
  * host's native binary protocol; the `statement-store` package layers a
  * higher-level client on top.
  *
- * Shape matches `@novasamatech/host-api-wrapper@0.7`'s `createStatementStore()`.
+ * Type identical to `createStatementStore()` from
+ * `@novasamatech/host-api-wrapper`.
  */
-export interface HostStatementStore {
-    /**
-     * Subscribe to statements matching the given topic filter.
-     *
-     * The callback is invoked once per page of statements. After the initial
-     * backfill completes (signaled by `page.isComplete === true`), subsequent
-     * pages contain new statements as they're produced.
-     *
-     * @param filter   - Topic match filter (`matchAll` or `matchAny`).
-     * @param callback - Called with each `StatementsPage` from the host.
-     * @returns Subscription handle with `unsubscribe`.
-     */
-    subscribe(
-        filter: StatementTopicFilter,
-        callback: (page: StatementsPage) => void,
-    ): HostSubscription;
-
-    /**
-     * Create a proof for a statement using the given account.
-     *
-     * @param accountId - The account ID tuple `[ss58Address, chainPrefix]` from product-sdk.
-     * @param statement - The unsigned statement.
-     * @returns The proof (signature + signer info, or chain-attestation reference).
-     */
-    createProof(accountId: [string, number], statement: unknown): Promise<StatementProof>;
-
-    /**
-     * Submit a signed statement to the bulletin chain.
-     * @param signedStatement - Statement with attached proof.
-     */
-    submit(signedStatement: unknown): Promise<void>;
-}
+export type HostStatementStore = ReturnType<typeof createStatementStore>;

--- a/product-sdk/packages/local-storage/src/kv-store.ts
+++ b/product-sdk/packages/local-storage/src/kv-store.ts
@@ -105,15 +105,25 @@ if (import.meta.vitest) {
             },
             async writeString(key, value) {
                 data.set(key, value);
+                return undefined;
             },
-            async readJSON<T>(key: string): Promise<T | null> {
-                return (data.get(key) as T) ?? null;
+            async readJSON(key) {
+                return data.get(key) ?? null;
             },
             async writeJSON(key, value) {
                 data.set(key, value);
+                return undefined;
             },
-            async clear() {
-                data.clear();
+            async readBytes(key) {
+                return (data.get(key) as Uint8Array | undefined) ?? undefined;
+            },
+            async writeBytes(key, value) {
+                data.set(key, value);
+                return undefined;
+            },
+            async clear(key) {
+                data.delete(key);
+                return undefined;
             },
         };
     }

--- a/product-sdk/packages/sdk/package.json
+++ b/product-sdk/packages/sdk/package.json
@@ -59,7 +59,7 @@
     },
     "files": ["dist", "src"],
     "scripts": {
-        "build": "tsup",
+        "build": "NODE_OPTIONS=--max-old-space-size=8192 tsup",
         "clean": "rm -rf dist"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary

Closes #103, closes #115. Unblocks #93 (host-playground migration) for every Novasama import except `createPaymentManager` (tracked separately in #85) and 5 low-level symbols (`metaProvider`, `createMetaProvider`, `sandboxTransport`, `injectSpektrExtension`, `createLegacyExtensionEnableFactory`) that are intentionally not wrapped — see *Out of scope* below.

## Commits per closed issue 
### `feat(host, storage): widen typed surface of Novasama wrappers (#103)`

Four host wrappers declared narrower TypeScript interfaces than the upstream `@novasamatech/product-sdk` runtime objects they cast from. The runtime worked, but typecheck failed for any method the Parity interface omitted, forcing direct Novasama imports or `as any` at call sites.

- `HostLocalStorage = typeof hostLocalStorage` - adds `readBytes` / `writeBytes` and the typed `clear(key)` signature.
- `HostStatementStore = ReturnType<typeof createStatementStore>` - tightens `createProof` input types from `[string, number]` + `unknown` to `ProductAccountId` + `Statement` codecs, and `StatementsPage.statements` from `unknown[]` to `SignedStatement[]`.
- `PreimageManager = typeof preimageManager` - aligns `lookup` return type to `Subscription<void>`.
- `AccountsProvider = ReturnType<typeof createAccountsProvider>` - adds `requestLogin` and `getUserId` (RFC-0009), fixes the existing `getProductAccount` type lie that claimed `name?` when the runtime never returned one.
- New named re-exports added in `types.ts`: `Statement`, `SignedStatement`, `Topic`, `ProductAccountId`.
- `mockHostStorage` in `packages/storage/src/kv-store.ts` updated to satisfy the widened `HostLocalStorage`.

### `feat(host, chain-client): add missing wrappers for host-playground migration (#115)`

All wrappers ship **flat-in-host** (`getX()` getters returning `T | null`), matching the existing pattern (`getAccountsProvider`, `getStatementStore`, `getPreimageManager`). The optional-peer-dep contract is preserved via dynamic `await import("@novasamatech/product-sdk")` + try/catch null fallback.

**New domain wrappers**:

- `getThemeProvider` + `ThemeMode` / `ThemeProvider` types
- `deriveEntropy(key)` (RFC-0007) - throws-on-error Promise matching the `requestPermission` pattern
- `requestDevicePermission(kind)` + `DevicePermissionKind` / `RemotePermissionItem` aliases
- `WellKnownChain` constant (in `@parity/product-sdk-chain-client`, hand-copied genesis hashes - immutable values, avoids dragging Novasama into chain-client as a runtime dep)
- `getChatManager` + `matchChatCustomRenderers` + 7 chat type re-exports (see *Chat shape* below)

**Factory forms** (for callers needing custom transports):

- `createHostLocalStorage(transport?)`
- `createHostPreimageManager(transport?)`

**TruApi type narrowing**: `TruApi` changes from `any` to `typeof hostApi`, so `truApi.foo(...)` calls keep full inference instead of decaying to `any`. 

## Deliberate deviations from #93

**Chat lives flat-in-host as `getChatManager()`, not as `getTruApi().chat.*` per #93's migration table.** Two reasons:

1. The upstream JS `hostApi` is a flat object - there is no `.chat` accessor to mirror. Building `getTruApi().chat.*` would mean synthesizing the namespacing layer ourselves, which is the same amount of work as a flat wrapper and creates a JS structure not reflected upstream.
2. The other three wrappers in this PR (theme, entropy, device-permission) all ship flat-in-host. Chat follows the established pattern.

host-playground's own migration doc already flagged this gap: ["the Rust `TrUAPI::chat` module structure doesn't map directly to a JS `.chat.*` namespace yet on `hostApi`, which is a flat object."](https://github.com/paritytech/host-playground/blob/main/docs/migration/09-not-migrated.md). If a namespaced view is wanted later, it can be layered on top without breaking `getChatManager()`.

## Verification

Run from the repo root:

```bash
pnpm --filter "@parity/product-sdk-host" exec tsc --noEmit  # exit 0
pnpm --filter "@parity/product-sdk-host" test --run         # 28 tests pass
pnpm --filter "@parity/product-sdk-host" build              # dist/index.d.ts ~30 KB

for pkg in storage statement-store bulletin signer terminal chain-client; do
  pnpm --filter "@parity/product-sdk-$pkg" exec tsc --noEmit
  pnpm --filter "@parity/product-sdk-$pkg" test --run
done
```

Local results: 
- host 28 ✓, 
- storage 13 ✓, 
- statement-store 48 ✓, 
- bulletin 75 ✓, 
- signer 88 ✓, 
- terminal 131 ✓, 
- chain-client 28 ✓ 
- 411 tests total, typecheck clean across all packages.

## Out of scope

- Payments (createPaymentManager) - tracked in #85.
- Wrappers for metaProvider / createMetaProvider / sandboxTransport / injectSpektrExtension / createLegacyExtensionEnableFactory - intentionally not added. host-playground's production code supersedes these with higher-level Parity surfaces (SignerManager.state.status, isInsideContainer, SignerManager.connect()); only its tests.ts feature-matrix uses them directly, where direct Novasama imports are the right answer.
- host-playground side migration - this PR closes the product-sdk-side gaps; the actual find-and-replace in host-playground happens after this lands.
- getTruApi().chat.* namespacing - addressed by the flat-in-host choice above. Re-open if you want a different shape; the getChatManager() API doesn't preclude adding a namespaced view later.

## What host-playground gains
The Novasama import line in [host-playground/src/lib/tests.ts](https://github.com/paritytech/host-playground/blob/main/src/lib/tests.ts) can shrink from 19 symbols to 6 - createPaymentManager (tracked in #85) plus the 5 low-level symbols listed in Out of scope above. Everything else routes through @parity/product-sdk-host (or @parity/product-sdk-chain-client for WellKnownChain).