### PR TITLE
feat(host): add getPaymentManager for RFC-0006 host payments

### DIFF
--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -88,3 +88,7 @@ export type {
     ChatCustomMessageRenderer,
     ChatCustomMessageRendererParams,
 } from "./chat.js";
+
+// Payments (RFC-0006)
+export { getPaymentManager } from "./payments.js";
+export type { PaymentManager, PaymentBalance, PaymentStatus, TopUpSource } from "./payments.js";

--- a/product-sdk/packages/host/src/payments.ts
+++ b/product-sdk/packages/host/src/payments.ts
@@ -1,0 +1,98 @@
+/**
+ * Wrapper for the host's payment manager (RFC-0006).
+ *
+ * Shipped flat-in-host rather than as `getTruApi().payment.*` because the
+ * upstream JS `hostApi` is itself a flat object - there is no `.payment`
+ * accessor to mirror. A flat `getPaymentManager()` matches the singleton
+ * pattern already used by {@link getPreimageManager},
+ * {@link getHostLocalStorage}, and {@link getAccountsProvider}.
+ *
+ * Returns the shared `paymentManager` singleton from
+ * `@novasamatech/host-api-wrapper` (not a fresh `createPaymentManager()`
+ * instance) so callers share one wrapper + hostApi closure across the app.
+ *
+ * Distinct from the CoinPayment / merchant-payments surface tracked under
+ * `@parity/product-sdk-merchant-payments` (RFC-0017). RFC-0006 is the
+ * user-initiated balance / top-up / payment-request flow; RFC-0017 is the
+ * merchant-initiated checkout flow.
+ *
+ * @module
+ */
+
+import { createLogger } from "@parity/product-sdk-logger";
+
+import type {
+    PaymentBalance as NovasamaPaymentBalance,
+    PaymentStatus as NovasamaPaymentStatus,
+    TopUpSource as NovasamaTopUpSource,
+    paymentManager,
+} from "@novasamatech/host-api-wrapper";
+
+const log = createLogger("host:payments");
+
+/** Available balance for the user's payment account. Re-exported from `@novasamatech/host-api-wrapper`. */
+export type PaymentBalance = NovasamaPaymentBalance;
+
+/** Status of an in-flight payment request. Re-exported from `@novasamatech/host-api-wrapper`. */
+export type PaymentStatus = NovasamaPaymentStatus;
+
+/** Source for {@link PaymentManager.topUp}. Re-exported from `@novasamatech/host-api-wrapper`. */
+export type TopUpSource = NovasamaTopUpSource;
+
+/**
+ * Payment manager handle. Exposes balance subscription, top-up, payment
+ * requests, and payment status subscription.
+ *
+ * Type identical to `paymentManager` from `@novasamatech/host-api-wrapper`.
+ */
+export type PaymentManager = typeof paymentManager;
+
+/**
+ * Get the host payment manager.
+ *
+ * Returns the shared `paymentManager` singleton from
+ * `@novasamatech/host-api-wrapper`, or `null` if the package is unavailable
+ * (running outside a host container or the optional peer dep isn't
+ * installed).
+ *
+ * @returns The payment manager, or `null` if unavailable.
+ *
+ * @example
+ * ```ts
+ * import { getPaymentManager } from "@parity/product-sdk-host";
+ *
+ * const payments = await getPaymentManager();
+ * if (payments) {
+ *   const sub = payments.subscribeBalance((b) => { ... });
+ *   await payments.topUp(1_000_000n, { type: "productAccount", derivationIndex: 0 });
+ *   const destination = new Uint8Array(32);
+ *   const { id } = await payments.requestPayment(500n, destination);
+ *   sub.unsubscribe();
+ * }
+ * ```
+ */
+export async function getPaymentManager(): Promise<PaymentManager | null> {
+    try {
+        const sdk = await import("@novasamatech/host-api-wrapper");
+        return sdk.paymentManager;
+    } catch (err) {
+        log.debug("getPaymentManager unavailable", err);
+        return null;
+    }
+}
+
+if (import.meta.vitest) {
+    const { test, expect } = import.meta.vitest;
+
+    test("getPaymentManager returns manager with full RFC-0006 surface when SDK is available", async () => {
+        const payments = await getPaymentManager();
+        if (payments === null) {
+            // Acceptable: SDK couldn't load (e.g. peer dep missing in some envs).
+            return;
+        }
+        expect(typeof payments.subscribeBalance).toBe("function");
+        expect(typeof payments.topUp).toBe("function");
+        expect(typeof payments.requestPayment).toBe("function");
+        expect(typeof payments.subscribePaymentStatus).toBe("function");
+    });
+}

--- a/product-sdk/pending-changesets/118-host-playground-migration-support.md
+++ b/product-sdk/pending-changesets/118-host-playground-migration-support.md
@@ -1,0 +1,27 @@
+---
+"@parity/product-sdk": minor
+"@parity/product-sdk-host": minor
+"@parity/product-sdk-chain-client": minor
+"@parity/product-sdk-local-storage": minor
+---
+
+### `@parity/product-sdk-host`
+
+- New wrappers: `getChatManager`, `getThemeProvider`, `deriveEntropy`, `requestPermission`, `requestDevicePermission`.
+- New container helpers: `createHostLocalStorage`.
+- New TruAPI re-exports: `createHostPreimageManager`, `formatHostError`.
+- New type re-exports: `ProductAccountId`, `SignedStatement`, `Statement`, `Topic`, `ChatManager`, `ChatMessageContent`, `ChatReceivedAction`, `ChatRoom`, `ChatRoomRegistrationResult`, `ChatBotRegistrationResult`, `ChatCustomMessageRenderer`, `ChatCustomMessageRendererParams`, `ThemeMode`, `ThemeProvider`, `DevicePermissionKind`, `RemotePermissionItem`.
+
+### `@parity/product-sdk-chain-client`
+
+- New exports: `WellKnownChain` constant + `WellKnownChainHash` type for canonical genesis-hash lookups.
+
+### `@parity/product-sdk-local-storage`
+
+- Widened the typed KV interface to match the upstream Novasama surface: `readBytes` / `writeBytes` methods and keyed `clear(key)`. Test mocks updated accordingly.
+
+### Umbrella
+
+- `@parity/product-sdk`: minor cascade per `RELEASES.md` — any constituent minor bump cascades the umbrella.
+
+No consumer-facing source-compat breaks: all changes are additive expansions of public exports.

--- a/product-sdk/pending-changesets/host-payment-manager.md
+++ b/product-sdk/pending-changesets/host-payment-manager.md
@@ -1,0 +1,12 @@
+---
+"@parity/product-sdk": minor
+"@parity/product-sdk-host": minor
+---
+
+**Add `getPaymentManager` for RFC-0006 host payments.**
+
+`@parity/product-sdk-host` now exports `getPaymentManager()` plus the `PaymentManager`, `PaymentBalance`, `PaymentStatus`, and `TopUpSource` types. The wrapper returns the shared `paymentManager` singleton from `@novasamatech/host-api-wrapper`, matching the singleton pattern already used by `getPreimageManager`, `getHostLocalStorage`, and `getAccountsProvider`.
+
+Closes the last `@novasamatech/host-api-wrapper` direct-import in the host-playground migration: callers can swap `createPaymentManager()` for `await getPaymentManager()`.
+
+Distinct from the CoinPayment / merchant-payments surface (RFC-0017). This is the user-initiated balance / top-up / payment-request flow.


### PR DESCRIPTION
## Summary

- Adds `getPaymentManager()` plus `PaymentManager`, `PaymentBalance`, `PaymentStatus`, and `TopUpSource` types to `@parity/product-sdk-host`.
- Closes the last `@novasamatech/host-api-wrapper` direct-import gap in the host-playground migration (RFC-0006 user-side payment flow).
- Mirrors the singleton shape of `getPreimageManager` / `getHostLocalStorage` / `getAccountsProvider` — flat helper on the host package, delegating to the upstream singleton, async to allow lazy `await import(...)`.

## What changed

```
product-sdk/packages/host/src/payments.ts                (new)
product-sdk/packages/host/src/index.ts                   (added re-export block)
product-sdk/pending-changesets/host-payment-manager.md   (new)
product-sdk/pending-changesets/118-host-playground-migration-support.md   (new, retroactive for #118)
```

The wrapper returns the `paymentManager` singleton from `@novasamatech/host-api-wrapper` — mirroring `getPreimageManager` / `getHostLocalStorage` / `getAccountsProvider` (singleton when published; factory only when no singleton exists, like `getThemeProvider`):

```ts
export async function getPaymentManager(): Promise<PaymentManager | null> {
    try {
        const sdk = await import("@novasamatech/host-api-wrapper");
        return sdk.paymentManager;
    } catch (err) {
        log.debug("getPaymentManager unavailable", err);
        return null;
    }
}
```

Types are re-exported from `@novasamatech/host-api-wrapper` so callers don't need a direct dep.


## Additional pending changeset for #118

The second commit (`chore: retroactive pending-changeset for #118 host migration surface`) parks a changeset in `pending-changesets/` covering the surface additions merged in #118 (`getChatManager`, `getThemeProvider`, `deriveEntropy`, `requestPermission`, `WellKnownChain`, widened local-storage KV interface)

## Test plan

- [x] `pnpm --filter @parity/product-sdk-host build`
- [x] `pnpm --filter @parity/product-sdk-host test --run` — 31/31 pass; new test asserts all 4 RFC-0006 methods are present on the manager
- [x] `pnpm --filter @parity/product-sdk build` — umbrella rebuilds cleanly
- [x] `pnpm check` — biome clean
- [x] **End-to-end smoke against `@parity/host-api-test-sdk`'s `createTestHostServer`** — host-playground loaded inside the test host, all three payment tests (`payment-balance-subscribe`, `payment-top-up`, `payment-request`) round-trip through the wrapper to the mocked RFC-0006 host implementation