### PR TITLE
ci: add Dependabot config for pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot configuration.
+#
+# Both `docs/` and `product-sdk/` are independent pnpm installs with their
+# own pnpm-lock.yaml. Dependabot's default behaviour without this file drifts
+# the in-lockfile `specifier:` fields away from the package.json's specifiers,
+# which breaks `pnpm install --frozen-lockfile` in CI even though the
+# resolved version is compatible.
+#
+# `versioning-strategy: increase-if-necessary` updates the package.json
+# `^X.Y.Z` floor only when the new version falls outside the current range,
+# keeping lockfile and manifest in sync without churning the manifest on
+# every patch bump.
+
+version: 2
+updates:
+    - package-ecosystem: "npm"
+      directory: "/docs"
+      schedule:
+          interval: "weekly"
+      versioning-strategy: "increase-if-necessary"
+      commit-message:
+          prefix: "chore(deps)"
+          include: "scope"
+      open-pull-requests-limit: 5
+
+    - package-ecosystem: "npm"
+      directory: "/product-sdk"
+      schedule:
+          interval: "weekly"
+      versioning-strategy: "increase-if-necessary"
+      commit-message:
+          prefix: "chore(deps)"
+          include: "scope"
+      open-pull-requests-limit: 5
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      commit-message:
+          prefix: "chore(ci)"
+          include: "scope"
+      open-pull-requests-limit: 3


### PR DESCRIPTION
  Without explicit config, Dependabot's default pnpm handling drifts the                                                                                                                                                                            
  in-lockfile `specifier:` field away from the package.json's specifier                                                                                                                                                                             
  across multiple PRs. The resolved version stays compatible, but                                                                                                                                                                                   
  `pnpm install --frozen-lockfile` checks the recorded specifier verbatim                                                                                                                                                                           
  and fails with `ERR_PNPM_OUTDATED_LOCKFILE`.                                                                                                                                                                                                      
                                                                                                                                                                                                                                                    
  Adds .github/dependabot.yml covering both /docs and /product-sdk as
  separate npm ecosystems, plus github-actions monthly. Uses                                                                                                                                                                                        
  `versioning-strategy: increase-if-necessary` so the manifest's `^X.Y.Z`                                                                                                                                                                           
  floor is bumped only when the lockfile version moves outside the                                                                                                                                                                                  
  current range — keeps the two in sync without churning the manifest                                                                                                                                                                               
  on every patch.  