### PR TITLE
ci(dependabot): security-only mode with pnpm-drift fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,17 @@
 # Dependabot configuration.
 #
-# Both `docs/` and `product-sdk/` are independent pnpm installs with their
-# own pnpm-lock.yaml. Dependabot's default behaviour without this file drifts
-# the in-lockfile `specifier:` fields away from the package.json's specifiers,
-# which breaks `pnpm install --frozen-lockfile` in CI even though the
-# resolved version is compatible.
+# We only want security-driven PRs, not routine version-bump noise. But
+# Dependabot security PRs use Dependabot's default versioning strategy
+# when no config is present — that default rewrites the lockfile's
+# in-lockfile `specifier:` fields without updating package.json, which
+# breaks `pnpm install --frozen-lockfile` in CI on pnpm projects.
 #
-# `versioning-strategy: increase-if-necessary` updates the package.json
-# `^X.Y.Z` floor only when the new version falls outside the current range,
-# keeping lockfile and manifest in sync without churning the manifest on
-# every patch bump.
+# Trick: define `updates:` entries with `open-pull-requests-limit: 0`.
+# That suppresses weekly version-update PRs while still letting security
+# PRs inherit the entry's config — most importantly,
+# `versioning-strategy: increase-if-necessary`, which raises the
+# package.json `^X.Y.Z` floor in lockstep with the lockfile so the two
+# stay in sync.
 
 version: 2
 updates:
@@ -21,7 +23,8 @@ updates:
       commit-message:
           prefix: "chore(deps)"
           include: "scope"
-      open-pull-requests-limit: 5
+      # Suppress routine version-update PRs; security PRs still fire.
+      open-pull-requests-limit: 0
 
     - package-ecosystem: "npm"
       directory: "/product-sdk"
@@ -31,13 +34,4 @@ updates:
       commit-message:
           prefix: "chore(deps)"
           include: "scope"
-      open-pull-requests-limit: 5
-
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-          interval: "monthly"
-      commit-message:
-          prefix: "chore(ci)"
-          include: "scope"
-      open-pull-requests-limit: 3
+      open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot configuration.
+#
+# Both `docs/` and `product-sdk/` are independent pnpm installs with their
+# own pnpm-lock.yaml. Dependabot's default behaviour without this file drifts
+# the in-lockfile `specifier:` fields away from the package.json's specifiers,
+# which breaks `pnpm install --frozen-lockfile` in CI even though the
+# resolved version is compatible.
+#
+# `versioning-strategy: increase-if-necessary` updates the package.json
+# `^X.Y.Z` floor only when the new version falls outside the current range,
+# keeping lockfile and manifest in sync without churning the manifest on
+# every patch bump.
+
+version: 2
+updates:
+    - package-ecosystem: "npm"
+      directory: "/docs"
+      schedule:
+          interval: "weekly"
+      versioning-strategy: "increase-if-necessary"
+      commit-message:
+          prefix: "chore(deps)"
+          include: "scope"
+      open-pull-requests-limit: 5
+
+    - package-ecosystem: "npm"
+      directory: "/product-sdk"
+      schedule:
+          interval: "weekly"
+      versioning-strategy: "increase-if-necessary"
+      commit-message:
+          prefix: "chore(deps)"
+          include: "scope"
+      open-pull-requests-limit: 5
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      commit-message:
+          prefix: "chore(ci)"
+          include: "scope"
+      open-pull-requests-limit: 3


### PR DESCRIPTION
  Previous config enabled routine version-update PRs across both                                                                                                                                                                                    
  ecosystems — not wanted. Sets `open-pull-requests-limit: 0` on each                                                                                                                                                                               
  entry to suppress weekly version bumps while still letting security                                                                                                                                                                               
  PRs inherit the entry's `versioning-strategy: increase-if-necessary`,                                                                                                                                                                             
  which is what keeps `pnpm install --frozen-lockfile` happy across                                                                                                                                                                                 
  multiple Dependabot updates.  