### PR TITLE
docs(skills): product-account signing, CID G12, area-7 renames

### DIFF
--- a/product-sdk/skills/migrating-to-product-sdk/SKILL.md
+++ b/product-sdk/skills/migrating-to-product-sdk/SKILL.md
@@ -34,9 +34,9 @@ Invoke when any of:
 
 - User asks to migrate a product to `@parity/product-sdk`.
 - The target repo's `package.json` (any workspace) declares any of:
-  `@polkadot-apps/*`, `@novasamatech/product-sdk`, `polkadot-api@^1.x`,
-  `@skiff-org/skiff-crypto`, `tweetnacl`, `@polkadot-labs/hdkd-helpers`,
-  `helia` / `@helia/*`.
+  `@polkadot-apps/*`, `@novasamatech/product-sdk` ∨ `@novasamatech/host-api-wrapper`,
+  `polkadot-api@^1.x`, `@skiff-org/skiff-crypto`, `tweetnacl`,
+  `@polkadot-labs/hdkd-helpers`, `helia` / `@helia/*`.
 - A GitHub issue or PR in the repo has "migrate to @parity/product-sdk"
   in the title or body.
 
@@ -119,7 +119,7 @@ each non-zero result.
 ```
 # Direct legacy package imports
 grep -rEn "from '@polkadot-apps/" --include='*.ts' --include='*.tsx' --include='*.vue' --include='*.js'
-grep -rEn "from '@novasamatech/product-sdk" --include='*.ts' --include='*.tsx' --include='*.vue' --include='*.js'
+grep -rEn "from '@novasamatech/(product-sdk|host-api-wrapper)" --include='*.ts' --include='*.tsx' --include='*.vue' --include='*.js'
 grep -rEn "from '@skiff-org/skiff-crypto'" --include='*.ts' --include='*.tsx'
 grep -rEn "from 'tweetnacl'" --include='*.ts' --include='*.tsx'
 grep -rEn "from '@polkadot-labs/hdkd-helpers'" --include='*.ts' --include='*.tsx'
@@ -179,7 +179,7 @@ For each of the 15 areas below, assign a **status** and pick a
 | # | Area | Owning skill | In-scope when | Defer when |
 |---|---|---|---|---|
 | 1 | Bootstrap | `product-sdk-app-builder` | at least one other area is in-scope (**evaluate last** — depends on rows 2–15) | n/a |
-| 2 | Chain access | `product-sdk-chain-connection` | `createClient` / `createPapiProvider` / `@polkadot-apps/chain-client` / `@novasamatech/product-sdk` present | target chain not supported by host |
+| 2 | Chain access | `product-sdk-chain-connection` | `createClient` / `createPapiProvider` / `@polkadot-apps/chain-client` / `@novasamatech/{product-sdk,host-api-wrapper}` present | target chain not supported by host |
 | 3 | Wallet/Signer | `product-sdk-transactions` | `getAccountsProvider` ∨ hand-rolled wallet injection | demo/mock mode (keep custom adapter) |
 | 4 | Crypto primitives | `product-sdk-utilities` | `tweetnacl` ∨ `@skiff-org/skiff-crypto` ∨ `crypto.subtle.digest` | n/a |
 | 5 | Utils (hex/hashing/planck) | `product-sdk-utilities` | manual `padStart(2,'0')` hex ∨ manual planck formatting | n/a |
@@ -203,8 +203,23 @@ For each of the 15 areas below, assign a **status** and pick a
 - **(5) Utils** → `@parity/product-sdk-utils`: `bytesToHex`, `hexToBytes`, `utf8ToBytes`, `concatBytes`, `sha256`, `blake2b256`, `keccak256`, `formatPlanck`, `parseToPlanck`, `getBalance`. Prefer the leaf package over the `@parity/product-sdk/crypto` re-exports in new code.
 - **(6) Key management** → `KeyManager.fromSignature(sig, addr, { salt })` + `deriveSymmetricKey('domain:'+id)`. **Verify byte-for-byte** against the legacy implementation before adopting `KeyManager.deriveKeypairs()` — SDK info strings are hardcoded (gotcha G3).
 - **(7) Address** → inline `normalizeSs58`/`isValidSs58`/`toGenericSs58`/`ss58Encode`/`ss58Decode`/`ss58ToH160`/`h160ToSs58`/`accountIdBytes`/`accountIdFromBytes`/`truncateAddress`/`addressesEqual` from `@parity/product-sdk-address`. Delete any thin wrapper file.
+
+    **Common rename map** — legacy names typically used in product code, mapped to their `@parity/product-sdk-address` equivalents:
+
+    | Legacy name (common forms) | SDK equivalent | Notes |
+    |---|---|---|
+    | `isValidEvmAddress` / `isValidEthAddress` | `isValidH160` | |
+    | `shortenAddress` / `formatAddress(addr, n, m)` | `truncateAddress(addr, n, m)` | Default `(6, 4)`; signature is `(address, startChars?, endChars?)` |
+    | `isSameAddress` / `addressEquals` | `addressesEqual` | H160 case-insensitive; SS58 case-sensitive; cross-type returns `false` |
+    | `ss58Decode(addr)[0]` | `accountIdBytes(addr)` | Direct `Uint8Array` return, no tuple destructure |
+    | `ss58Encode(toHex(bytes))` | `accountIdFromBytes(bytes, prefix?)` | Default prefix `42` |
+
+    **Things the SDK does NOT cover** — keep as local wrappers if the product needs them:
+
+    - Force-lowercase H160 for viem EIP-1191 compatibility (viem rejects EIP-1191 chain-ID-aware checksums against standard EIP-55). SDK's `toH160` preserves casing; products surfacing host-provided addresses through viem need a thin local wrapper.
+    - Stable cross-prefix SS58 equality. `addressesEqual` returns `false` for the same key encoded at different prefixes; products needing that must `normalizeSs58` both sides first.
 - **(8) App storage** → `createLocalKvStore()` from `@parity/product-sdk-local-storage`. Migrate direct `localStorage.{get,set,remove}Item` to the resulting `LocalKvStore`.
-- **(9) Cloud Storage** → drop Helia/IndexedDB stack. Three valid paths: (a) via App — `app.cloudStorage.upload(bytes)` / `fetch(cid)`; (b) standalone — `CloudStorageClient.create({ environment, signer })`. (c) host-sponsored — `getPreimageManager().submit(data)` from `@parity/product-sdk-host` (@^0.3.0+). Host signs end-to-end, no app-side signer wired; ≤ 2 MiB only (single preimage, no chunking). Cloud Storage can migrate independently of AuthProvider. For better UX, pair (c) with `requestResourceAllocation([{tag: 'BulletInAllowance'}])` (also in `@^0.3.0+`, typed wrapper from PR #82) to grant the allowance once via a single permission modal rather than re-prompting per submission. Decision: any file > 2 MiB in the product → (a) or (b) — both require an app-side signer source, so cloud storage migrates alongside `AuthProvider` / `HostProvider.connect()` work. All files ≤ 2 MiB → (c) — smallest migration scope, cloud storage flips independently. Use `.withWaitFor('finalized')` for reorg-safe semantics. Reconstruct block hash via `api.query.System.BlockHash.getValue(blockNumber)` when needed (gotcha G9).
+- **(9) Cloud Storage** → drop Helia/IndexedDB stack. Three valid paths: (a) via App — `app.cloudStorage.upload(bytes)` / `fetch(cid)`; (b) standalone — `CloudStorageClient.create({ environment, signer })`. (c) host-sponsored — `getPreimageManager().submit(data)` from `@parity/product-sdk-host` (@^0.3.0+). Host signs end-to-end, no app-side signer wired; ≤ 2 MiB only (single preimage, no chunking). Cloud Storage can migrate independently of AuthProvider. For better UX, pair (c) with `requestResourceAllocation([{tag: 'BulletInAllowance'}])` (also in `@^0.3.0+`, typed wrapper from PR #82) to grant the allowance once via a single permission modal rather than re-prompting per submission. Decision: any file > 2 MiB in the product → (a) or (b) — both require an app-side signer source, so cloud storage migrates alongside `AuthProvider` / `HostProvider.connect()` work. All files ≤ 2 MiB → (c) — smallest migration scope, cloud storage flips independently. Use `.withWaitFor('finalized')` for reorg-safe semantics. Reconstruct block hash via `api.query.System.BlockHash.getValue(blockNumber)` when needed (gotcha G9). `calculateCid` returns `Promise<CID>` (uses Web Crypto for blake2b on web platforms) — any hand-rolled CID computation that imports it needs to async-ify its wrappers **and** any test fixtures. `node:test` test bodies (`test('name', () => {...})`) need to become `async () => {...}`; grep for the wrapper function name when searching for callsites, not just for `calculateCid`. When a product stores CID digests in `bytes32`-shaped on-chain slots, use `cidToPreimageKey` + `parseCid(hashToCid(...))` from `@parity/product-sdk-cloud-storage` — **not** `cidToBytes` / `cidFromBytes`, which operate on the full 38-byte CIDv1 encoding (see G12).
 - **(10) Contracts** → `createContract(runtime, address, abi)` for ad-hoc reads; `ContractManager` with `cdm.json` for full apps. Drop `@polkadot-api/sdk-ink` unless signer plumbing is non-trivial.
 - **(11) Logger** → `configure({ level })` once at bootstrap. Wrap the existing `createLogger(prefix)` so app-level call sites don't change.
 - **(12) Statement Store** → `StatementStoreClient` with `{ mode: 'host', accountId }` inside containers, `{ mode: 'local', signer }` standalone. Use `ChannelStore` for stable two-party streams.
@@ -291,7 +306,7 @@ files affected (with paths), owning SDK skill, notes.
 ### Dependencies and overrides
 - Add: [list with versions]
 - Remove (direct): [list]
-- Remains transitive: @novasamatech/product-sdk (via @parity/product-sdk-host)
+- Remains transitive: @novasamatech/host-api-wrapper (via @parity/product-sdk-host; was @novasamatech/product-sdk pre-#110)
 - pnpm.overrides (required):
     "@polkadot-api/json-rpc-provider": "^0.2.0"          # always; SDK monorepo root has this
     "@polkadot-api/json-rpc-provider-proxy": "^0.4.0"    # add if legacy 0.2.8 proxy is being hoisted

--- a/product-sdk/skills/migrating-to-product-sdk/references/gotchas.md
+++ b/product-sdk/skills/migrating-to-product-sdk/references/gotchas.md
@@ -1,9 +1,9 @@
 # Gotcha catalog
 
-Eleven trap doors observed across three reference migrations
-(`paritytech/sh33ts#33`, `paritytech/t3ams#30`, `paritytech/t3rminal#98`).
-Apply the fix when the symptom appears; reference the gotcha number
-(G1–G11) from the migration spec when applicable.
+Twelve trap doors observed across four reference migrations
+(`paritytech/sh33ts#33`, `paritytech/t3ams#30`, `paritytech/t3rminal#98`,
+w3s-conference-app Phase 1). Apply the fix when the symptom appears;
+reference the gotcha number (G1–G12) from the migration spec when applicable.
 
 | # | Gotcha | Symptom | Cause | Fix |
 |---|---|---|---|---|
@@ -17,4 +17,5 @@ Apply the fix when the symptom appears; reference the gotcha number
 | G8 | Container-only vs dual paths | SDK doesn't work standalone in some cases | Some App hooks (e.g. `app.cloudStorage`) are container-only by design | Gate on `isInsideContainer()` / `isInsideContainerSync`; keep standalone PAPI raw paths for CLI scripts and web-only deployments |
 | G9 | `StoreResult` no longer exposes `blockHash` | Code reading `result.blockHash` breaks | SDK 0.2+ removed the field | Reconstruct via `api.query.System.BlockHash.getValue(result.blockNumber)` |
 | G10 | `.papi/descriptors/package.json` bump forgotten | Type mismatches against generated descriptors | The descriptors package version must follow `polkadot-api` major bumps | Always touch `.papi/descriptors/package.json` alongside the `polkadot-api` bump |
-| G11 | `@novasamatech/product-sdk` removed but reappears | Lockfile still shows `@novasamatech/product-sdk` after migration | `@parity/product-sdk-host` re-exports `getTruApi` / `getPreimageManager` from `@novasamatech/product-sdk` — it remains as a transitive dep | Expected. Remove only as a **direct** dependency. Document in PR body that it remains transitive via host. |
+| G11 | `@novasamatech/*` removed but reappears | Lockfile still shows a `@novasamatech/*` package after migration | `@parity/product-sdk-host` re-exports `getTruApi` / `getPreimageManager` from `@novasamatech/host-api-wrapper` — it remains as a transitive dep. (Legacy products imported this as `@novasamatech/product-sdk` before its rename in PR #110.) | Expected. Remove only as a **direct** dependency (whichever name the legacy product used). Document in PR body that it remains transitive via host under its current name. |
+| G12 | `cidToBytes` / `cidFromBytes` are full-CID helpers, not digest helpers | Runtime error on first round-trip: `Expected 32-byte digest, got 38`; or hash-storage extrinsic submits 38-byte hashes instead of 32 | The upstream `@parity/bulletin-sdk`'s `cidToBytes(cid): Uint8Array` returns the full CIDv1 binary encoding (1+1+1+1+32 = 38 bytes for blake2b-256 raw codec), not the 32-byte multihash digest. Symmetric for `cidFromBytes`. The names invite misuse for products storing digests in `bytes32` on-chain slots. | Use `cidToPreimageKey(cid.toString()): \`0x${string}\`` and `parseCid(hashToCid(bytes32))` from `@parity/product-sdk-cloud-storage` directly. Both are digest-level. |

--- a/product-sdk/skills/product-sdk-app-builder/references/package-selector.md
+++ b/product-sdk/skills/product-sdk-app-builder/references/package-selector.md
@@ -132,13 +132,13 @@ crypto ────────────────────────�
 utils ───────────────────────────── (leaf, depends on logger)
 logger ──────────────────────────── (leaf)
 host ────────────────────────────── (leaf)
-storage ← host, logger
-keys ← address, crypto, utils, storage
+local-storage ← host, logger
+keys ← address, crypto, utils, local-storage
 tx ← keys, logger
 signer ← address, keys, logger
 chain-client ← descriptors, host  (provides .raw for ContractRuntime creation)
 contracts ← tx, signer, keys, logger  (needs ContractRuntime from @parity/product-sdk-contracts)
-bulletin ← chain-client, descriptors, host, logger, tx
+cloud-storage ← chain-client, descriptors, host, logger, tx
 statement-store ← host, logger, utils  (+ @novasamatech/sdk-statement, @polkadot-api/substrate-client)
 ```
 

--- a/product-sdk/skills/product-sdk-contracts/SKILL.md
+++ b/product-sdk/skills/product-sdk-contracts/SKILL.md
@@ -138,21 +138,35 @@ entirely — including this revert pre-check.
 
 ## SignerManager Integration
 
-Pass a `SignerManager` to automatically use the connected wallet account:
+Pass a `SignerManager` and a **product-account signer** to sign contract `tx()` calls:
 
 ```typescript
 import { SignerManager } from "@parity/product-sdk-signer";
 
-const signerManager = new SignerManager();
+const signerManager = new SignerManager({ ss58Prefix: 0, dappName: "your-app" });
+
+// Establish the host session.
 await signerManager.connect();
+
+// Request a product account — its signer routes through
+// `host_create_transaction` (PR #96), which preserves arbitrary signed
+// extensions (e.g. `AsPgas` on Paseo Next v2). Required on any chain that
+// ships signed extensions PJS doesn't know about.
+const productRes = await signerManager.getProductAccount("your-app.dot", 0);
+if (!productRes.ok) throw productRes.error;
+const productAccount = productRes.value;
 
 const manager = await ContractManager.fromClient(cdmJson, client.raw.assetHub, {
     signerManager,
 });
 
-// All tx() calls use the connected account automatically
-await counter.increment.tx();
+// All tx() calls sign via the product account's `host_create_transaction` path.
+await counter.increment.tx({ signer: productAccount.getSigner() });
 ```
+
+See [`examples/tx-demo/src/main.ts`](../../examples/tx-demo/src/main.ts) and
+[`examples/contracts-demo/src/main.ts`](../../examples/contracts-demo/src/main.ts)
+for full end-to-end references.
 
 You can also set a default signer or origin:
 
@@ -259,6 +273,8 @@ const counter = createContract(runtime, "0x...", abi, { signerManager });
 5. **Assuming `tx()` only fails for signer/dispatch reasons** — `tx()` also throws `ContractRevertedError` when the dry-run shows the contract would revert. Catch it (or its base `ContractError`) if you're surfacing revert reasons to users.
 
 6. **Assuming `query()` throws on revert** — It doesn't. Reverts come back as `{ success: false, value: { type: "ContractRevertedWithPayload", ... } }`. Always check `success` before reading `value` as the return type.
+
+7. **Using `manager.getSigner()` (legacy account) on chains with unknown signed extensions** — `signerManager.connect()` exposes legacy accounts, whose signer routes through PJS. On chains like Paseo Next v2 that ship `AsPgas`, PJS throws `PJS does not support this signed-extension: AsPgas` at signing time. Use `signerManager.getProductAccount(<appOrigin>, 0)` and `productAccount.getSigner()` instead — that path goes through `host_create_transaction` and preserves arbitrary extensions.
 
 ## Reference Files
 

--- a/product-sdk/skills/product-sdk-transactions/SKILL.md
+++ b/product-sdk/skills/product-sdk-transactions/SKILL.md
@@ -179,16 +179,25 @@ const unsub = manager.subscribe((state) => {
 const result = await manager.connect();
 
 if (result.ok) {
-  manager.selectAccount(result.value[0].address);
-  const signer = manager.getSigner();
-
-  if (signer) {
-    const txResult = await submitAndWatch(tx, signer);
+  // Request a product account — its signer routes through
+  // `host_create_transaction` (PR #96), which preserves arbitrary signed
+  // extensions (e.g. `AsPgas` on Paseo Next v2). Required on any chain that
+  // ships signed extensions PJS doesn't know about. The legacy path
+  // (`manager.selectAccount(...)` + `manager.getSigner()`) routes through PJS
+  // and throws `PJS does not support this signed-extension: AsPgas` on such
+  // chains — use it only when targeting chains with no unknown extensions.
+  const productRes = await manager.getProductAccount("my-app.dot", 0);
+  if (productRes.ok) {
+    const productAccount = productRes.value;
+    const txResult = await submitAndWatch(tx, productAccount.getSigner());
   }
 }
 
 manager.destroy();
 ```
+
+See [`examples/tx-demo/src/main.ts`](../../examples/tx-demo/src/main.ts) for the
+full end-to-end pattern (imports, state, init flow).
 
 ## KeyManager: Hierarchical Key Derivation
 

--- a/product-sdk/skills/product-sdk-transactions/references/signer-api.md
+++ b/product-sdk/skills/product-sdk-transactions/references/signer-api.md
@@ -27,21 +27,40 @@ connect(providerType?: ProviderType): Promise<Result<SignerAccount[], SignerErro
 Connect to a provider. Defaults to the Host API; pass `"dev"` for dev accounts (testing).
 The SDK is designed for container-only usage — `connect()` with no argument always targets the Host API.
 
-#### selectAccount
+#### getProductAccount (recommended)
+
+```ts
+getProductAccount(
+    dotNsIdentifier: string,
+    derivationIndex?: number,  // default 0
+): Promise<Result<SignerAccount, SignerError>>
+```
+
+Request a product account derived by the host wallet for this app, identified by `dotNsIdentifier` (e.g., `"myapp.dot"`). The returned account's `getSigner()` routes through `host_create_transaction`, which preserves arbitrary signed extensions (e.g. `AsPgas` on Paseo Next v2) end-to-end. **This is the recommended signing path** for any chain that ships signed extensions PJS doesn't know about. Only available when connected via the host provider — returns `HOST_UNAVAILABLE` otherwise.
+
+```ts
+const result = await manager.getProductAccount("myapp.dot");
+if (result.ok) {
+  const signer = result.value.getSigner();
+  // pass `signer` to submitAndWatch / contract.tx() / etc.
+}
+```
+
+#### selectAccount (legacy)
 
 ```ts
 selectAccount(address: string): Result<SignerAccount, SignerError>
 ```
 
-Select an account by SS58 address.
+Select a **legacy account** (one returned by `connect()`) by SS58 address. Pair with `getSigner()` below. Legacy accounts sign via PJS, which can't encode unknown signed extensions — on chains shipping `AsPgas` (Paseo Next v2) or similar, this throws `PJS does not support this signed-extension: AsPgas` at signing time. Use `getProductAccount` above for those chains.
 
-#### getSigner
+#### getSigner (legacy)
 
 ```ts
 getSigner(): PolkadotSigner | null
 ```
 
-Get the `PolkadotSigner` for the currently selected account.
+Get the `PolkadotSigner` for the currently selected **legacy** account. Same PJS routing constraint as `selectAccount` — not safe on chains with unknown signed extensions.
 
 #### signRaw
 


### PR DESCRIPTION
### Description

Three independent skill improvements plus two opportunistic rename sweeps. No code changes.

### Changes

- product-sdk-contracts + product-sdk-transactions SKILL.md, signer-api.md: recommend `getProductAccount` + `productAccount.getSigner()` over legacy `selectAccount` + `getSigner()`. Legacy
path routes through PJS and throws `PJS does not support this signed-extension: AsPgas` on Paseo Next v2. Recommended path uses `host_create_transaction` (PR #96).
- gotchas.md: add G12 - `cidToBytes` / `cidFromBytes` return the full CIDv1 encoding (38 bytes), not the 32-byte digest. Use `cidToPreimageKey` + `parseCid(hashToCid(...))` for `bytes32` on-chain slots.
- migrating-to-product-sdk SKILL.md area 7: legacy-name -> SDK rename map + "things the SDK does NOT cover" (viem EIP-1191, cross-prefix SS58).
- migrating-to-product-sdk SKILL.md area 9: one-sentence note that `calculateCid` is async.
- migrating-to-product-sdk: sweep `@novasamatech/product-sdk` -> `@novasamatech/host-api-wrapper` (PR #110 missed skills/). Refresh G11 + 4 SKILL.md sites; broaden discovery grep to match both names.
- product-sdk-app-builder/references/package-selector.md: refresh dep graph for `storage` -> `local-storage` (PR #54) and `bulletin` -> `cloud-storage` (PR #59).

### Notes

- `examples/contracts-demo/src/main.ts` is referenced as a canonical demo but still uses the legacy pattern on `main`. Its product-account migration is in flight on `domi-contract-redeploy-paseo-v2` ([#124](https://github.com/paritytech/product-sdk/pull/124)); sequence merges accordingly.
