### PR TITLE
feat(skills): export as Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "product-sdk",
+  "description": "Parity Technologies plugin marketplace for the Polkadot developer ecosystem.",
+  "owner": {
+    "name": "Parity Technologies",
+    "url": "https://github.com/paritytech"
+  },
+  "plugins": [
+    {
+      "name": "product-sdk",
+      "source": "./product-sdk",
+      "description": "Polkadot product-SDK skills: chain connection, transactions, contracts, cloud storage, statement store, utilities, migration, and app builder."
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "plugins": [
     {
-      "name": "polkadot-sdk",
+      "name": "product-sdk",
       "source": "./product-sdk",
       "description": "Polkadot product-SDK skills: chain connection, transactions, contracts, cloud storage, statement store, utilities, migration, and app builder."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "product-sdk",
+  "name": "paritytech",
   "description": "Parity Technologies plugin marketplace for the Polkadot developer ecosystem.",
   "owner": {
     "name": "Parity Technologies",
@@ -7,7 +7,7 @@
   },
   "plugins": [
     {
-      "name": "product-sdk",
+      "name": "polkadot-sdk",
       "source": "./product-sdk",
       "description": "Polkadot product-SDK skills: chain connection, transactions, contracts, cloud storage, statement store, utilities, migration, and app builder."
     }

--- a/README.md
+++ b/README.md
@@ -8,4 +8,42 @@ TypeScript SDK for building products in the Polkadot ecosystem. Provides typed A
 
 See [product-sdk/README.md](./product-sdk/README.md) for details.
 
+## Claude Code Plugin
+
+This repo doubles as a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin marketplace. The plugin ships skills that teach Claude Code how to use the `@parity/product-sdk` packages — chain connections, transactions, contracts, cloud storage, statement store, utilities, and end-to-end app scaffolding.
+
+### Install
+
+```
+/plugin marketplace add paritytech/product-sdk
+/plugin install product-sdk@product-sdk
+/reload-plugins
+```
+
+The `/reload-plugins` step (or restarting Claude Code) is required to load the skills into your current session.
+
+### Verify
+
+```bash
+claude plugin list                    # should show product-sdk@product-sdk enabled
+claude plugin details product-sdk     # shows all 8 skills + projected token cost
+```
+
+Or open a new Claude Code session and ask "build me a Polkadot app" — the `product-sdk:product-sdk-app-builder` skill should fire automatically.
+
+### Skills included
+
+| Skill | Use when |
+|-------|----------|
+| `product-sdk-app-builder` | Scaffolding a new Polkadot app or dApp end-to-end |
+| `product-sdk-chain-connection` | Connecting to a chain, querying state, choosing preset vs BYOD descriptors |
+| `product-sdk-transactions` | Submitting transactions, managing signers, key derivation |
+| `product-sdk-contracts` | Smart contract calls on Asset Hub (PolkaVM/Solidity) |
+| `product-sdk-cloud-storage` | CID-based upload/retrieve via Cloud Storage |
+| `product-sdk-statement-store` | Publish/subscribe on the Polkadot Statement Store |
+| `product-sdk-utilities` | Addresses, crypto, encoding, token formatting, logging |
+| `migrating-to-product-sdk` | Porting an existing codebase from legacy stacks |
+
+Skills live under [`product-sdk/skills/`](./product-sdk/skills/) and are auto-discovered by Claude Code at install time.
+
 ## More tools coming soon

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo doubles as a [Claude Code](https://docs.anthropic.com/en/docs/claude-c
 
 ```
 /plugin marketplace add paritytech/product-sdk
-/plugin install polkadot-sdk@paritytech
+/plugin install product-sdk@paritytech
 /reload-plugins
 ```
 
@@ -25,11 +25,11 @@ The `/reload-plugins` step (or restarting Claude Code) is required to load the s
 ### Verify
 
 ```bash
-claude plugin list                     # should show polkadot-sdk@paritytech enabled
-claude plugin details polkadot-sdk     # shows all 8 skills + projected token cost
+claude plugin list                     # should show product-sdk@paritytech enabled
+claude plugin details product-sdk     # shows all 8 skills + projected token cost
 ```
 
-Or open a new Claude Code session and ask "build me a Polkadot app" — the `polkadot-sdk:product-sdk-app-builder` skill should fire automatically.
+Or open a new Claude Code session and ask "build me a Polkadot app" — the `product-sdk:product-sdk-app-builder` skill should fire automatically.
 
 ### Skills included
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo doubles as a [Claude Code](https://docs.anthropic.com/en/docs/claude-c
 
 ```
 /plugin marketplace add paritytech/product-sdk
-/plugin install product-sdk@product-sdk
+/plugin install polkadot-sdk@paritytech
 /reload-plugins
 ```
 
@@ -25,11 +25,11 @@ The `/reload-plugins` step (or restarting Claude Code) is required to load the s
 ### Verify
 
 ```bash
-claude plugin list                    # should show product-sdk@product-sdk enabled
-claude plugin details product-sdk     # shows all 8 skills + projected token cost
+claude plugin list                     # should show polkadot-sdk@paritytech enabled
+claude plugin details polkadot-sdk     # shows all 8 skills + projected token cost
 ```
 
-Or open a new Claude Code session and ask "build me a Polkadot app" — the `product-sdk:product-sdk-app-builder` skill should fire automatically.
+Or open a new Claude Code session and ask "build me a Polkadot app" — the `polkadot-sdk:product-sdk-app-builder` skill should fire automatically.
 
 ### Skills included
 

--- a/product-sdk/.claude-plugin/plugin.json
+++ b/product-sdk/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "product-sdk",
+  "version": "0.1.0",
+  "description": "Skills for building Polkadot apps with @parity/product-sdk",
+  "author": {
+    "name": "Parity Technologies",
+    "url": "https://github.com/paritytech/product-sdk"
+  }
+}

--- a/product-sdk/.claude-plugin/plugin.json
+++ b/product-sdk/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "polkadot-sdk",
+  "name": "product-sdk",
   "version": "0.1.0",
   "description": "Skills for building Polkadot apps with @parity/product-sdk",
   "author": {

--- a/product-sdk/.claude-plugin/plugin.json
+++ b/product-sdk/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "product-sdk",
+  "name": "polkadot-sdk",
   "version": "0.1.0",
   "description": "Skills for building Polkadot apps with @parity/product-sdk",
   "author": {


### PR DESCRIPTION
Closes #119

### Summary

- Add `.claude-plugin/marketplace.json` and `product-sdk/.claude-plugin/plugin.json` so this repo doubles as a Claude Code plugin marketplace.
- The 8 existing skills under `product-sdk/skills/` are auto-discovered - no skill content changes.
- README updated with install + verify instructions.

### How to install (post-merge)

```
/plugin marketplace add paritytech/product-sdk
/plugin install product-sdk@paritytech
/reload-plugins
```

### Test locally from this branch
```
git checkout domi-export-skills-plugin
```
@ claude terminal
```
/plugin marketplace add /Users/dominique/Documents/Parity/dev-sprint/product-sdk
  ⎿  Successfully added marketplace: paritytech
/plugin install product-sdk@paritytech
  ⎿  ✓ Installed product-sdk Run /reload-plugins to apply.
```


## Test plan

- `claude plugin validate` passes for marketplace and plugin manifests
- Local install via path works - `claude plugin list` shows `product-sdk@paritytech` enabled
- `claude plugin details product-sdk` lists all 8 skills with projected token cost
- Skills are namespaced as `product-sdk:<skill-name>` and fire on relevant prompts
- After merge: confirm `/plugin marketplace add paritytech/product-sdk` works from a clean machine
