### PR TITLE
feat(contracts-demo): revive e2e specs on Paseo v2 - close Group 2

### DIFF
--- a/product-sdk/examples/contracts-demo/e2e/helpers.ts
+++ b/product-sdk/examples/contracts-demo/e2e/helpers.ts
@@ -25,7 +25,6 @@ export async function waitForAppReady(
     await expect(frame.locator('[data-testid="account-address"]')).not.toHaveText("-", { timeout });
 
     // ContractManager ready → action buttons enabled
-    await expect(frame.locator('[data-testid="btn-query-owner"]')).toBeEnabled({ timeout });
     await expect(frame.locator('[data-testid="btn-query-report-count"]')).toBeEnabled({ timeout });
     await expect(frame.locator('[data-testid="btn-query-all-dates"]')).toBeEnabled({ timeout });
     await expect(frame.locator('[data-testid="btn-query-cid"]')).toBeEnabled({ timeout });

--- a/product-sdk/examples/contracts-demo/e2e/helpers.ts
+++ b/product-sdk/examples/contracts-demo/e2e/helpers.ts
@@ -5,8 +5,9 @@ import { expect, type FrameLocator } from "@playwright/test";
  * Wait for the contracts-demo app to be fully ready inside the test host iframe:
  *   1. Host ↔ product-sdk connection established.
  *   2. App heading rendered.
- *   3. SignerManager reports "connected" and an account is selected.
- *   4. ContractManager initialised — both action buttons are enabled.
+ *   3. SignerManager reports "connected" and a product account is populated
+ *      via `manager.getProductAccount("contracts-demo.dot", 0)`.
+ *   4. ContractManager initialised — all action buttons are enabled.
  */
 export async function waitForAppReady(
     testHost: TestHost,

--- a/product-sdk/examples/contracts-demo/e2e/query.spec.ts
+++ b/product-sdk/examples/contracts-demo/e2e/query.spec.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+
 import { test, expect } from "./fixtures";
 import { waitForAppReady } from "./helpers";
 
@@ -5,113 +7,90 @@ import { waitForAppReady } from "./helpers";
  * Covers `contract.method.query()` — the dry-run (read-only) path in
  * `@parity/product-sdk-contracts`.
  *
- * `owner()` on the t3rminal bulletin-index contract is a zero-arg view
- * function that returns the deployer's H160 address. It exercises:
- *   - The full RPC path through the host's chainConnection handler.
- *   - `ContractManager.getContract().owner.query()` resolution.
- *   - No signing is involved — proves queries work independently.
+ * The three tests are the live-chain counterpart to the
+ * `wrapContract — PAPI 2.x boundary` integration tests in `wrap.ts`.
  *
- * The owner address is stable (deployer set at construction), so the
- * assertion is a simple non-null, non-error check.
+ * They feed the contract a freshly-randomised `bytes32` shopKey
+ * (generated per test-run, guaranteed never-before-written) and assert
+ * the decoded return value. Together they exercise every leg of the
+ * boundary:
+ *   - viem encoding the `bytes32` arg into the calldata,
+ *   - the calldata flowing as a `Uint8Array` through PAPI's
+ *     `ReviveApi.call`,
+ *   - the chain's response coming back as a `Uint8Array`,
+ *   - viem decoding three different ABI return shapes (uint256,
+ *     string[], string).
+ *
+ * If the SDK ever regresses to passing class-based `Binary` /
+ * `FixedSizeBinary` instances again, every one of these will fail
+ * with `Incompatible runtime entry RuntimeCall(ReviveApi_call)`
+ * before the response decode is even reached — i.e. these are the
+ * canary that turns red the moment the version skew comes back.
+ *
+ * Why randomise the shopKey: Paseo v2 is a public testnet with
+ * permanent state. An earlier version of this suite used the zero
+ * shopKey, which collided with submit.spec.ts's write (also zero at
+ * the time) and produced flaky "expected 0, got 1" failures after the
+ * first run. A fresh 32 random bytes per test-run is vanishingly
+ * unlikely to have ever been written to, so the deterministic empties
+ * (`uint256 0`, `string[] []`, `string ""`) hold regardless of the
+ * chain's accumulated history.
  */
-// TODO(contract-redeploy): Unskip once `@t3rminal/bulletin-index` is redeployed
-// on paseo v2 and `examples/contracts-demo/src/cdm.json` is updated with the new
-// address. Today the cdm.json points at the v1 deployment address (0xA2E388…),
-// which has no code on v2, so every query returns `undefined`.
-test.describe.skip("@parity/product-sdk-contracts via Host API — query", () => {
-    test("owner() dry-run returns a hex address without signing", async ({ testHost }) => {
-        const frame = await waitForAppReady(testHost);
-        await testHost.clearSigningLog();
+const FRESH_SHOP_KEY = ("0x" + randomBytes(32).toString("hex")) as `0x${string}`;
 
-        await frame.locator('[data-testid="btn-query-owner"]').click();
-
-        const logLoc = frame.locator('[data-testid="contract-log"]');
-
-        // The result is an H160 address (0x...)
-        await expect(logLoc).toContainText(/owner: 0x[0-9a-fA-F]{40}/i, { timeout: 30_000 });
-
-        // No signing should have occurred — query is a pure dry-run
-        const signingLog = await testHost.getSigningLog();
-        expect(signingLog).toHaveLength(0);
-    });
-
-    /**
-     * The next three tests are the live-chain counterpart to the new
-     * `wrapContract — PAPI 2.x boundary` integration tests in `wrap.ts`.
-     *
-     * They feed the contract a live `address` argument (the zero address,
-     * for deterministic empty results) and assert the decoded return value.
-     * Together they exercise every leg of the boundary:
-     *   - viem encoding `HexString` address args into the calldata,
-     *   - the calldata flowing as a `Uint8Array` through PAPI's
-     *     `ReviveApi.call`,
-     *   - the chain's response coming back as a `Uint8Array`,
-     *   - viem decoding three different ABI return shapes (uint256,
-     *     string[], string).
-     *
-     * If the SDK ever regresses to passing class-based `Binary` /
-     * `FixedSizeBinary` instances again, every one of these will fail
-     * with `Incompatible runtime entry RuntimeCall(ReviveApi_call)`
-     * before the response decode is even reached — i.e. these are the
-     * canary that turns red the moment the version skew comes back.
-     */
-    test("getReportCount(zero address) decodes uint256 → 0 (deterministic)", async ({
+test.describe("@parity/product-sdk-contracts via Host API — query", () => {
+    test("getReportCount(fresh shopKey) decodes uint256 → 0 (deterministic)", async ({
         testHost,
     }) => {
         const frame = await waitForAppReady(testHost);
         await testHost.clearSigningLog();
 
-        await frame
-            .locator('[data-testid="query-shop-input"]')
-            .fill("0x0000000000000000000000000000000000000000");
+        await frame.locator('[data-testid="query-shopkey-input"]').fill(FRESH_SHOP_KEY);
         await frame.locator('[data-testid="btn-query-report-count"]').click();
 
         const logLoc = frame.locator('[data-testid="contract-log"]');
-        // The contract has never seen the zero address, so the count must
-        // be exactly 0. The word boundary anchors the digit so e.g. 10
-        // or 100 wouldn't slip through.
+        // The contract has never seen this freshly-randomised shopKey, so
+        // the count must be exactly 0. The word boundary anchors the digit
+        // so e.g. 10 or 100 wouldn't slip through.
         await expect(logLoc).toContainText(/reportCount: 0\b/, { timeout: 30_000 });
 
         const signingLog = await testHost.getSigningLog();
         expect(signingLog).toHaveLength(0);
     });
 
-    test("getAllDates(zero address) decodes string[] → [] (deterministic)", async ({
+    test("getAllDates(fresh shopKey) decodes string[] → [] (deterministic)", async ({
         testHost,
     }) => {
         const frame = await waitForAppReady(testHost);
         await testHost.clearSigningLog();
 
-        await frame
-            .locator('[data-testid="query-shop-input"]')
-            .fill("0x0000000000000000000000000000000000000000");
+        await frame.locator('[data-testid="query-shopkey-input"]').fill(FRESH_SHOP_KEY);
         await frame.locator('[data-testid="btn-query-all-dates"]').click();
 
         const logLoc = frame.locator('[data-testid="contract-log"]');
         // viem decodes a Solidity `string[]` to a JS array — for an
-        // unknown shop, exactly the empty array `[]`. The demo logs it
-        // as `allDates: []` via `JSON.stringify`.
+        // unknown shopKey, exactly the empty array `[]`. The demo logs
+        // it as `allDates: []` via `JSON.stringify`.
         await expect(logLoc).toContainText("allDates: []", { timeout: 30_000 });
 
         const signingLog = await testHost.getSigningLog();
         expect(signingLog).toHaveLength(0);
     });
 
-    test("getCID(zero address, date) decodes string → \"\" (deterministic)", async ({
+    test("getCID(fresh shopKey, date) decodes string → \"\" (deterministic)", async ({
         testHost,
     }) => {
         const frame = await waitForAppReady(testHost);
         await testHost.clearSigningLog();
 
-        await frame
-            .locator('[data-testid="query-shop-input"]')
-            .fill("0x0000000000000000000000000000000000000000");
+        await frame.locator('[data-testid="query-shopkey-input"]').fill(FRESH_SHOP_KEY);
         await frame.locator('[data-testid="report-date-input"]').fill("2099-12-31");
         await frame.locator('[data-testid="btn-query-cid"]').click();
 
         const logLoc = frame.locator('[data-testid="contract-log"]');
-        // No CID stored for this (shop, date) — viem decodes the empty
-        // string return as `""`. The demo logs `cid: ""` via JSON.stringify.
+        // No CID stored for this (shopKey, date) — viem decodes the
+        // empty string return as `""`. The demo logs `cid: ""` via
+        // JSON.stringify.
         await expect(logLoc).toContainText('cid: ""', { timeout: 30_000 });
 
         const signingLog = await testHost.getSigningLog();

--- a/product-sdk/examples/contracts-demo/e2e/submit.spec.ts
+++ b/product-sdk/examples/contracts-demo/e2e/submit.spec.ts
@@ -20,11 +20,12 @@ import { waitForAppReady } from "./helpers";
  *     `"createTransaction"` path).
  *   - The button re-enables after completion.
  *
- * State isolation: this test writes to `SUBMIT_SHOP_KEY` (a non-zero
- * sentinel), NOT to the zero shopKey that query.spec.ts asserts against.
- * Paseo v2 is a public testnet — every successful submit persists
- * forever, so the two specs must use disjoint keys to avoid the submit's
- * write polluting the query's "deterministic empty" assertions.
+ * State isolation: this test writes to `SUBMIT_SHOP_KEY` (a fixed
+ * non-zero sentinel), while `query.spec.ts` asserts against a freshly
+ * randomised shopKey generated per test-run. The two specs use disjoint
+ * keys because Paseo v2 is a public testnet — every successful submit
+ * persists forever, and if both specs used the same key the submit's
+ * write would pollute the query's "deterministic empty" assertions.
  */
 const SUBMIT_SHOP_KEY = "0x0000000000000000000000000000000000000000000000000000000000000001";
 

--- a/product-sdk/examples/contracts-demo/e2e/submit.spec.ts
+++ b/product-sdk/examples/contracts-demo/e2e/submit.spec.ts
@@ -34,8 +34,8 @@ test.describe("@parity/product-sdk-contracts via Host API — submit", () => {
         const frame = await waitForAppReady(testHost);
         await testHost.clearSigningLog();
 
-        // Write under a non-zero key so we don't pollute the zero shopKey
-        // that query.spec.ts uses for "deterministic empty" assertions.
+        // Write under a fixed non-zero sentinel so this submit doesn't collide
+        // with query.spec.ts's randomised shopKeys (see header for rationale).
         await frame.locator('[data-testid="query-shopkey-input"]').fill(SUBMIT_SHOP_KEY);
 
         const btn = frame.locator('[data-testid="btn-store-report"]');

--- a/product-sdk/examples/contracts-demo/e2e/submit.spec.ts
+++ b/product-sdk/examples/contracts-demo/e2e/submit.spec.ts
@@ -5,28 +5,37 @@ import { waitForAppReady } from "./helpers";
  * Covers `contract.method.tx()` — the signed-transaction path in
  * `@parity/product-sdk-contracts`.
  *
- * `storeDailyReport(date, cid, entryCount)` on the t3rminal bulletin-index
- * contract is permissionless: any caller stores a report indexed by
- * msg.sender. It exercises the full host-signing path:
+ * `storeDailyReport(shopKey, date, cid, entryCount)` on the t3rminal
+ * bulletin-index contract is permissionless (per the contract's NatSpec
+ * `@dev Write is permissionless`). It exercises the full host-signing
+ * path:
  *
  *   ContractManager → ReviveApi.call (dry-run) → Revive.call → submitAndWatch()
- *     → host.handleSignPayload (TransactionSubmit permission)
+ *     → productAccount.getSigner() (host_create_transaction)
  *       → pallet_revive::call on Paseo Asset Hub
  *
  * Asserts:
  *   - The tx lands in a best block (result.ok = true).
- *   - Exactly one payload was signed by the host signer.
+ *   - Exactly one extrinsic was signed by the host signer (via the
+ *     `"createTransaction"` path).
  *   - The button re-enables after completion.
+ *
+ * State isolation: this test writes to `SUBMIT_SHOP_KEY` (a non-zero
+ * sentinel), NOT to the zero shopKey that query.spec.ts asserts against.
+ * Paseo v2 is a public testnet — every successful submit persists
+ * forever, so the two specs must use disjoint keys to avoid the submit's
+ * write polluting the query's "deterministic empty" assertions.
  */
-// TODO(truapi-migration): Unskip once `@parity/product-sdk-signer`'s host
-// provider routes through TrUAPI's `signing.createTransaction` instead of
-// `@novasamatech/host-api-wrapper`'s PJS bridge, which throws on Paseo v2's
-// `AsPgas` signed extension. Also depends on `@t3rminal/bulletin-index` being
-// redeployed on paseo v2 — see the contract-redeploy tracker.
-test.describe.skip("@parity/product-sdk-contracts via Host API — submit", () => {
+const SUBMIT_SHOP_KEY = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+test.describe("@parity/product-sdk-contracts via Host API — submit", () => {
     test("storeDailyReport tx lands in best block via host signing", async ({ testHost }) => {
         const frame = await waitForAppReady(testHost);
         await testHost.clearSigningLog();
+
+        // Write under a non-zero key so we don't pollute the zero shopKey
+        // that query.spec.ts uses for "deterministic empty" assertions.
+        await frame.locator('[data-testid="query-shopkey-input"]').fill(SUBMIT_SHOP_KEY);
 
         const btn = frame.locator('[data-testid="btn-store-report"]');
         await btn.click();
@@ -42,7 +51,7 @@ test.describe.skip("@parity/product-sdk-contracts via Host API — submit", () =
         // Exactly one extrinsic was signed — no duplicate submissions
         const signingLog = await testHost.getSigningLog();
         expect(signingLog).toHaveLength(1);
-        expect(signingLog[0].type).toBe("payload");
+        expect(signingLog[0].type).toBe("createTransaction");
 
         await expect(btn).toBeEnabled({ timeout: 10_000 });
     });

--- a/product-sdk/examples/contracts-demo/index.html
+++ b/product-sdk/examples/contracts-demo/index.html
@@ -77,8 +77,10 @@
             boundary against the live chain. viem encodes the `bytes32`
             shopKey arg into the calldata `Uint8Array`; the host returns a
             `Uint8Array` which viem decodes back to uint256 / string[] /
-            string. The zero-bytes32 default makes results deterministic
-            across runs (always 0 reports, [] dates, "" CID).
+            string. The zero-bytes32 default is a convenient placeholder
+            for interactive exploration — its return values depend on
+            what's accumulated on Paseo v2 testnet (the e2e specs use a
+            freshly-randomised shopKey to guarantee empty results).
         -->
         <div class="row">
             <label>Shop key:</label>

--- a/product-sdk/examples/contracts-demo/index.html
+++ b/product-sdk/examples/contracts-demo/index.html
@@ -72,37 +72,32 @@
 
         <hr />
 
-        <!-- Query: read contract owner — no signing required -->
-        <div class="row">
-            <button id="btn-query-owner" data-testid="btn-query-owner" disabled>Query owner()</button>
-        </div>
-
         <!--
             Read-only queries with arguments — exercise the PAPI 2.x codec
-            boundary against the live chain. viem encodes the `address` arg
-            as a hex string into the calldata `Uint8Array`; the host returns
-            a `Uint8Array` which viem decodes back to uint256 / string[] /
-            string. The zero-address default makes results deterministic
+            boundary against the live chain. viem encodes the `bytes32`
+            shopKey arg into the calldata `Uint8Array`; the host returns a
+            `Uint8Array` which viem decodes back to uint256 / string[] /
+            string. The zero-bytes32 default makes results deterministic
             across runs (always 0 reports, [] dates, "" CID).
         -->
         <div class="row">
-            <label>Shop addr:</label>
+            <label>Shop key:</label>
             <input
-                id="query-shop-input"
-                data-testid="query-shop-input"
+                id="query-shopkey-input"
+                data-testid="query-shopkey-input"
                 type="text"
-                value="0x0000000000000000000000000000000000000000"
+                value="0x0000000000000000000000000000000000000000000000000000000000000000"
             />
         </div>
         <div class="row">
             <button id="btn-query-report-count" data-testid="btn-query-report-count" disabled>
-                getReportCount(shop)
+                getReportCount(shopKey)
             </button>
             <button id="btn-query-all-dates" data-testid="btn-query-all-dates" disabled>
-                getAllDates(shop)
+                getAllDates(shopKey)
             </button>
             <button id="btn-query-cid" data-testid="btn-query-cid" disabled>
-                getCID(shop, date)
+                getCID(shopKey, date)
             </button>
         </div>
 

--- a/product-sdk/examples/contracts-demo/src/cdm.json
+++ b/product-sdk/examples/contracts-demo/src/cdm.json
@@ -1,81 +1,104 @@
 {
     "targets": {
-        "acc2c3b5e912b762": {
+        "929b5c63e2cb5202": {
             "asset-hub": "wss://paseo-asset-hub-next-rpc.polkadot.io",
-            "bulletin": "https://paseo-bulletin-next-ipfs.polkadot.io"
+            "bulletin": "https://paseo-bulletin-next-ipfs.polkadot.io/ipfs",
+            "registry": "0xa7ae171c78f06c248a9b2556c793aa1df5c9173a"
+        }
+    },
+    "dependencies": {
+        "929b5c63e2cb5202": {
+            "@t3rminal/bulletin-index": 3
         }
     },
     "contracts": {
-        "acc2c3b5e912b762": {
+        "929b5c63e2cb5202": {
             "@t3rminal/bulletin-index": {
-                "version": 0,
-                "address": "0xA2E388421467E0193570Af45Bd03F0F379c47E88",
+                "version": 3,
+                "address": "0x3331A87C2B9312E246E6A7eE8D0C0AdD8d282B6F",
                 "abi": [
                     {
-                        "type": "constructor",
-                        "inputs": [],
-                        "stateMutability": "nonpayable"
-                    },
-                    {
-                        "type": "event",
+                        "anonymous": false,
+                        "inputs": [
+                            { "indexed": true, "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
+                            { "indexed": true, "internalType": "string", "name": "date", "type": "string" },
+                            { "indexed": false, "internalType": "string", "name": "cid", "type": "string" },
+                            { "indexed": false, "internalType": "uint256", "name": "entryCount", "type": "uint256" },
+                            { "indexed": false, "internalType": "address", "name": "writer", "type": "address" }
+                        ],
                         "name": "DailyReportStored",
-                        "inputs": [
-                            { "indexed": true, "name": "shop", "type": "address" },
-                            { "indexed": true, "name": "date", "type": "string" },
-                            { "indexed": false, "name": "cid", "type": "string" },
-                            { "indexed": false, "name": "entryCount", "type": "uint256" }
-                        ]
+                        "type": "event"
                     },
                     {
-                        "type": "function",
-                        "name": "owner",
-                        "inputs": [],
-                        "outputs": [{ "name": "", "type": "address" }],
-                        "stateMutability": "view"
-                    },
-                    {
-                        "type": "function",
-                        "name": "storeDailyReport",
                         "inputs": [
-                            { "name": "date", "type": "string" },
-                            { "name": "cid", "type": "string" },
-                            { "name": "entryCount", "type": "uint256" }
+                            { "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
+                            { "internalType": "string", "name": "date", "type": "string" }
                         ],
-                        "outputs": [],
-                        "stateMutability": "nonpayable"
+                        "name": "dateExists",
+                        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+                        "stateMutability": "view",
+                        "type": "function"
                     },
                     {
-                        "type": "function",
+                        "inputs": [{ "internalType": "bytes32", "name": "shopKey", "type": "bytes32" }],
                         "name": "getAllDates",
-                        "inputs": [{ "name": "shop", "type": "address" }],
-                        "outputs": [{ "name": "", "type": "string[]" }],
-                        "stateMutability": "view"
+                        "outputs": [{ "internalType": "string[]", "name": "", "type": "string[]" }],
+                        "stateMutability": "view",
+                        "type": "function"
                     },
                     {
-                        "type": "function",
-                        "name": "getReportCount",
-                        "inputs": [{ "name": "shop", "type": "address" }],
-                        "outputs": [{ "name": "", "type": "uint256" }],
-                        "stateMutability": "view"
-                    },
-                    {
-                        "type": "function",
-                        "name": "getCID",
                         "inputs": [
-                            { "name": "shop", "type": "address" },
-                            { "name": "date", "type": "string" }
+                            { "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
+                            { "internalType": "string", "name": "date", "type": "string" }
                         ],
-                        "outputs": [{ "name": "", "type": "string" }],
-                        "stateMutability": "view"
+                        "name": "getCID",
+                        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+                        "stateMutability": "view",
+                        "type": "function"
                     },
                     {
-                        "type": "function",
-                        "name": "transferOwnership",
-                        "inputs": [{ "name": "newOwner", "type": "address" }],
+                        "inputs": [
+                            { "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
+                            { "internalType": "string", "name": "date", "type": "string" }
+                        ],
+                        "name": "getMetadata",
+                        "outputs": [
+                            {
+                                "components": [
+                                    { "internalType": "string", "name": "cid", "type": "string" },
+                                    { "internalType": "uint256", "name": "entryCount", "type": "uint256" },
+                                    { "internalType": "uint256", "name": "publishedAt", "type": "uint256" },
+                                    { "internalType": "bool", "name": "exists", "type": "bool" }
+                                ],
+                                "internalType": "struct IT3rminalBulletinIndex.DayMetadata",
+                                "name": "",
+                                "type": "tuple"
+                            }
+                        ],
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "inputs": [{ "internalType": "bytes32", "name": "shopKey", "type": "bytes32" }],
+                        "name": "getReportCount",
+                        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+                        "stateMutability": "view",
+                        "type": "function"
+                    },
+                    {
+                        "inputs": [
+                            { "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
+                            { "internalType": "string", "name": "date", "type": "string" },
+                            { "internalType": "string", "name": "cid", "type": "string" },
+                            { "internalType": "uint256", "name": "entryCount", "type": "uint256" }
+                        ],
+                        "name": "storeDailyReport",
                         "outputs": [],
-                        "stateMutability": "nonpayable"
+                        "stateMutability": "nonpayable",
+                        "type": "function"
                     }
-                ]
+                ],
+                "metadataCid": "bafk2bzacecs43cb4byqnwi4p7fj5iqzyrbluuwbp5aho2gxyxrzuqp5jkedn2"
             }
         }
     }

--- a/product-sdk/examples/contracts-demo/src/main.ts
+++ b/product-sdk/examples/contracts-demo/src/main.ts
@@ -8,7 +8,7 @@
  *
  * Exercises the two core host-API paths in @parity/product-sdk-contracts:
  *   - query()  — dry-run via chain RPC (no signing)
- *   - tx()     — signed extrinsic via host's handleSignPayload
+ *   - tx()     — signed extrinsic via host_create_transaction 
  *
  * Flow inside the host-api-test-sdk test host:
  *   1. SignerManager.connect() establishes the HostProvider session.

--- a/product-sdk/examples/contracts-demo/src/main.ts
+++ b/product-sdk/examples/contracts-demo/src/main.ts
@@ -11,15 +11,27 @@
  *   - tx()     — signed extrinsic via host's handleSignPayload
  *
  * Flow inside the host-api-test-sdk test host:
- *   1. SignerManager.connect() auto-detects → HostProvider
- *   2. Host responds with Bob's non-product account
- *   3. getChainAPI("paseo") routes RPC through the host's chainConnection handler
- *   4. ContractManager.fromClient(cdm, chain.raw.assetHub) wraps the contract
- *   5. contract.getReportCount.query(shopKey) → dry-run via RPC — no signing
- *   6. contract.storeDailyReport.tx(shopKey, date, cid, count) → signs via
- *      host.handleSignPayload → on-chain
+ *   1. SignerManager.connect() establishes the HostProvider session.
+ *   2. manager.getProductAccount("contracts-demo.dot", 0) asks the host for
+ *      a DotNS-derived product account. The fixture maps
+ *      "contracts-demo.dot/0" to Bob's funded keypair via `productAccounts`.
+ *   3. getChainAPI("paseo") routes RPC through the host's chainConnection
+ *      handler.
+ *   4. ContractManager.fromClient(cdm, chain.raw.assetHub) wraps the contract.
+ *   5. contract.getReportCount.query(shopKey) → dry-run via RPC — no signing.
+ *   6. contract.storeDailyReport.tx(shopKey, date, cid, count) uses
+ *      productAccount.getSigner() — which routes through
+ *      `getProductAccountSigner(..., "createTransaction")` and preserves
+ *      arbitrary signed extensions (e.g. AsPgas on Paseo Next).
+ *
+ * Why not the legacy-account path: `manager.connect()` + `selectAccount`
+ * + `manager.getSigner()` builds the signer via `getLegacyAccountSigner`,
+ * which has no signerType switch upstream and always routes through PJS.
+ * PJS throws on unknown signed extensions like AsPgas. Product-account
+ * signing avoids that path entirely.
  */
 
+import type { SignerAccount } from "@parity/product-sdk-signer";
 import { SignerManager } from "@parity/product-sdk-signer";
 import { getChainAPI } from "@parity/product-sdk-chain-client";
 import { ContractManager, ensureContractAccountMapped } from "@parity/product-sdk-contracts";
@@ -66,6 +78,12 @@ const SS58_PREFIX = 0; // Paseo Asset Hub
 
 const manager = new SignerManager({ ss58Prefix: SS58_PREFIX, dappName: "contracts-demo" });
 
+// The product account we sign all transactions with. Populated by init()
+// via `manager.getProductAccount("contracts-demo.dot", 0)`. Its `getSigner()`
+// routes through the host's `host_create_transaction` path so unknown
+// signed extensions (e.g. AsPgas on Paseo Next) round-trip end-to-end.
+let productAccount: SignerAccount | null = null;
+
 type ChainClient = Awaited<ReturnType<typeof getChainAPI<"paseo">>>;
 let chain: ChainClient | null = null;
 let contractManager: ContractManager | null = null;
@@ -74,11 +92,21 @@ let contractManager: ContractManager | null = null;
 manager.subscribe((state) => {
     $connectionStatus.textContent = state.status;
     $activeProvider.textContent = state.activeProvider ?? "-";
-    $accountAddress.textContent = state.selectedAccount?.address ?? "-";
+    $accountAddress.textContent = productAccount?.address ?? "-";
     const ready =
-        state.status === "connected" && state.selectedAccount !== null && contractManager !== null;
+        state.status === "connected" && productAccount !== null && contractManager !== null;
     setControlsEnabled(ready);
 });
+
+// Re-render readiness when fields the manager subscription doesn't observe
+// (productAccount, contractManager) change. Called at the end of init().
+function renderReady(): void {
+    $accountAddress.textContent = productAccount?.address ?? "-";
+    const state = manager.getState();
+    const ready =
+        state.status === "connected" && productAccount !== null && contractManager !== null;
+    setControlsEnabled(ready);
+}
 
 // ── Actions ──────────────────────────────────────────────────────────
 
@@ -166,11 +194,11 @@ $btnStoreReport.addEventListener("click", async () => {
         log("Contract manager not ready", "err");
         return;
     }
-    const signer = manager.getSigner();
-    if (!signer) {
-        log("No signer selected", "err");
+    if (!productAccount) {
+        log("Product account not ready", "err");
         return;
     }
+    const signer = productAccount.getSigner();
 
     const shopKey = $queryShopKeyInput.value || ZERO_SHOP_KEY;
     const date = $reportDateInput.value || "2026-01-01";
@@ -201,23 +229,29 @@ $btnStoreReport.addEventListener("click", async () => {
 async function init() {
     log("Booting contracts-demo…");
 
+    // Step 1: establish the host session. We don't use the returned legacy
+    // accounts — they sign via the PJS bridge, which throws on unknown
+    // signed extensions (e.g. AsPgas on Paseo Next). The product-account
+    // request below uses `getProductAccountSigner` with `"createTransaction"`
+    // and avoids that path.
     log("Connecting signer…");
     const connectRes = await manager.connect();
     if (!connectRes.ok) {
         log(`Signer connect failed: ${connectRes.error.message}`, "err");
         return;
     }
-    const accounts = connectRes.value;
-    if (accounts.length === 0) {
-        log("No accounts exposed by the host", "err");
+
+    // Step 2: request the product account. The fixture maps
+    // "contracts-demo.dot/0" → bob via `productAccounts`, so this returns
+    // Bob's funded account but signs through host_create_transaction.
+    log("Requesting product account contracts-demo.dot/0…");
+    const productRes = await manager.getProductAccount("contracts-demo.dot", 0);
+    if (!productRes.ok) {
+        log(`getProductAccount failed: ${productRes.error.message}`, "err");
         return;
     }
-    const selectRes = manager.selectAccount(accounts[0].address);
-    if (!selectRes.ok) {
-        log(`selectAccount failed: ${selectRes.error.message}`, "err");
-        return;
-    }
-    log(`Signer ready: ${accounts[0].address}`, "ok");
+    productAccount = productRes.value;
+    log(`Product account ready: ${productAccount.address}`, "ok");
 
     log("Opening chain client…");
     try {
@@ -250,29 +284,29 @@ async function init() {
     // `pallet-revive` rejects `Revive.call` from any SS58 origin that hasn't
     // been mapped to its derived H160 via `Revive.map_account()`. The helper
     // is idempotent — short-circuits on a storage hit — so the first-time
-    // path costs one signature and subsequent boots are free.
+    // path costs one signature and subsequent boots are free. The
+    // `Revive.map_account` extrinsic also carries AsPgas on Paseo Next, so
+    // it must sign through the product-account path too.
     try {
-        const signer = manager.getSigner();
-        if (signer) {
-            log("Ensuring account is mapped on pallet-revive…");
-            const mapped = await ensureContractAccountMapped(
-                contractManager.getRuntime(),
-                accounts[0].address,
-                signer,
-            );
-            log(
-                mapped === null
-                    ? "Account already mapped (no signature needed)"
-                    : `Account mapped in block #${mapped.block.number}`,
-                "ok",
-            );
-        }
+        const signer = productAccount.getSigner();
+        log("Ensuring account is mapped on pallet-revive…");
+        const mapped = await ensureContractAccountMapped(
+            contractManager.getRuntime(),
+            productAccount.address,
+            signer,
+        );
+        log(
+            mapped === null
+                ? "Account already mapped (no signature needed)"
+                : `Account mapped in block #${mapped.block.number}`,
+            "ok",
+        );
     } catch (err) {
         log(`ensureContractAccountMapped failed: ${(err as Error).message}`, "err");
         return;
     }
 
-    setControlsEnabled(manager.getState().selectedAccount !== null);
+    renderReady();
 }
 
 init().catch((err) => log(`Unhandled init error: ${(err as Error).message}`, "err"));

--- a/product-sdk/examples/contracts-demo/src/main.ts
+++ b/product-sdk/examples/contracts-demo/src/main.ts
@@ -4,7 +4,7 @@
  * Wires up SignerManager + chain-client + ContractManager against the
  * t3rminal @t3rminal/bulletin-index contract deployed on Paseo Asset Hub.
  *
- * Contract address: 0xA2E388421467E0193570Af45Bd03F0F379c47E88
+ * Contract address: 0x3331A87C2B9312E246E6A7eE8D0C0AdD8d282B6F (CDM v3)
  *
  * Exercises the two core host-API paths in @parity/product-sdk-contracts:
  *   - query()  — dry-run via chain RPC (no signing)
@@ -15,8 +15,9 @@
  *   2. Host responds with Bob's non-product account
  *   3. getChainAPI("paseo") routes RPC through the host's chainConnection handler
  *   4. ContractManager.fromClient(cdm, chain.raw.assetHub) wraps the contract
- *   5. contract.owner.query() → dry-run via RPC — no signing
- *   6. contract.storeDailyReport.tx() → signs via host.handleSignPayload → on-chain
+ *   5. contract.getReportCount.query(shopKey) → dry-run via RPC — no signing
+ *   6. contract.storeDailyReport.tx(shopKey, date, cid, count) → signs via
+ *      host.handleSignPayload → on-chain
  */
 
 import { SignerManager } from "@parity/product-sdk-signer";
@@ -33,23 +34,27 @@ const $activeProvider = getEl<HTMLSpanElement>("active-provider");
 const $accountAddress = getEl<HTMLSpanElement>("account-address");
 const $reportDateInput = getEl<HTMLInputElement>("report-date-input");
 const $reportCidInput = getEl<HTMLInputElement>("report-cid-input");
-const $queryShopInput = getEl<HTMLInputElement>("query-shop-input");
-const $btnQueryOwner = getEl<HTMLButtonElement>("btn-query-owner");
+const $queryShopKeyInput = getEl<HTMLInputElement>("query-shopkey-input");
 const $btnQueryReportCount = getEl<HTMLButtonElement>("btn-query-report-count");
 const $btnQueryAllDates = getEl<HTMLButtonElement>("btn-query-all-dates");
 const $btnQueryCid = getEl<HTMLButtonElement>("btn-query-cid");
 const $btnStoreReport = getEl<HTMLButtonElement>("btn-store-report");
 const $contractLog = getEl<HTMLElement>("contract-log");
 
+// 32 zero bytes — a `shopKey` value that the on-chain registry has never
+// minted, so every query against it yields deterministic empty results
+// (0 reports, [] dates, "" CID). Used as the default for both query inputs
+// and the storeDailyReport `tx()` call.
+const ZERO_SHOP_KEY = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
 function setControlsEnabled(enabled: boolean): void {
-    $btnQueryOwner.disabled = !enabled;
     $btnQueryReportCount.disabled = !enabled;
     $btnQueryAllDates.disabled = !enabled;
     $btnQueryCid.disabled = !enabled;
     $btnStoreReport.disabled = !enabled;
     $reportDateInput.disabled = !enabled;
     $reportCidInput.disabled = !enabled;
-    $queryShopInput.disabled = !enabled;
+    $queryShopKeyInput.disabled = !enabled;
 }
 
 function log(msg: string, level: Parameters<typeof appendLog>[2] = "info"): void {
@@ -78,48 +83,25 @@ manager.subscribe((state) => {
 // ── Actions ──────────────────────────────────────────────────────────
 
 /**
- * Read-only query — calls owner() as a chain-RPC dry-run.
- * No signing is involved; proves the query() path works through the host.
- */
-$btnQueryOwner.addEventListener("click", async () => {
-    if (!contractManager) {
-        log("Contract manager not ready", "err");
-        return;
-    }
-    log("Querying bulletin-index owner()…");
-    try {
-        const contract = contractManager.getContract("@t3rminal/bulletin-index");
-        const result = await contract.owner.query();
-        if (result.success) {
-            log(`owner: ${result.value}`, "ok");
-        } else {
-            log("owner() query failed (dry-run returned success=false)", "err");
-        }
-    } catch (err) {
-        log(`query failed: ${(err as Error).message}`, "err");
-    }
-});
-
-/**
  * Query helpers that exercise the PAPI 2.x codec boundary end-to-end:
- *   - viem encodes the `address` arg as a `0x…` hex string into the
- *     calldata `Uint8Array`,
+ *   - viem encodes the `bytes32` shopKey arg into the calldata `Uint8Array`,
  *   - PAPI's `ReviveApi.call` returns a `Uint8Array`,
  *   - viem decodes it back to the typed JS value.
  *
- * The default shop address is the zero address, so the results are
- * deterministic regardless of accumulated chain state.
+ * The default shopKey is 32 zero bytes — a value the registry has never
+ * minted — so the results are deterministic regardless of accumulated
+ * chain state.
  */
 $btnQueryReportCount.addEventListener("click", async () => {
     if (!contractManager) {
         log("Contract manager not ready", "err");
         return;
     }
-    const shop = $queryShopInput.value || "0x0000000000000000000000000000000000000000";
-    log(`Querying getReportCount(${shop})…`);
+    const shopKey = $queryShopKeyInput.value || ZERO_SHOP_KEY;
+    log(`Querying getReportCount(${shopKey})…`);
     try {
         const contract = contractManager.getContract("@t3rminal/bulletin-index");
-        const result = await contract.getReportCount.query(shop);
+        const result = await contract.getReportCount.query(shopKey);
         if (result.success) {
             log(`reportCount: ${result.value}`, "ok");
         } else {
@@ -135,11 +117,11 @@ $btnQueryAllDates.addEventListener("click", async () => {
         log("Contract manager not ready", "err");
         return;
     }
-    const shop = $queryShopInput.value || "0x0000000000000000000000000000000000000000";
-    log(`Querying getAllDates(${shop})…`);
+    const shopKey = $queryShopKeyInput.value || ZERO_SHOP_KEY;
+    log(`Querying getAllDates(${shopKey})…`);
     try {
         const contract = contractManager.getContract("@t3rminal/bulletin-index");
-        const result = await contract.getAllDates.query(shop);
+        const result = await contract.getAllDates.query(shopKey);
         if (result.success) {
             // Stringify so the test can match a stable representation of the
             // decoded `string[]` regardless of how arrays render in the DOM.
@@ -157,12 +139,12 @@ $btnQueryCid.addEventListener("click", async () => {
         log("Contract manager not ready", "err");
         return;
     }
-    const shop = $queryShopInput.value || "0x0000000000000000000000000000000000000000";
+    const shopKey = $queryShopKeyInput.value || ZERO_SHOP_KEY;
     const date = $reportDateInput.value || "2026-01-01";
-    log(`Querying getCID(${shop}, "${date}")…`);
+    log(`Querying getCID(${shopKey}, "${date}")…`);
     try {
         const contract = contractManager.getContract("@t3rminal/bulletin-index");
-        const result = await contract.getCID.query(shop, date);
+        const result = await contract.getCID.query(shopKey, date);
         if (result.success) {
             log(`cid: ${JSON.stringify(result.value)}`, "ok");
         } else {
@@ -174,9 +156,10 @@ $btnQueryCid.addEventListener("click", async () => {
 });
 
 /**
- * Signed transaction — calls storeDailyReport(date, cid, count).
- * The contract is permissionless: any address can store a daily report
- * indexed by msg.sender. Exercises the full host-signing path.
+ * Signed transaction — calls storeDailyReport(shopKey, date, cid, count).
+ * The contract is permissionless: any caller stores a report under the
+ * given shopKey (subject to the upstream registry/shop-ownership rules
+ * enforced inside the contract). Exercises the full host-signing path.
  */
 $btnStoreReport.addEventListener("click", async () => {
     if (!contractManager) {
@@ -189,15 +172,16 @@ $btnStoreReport.addEventListener("click", async () => {
         return;
     }
 
+    const shopKey = $queryShopKeyInput.value || ZERO_SHOP_KEY;
     const date = $reportDateInput.value || "2026-01-01";
     const cid = $reportCidInput.value || "bafktest";
 
     setControlsEnabled(false);
-    log(`Submitting storeDailyReport("${date}", "${cid}", 1)…`);
+    log(`Submitting storeDailyReport(${shopKey}, "${date}", "${cid}", 1)…`);
 
     try {
         const contract = contractManager.getContract("@t3rminal/bulletin-index");
-        const result = await contract.storeDailyReport.tx(date, cid, 1n, { signer });
+        const result = await contract.storeDailyReport.tx(shopKey, date, cid, 1n, { signer });
         if (result.ok) {
             log(
                 `storeDailyReport landed in block #${result.block.number} (${result.txHash.slice(0, 18)}…)`,

--- a/product-sdk/examples/tx-demo/e2e/signing-rejected.spec.ts
+++ b/product-sdk/examples/tx-demo/e2e/signing-rejected.spec.ts
@@ -29,8 +29,8 @@ test.describe("@parity/product-sdk-tx via Host API — signing rejection", () =>
 
         // Flip the host to reject every permission re-request, then remove
         // the grant established during SignerManager.connect(). The next
-        // sign call goes through the host's handleSignPayload, fails the
-        // permission gate, and propagates back through PAPI's observable.
+        // sign call goes through the host's host_create_transaction, fails
+        // the permission gate, and propagates back through PAPI's observable.
         await testHost.setPermissionBehavior("reject-all");
         await testHost.revokePermission("TransactionSubmit");
         await testHost.clearSigningLog();
@@ -46,7 +46,7 @@ test.describe("@parity/product-sdk-tx via Host API — signing rejection", () =>
         });
 
         // No sign payload should have been recorded: the host rejected
-        // before reaching handleSignPayload's keyring path.
+        // before reaching host_create_transaction's signing path.
         const signingLog = await testHost.getSigningLog();
         expect(signingLog).toHaveLength(0);
     });

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -463,11 +463,13 @@ export class HostProvider implements SignerProvider {
 
         // Step 4: Request ChainSubmit permission up-front.
         //
-        // The host gates signing on this permission — without it
-        // `handleSignPayload` (and the production host) rejects every sign
-        // request with `PermissionDenied`, which typically manifests as a
-        // silently-hanging tx. Doing it once during connect() matches what
-        // production apps need and spares consumers the boilerplate.
+        // The host gates signing on this permission — without it, the
+        // production host rejects every sign request with `PermissionDenied`
+        // at both `handleSignPayload` (legacy account path) and
+        // `host_create_transaction` (product-account path), which typically
+        // manifests as a silently-hanging tx. Doing it once during connect()
+        // matches what production apps need and spares consumers the
+        // boilerplate.
         //
         // We don't fail `connect()` if this step fails: the consumer can still
         // use the signer for read-only code paths, and the actual sign call


### PR DESCRIPTION
Rel: https://github.com/paritytech/product-sdk/issues/97

### Description

Closes Group 2 of paritytech/product-sdk#97

- Migrates `examples/contracts-demo` to `@t3rminal/bulletin-index` v3 (`0x3331A8...`) with the rebuilt ABI: `shop: address` -> `shopKey: bytes32`, `owner()` removed, `storeDailyReport` gains a `shopKey` arg, plus new `dateExists` / `getMetadata` views.
- Adopts tx-demo's product-account signing pattern from #96 - required so the `AsPgas` signed extension on Paseo Next v2 doesn't dead-end in the PJS bridge.
- Reverts 4 `describe.skip` / TODO markers; all 5 active specs now run green.

### Verification

- `pnpm check` clean
- `pnpm --filter "@parity/product-sdk-contracts-demo" build` clean
- `pnpm test:e2e`: 5 passed, 1 skipped (`signing-rejected`, out of scope), 13.3s
- Stability confirmed across 2 runs against `wss://paseo-asset-hub-next-rpc.polkadot.io`

