### PR TITLE
feat(contracts): flatten cdm.json manifest + live registry address resolution

### DIFF
--- a/product-sdk/.changeset/flatten-cdm-manifest.md
+++ b/product-sdk/.changeset/flatten-cdm-manifest.md
@@ -1,0 +1,21 @@
+---
+"@parity/product-sdk-contracts": minor
+---
+
+**Support the flattened `cdm.json` manifest shape and add live CDM registry address resolution.**
+
+`cdm.json` is no longer bucketed by target hash. The manifest is now flat:
+
+```jsonc
+{
+  "registry": "0x…",
+  "dependencies": { "@org/contract-name": "latest" },
+  "contracts": { "@org/contract-name": { "version": 6, "address": "0x…", "abi": [ /* … */ ] } }
+}
+```
+
+- `CdmJson` loses `targets` and the per-target `dependencies` / `contracts` buckets; `dependencies` and `contracts` are now keyed directly by library name, with an optional top-level `registry` address.
+- `ContractManagerOptions.targetHash` and the `CdmJsonTarget` type are removed. `ContractManager` resolves contracts directly from the flat `contracts` map.
+- `ContractNotFoundError` no longer carries a `targetHash`.
+- New `ContractManager.fromLive(...)` / `fromLiveClient(...)` and the standalone `withLiveContractAddresses(...)` helper strictly resolve installed contract addresses from the live CDM registry (ABIs still come from the installed snapshot). Backed by the new `LiveContractResolutionOptions` type and `ContractLiveAddressResolutionError`.
+- New exported type alias `CdmJsonDependencyVersion`.

--- a/product-sdk/.pending-changesets/flatten-cdm-manifest.md
+++ b/product-sdk/.pending-changesets/flatten-cdm-manifest.md
@@ -17,5 +17,5 @@
 - `CdmJson` loses `targets` and the per-target `dependencies` / `contracts` buckets; `dependencies` and `contracts` are now keyed directly by library name, with an optional top-level `registry` address.
 - `ContractManagerOptions.targetHash` and the `CdmJsonTarget` type are removed. `ContractManager` resolves contracts directly from the flat `contracts` map.
 - `ContractNotFoundError` no longer carries a `targetHash`.
-- New `ContractManager.fromLive(...)` / `fromLiveClient(...)` and the standalone `withLiveContractAddresses(...)` helper strictly resolve installed contract addresses from the live CDM registry (ABIs still come from the installed snapshot). Backed by the new `LiveContractResolutionOptions` type and `ContractLiveAddressResolutionError`.
+- New `ContractManager.fromLive(...)` / `fromLiveClient(...)` and the standalone `withLiveContractAddresses(...)` helper strictly resolve installed contract addresses from the live CDM registry (ABIs still come from the installed snapshot). `"latest"` dependencies resolve the registry's latest address; pinned numeric dependencies resolve the installed version's address. Backed by the new `LiveContractResolutionOptions` type and `ContractLiveAddressResolutionError`.
 - New exported type alias `CdmJsonDependencyVersion`.

--- a/product-sdk/examples/contracts-demo/src/cdm.json
+++ b/product-sdk/examples/contracts-demo/src/cdm.json
@@ -1,105 +1,212 @@
 {
-    "targets": {
-        "929b5c63e2cb5202": {
-            "asset-hub": "wss://paseo-asset-hub-next-rpc.polkadot.io",
-            "bulletin": "https://paseo-bulletin-next-ipfs.polkadot.io/ipfs",
-            "registry": "0xa7ae171c78f06c248a9b2556c793aa1df5c9173a"
-        }
-    },
+    "registry": "0xa7ae171c78f06c248a9b2556c793aa1df5c9173a",
     "dependencies": {
-        "929b5c63e2cb5202": {
-            "@t3rminal/bulletin-index": 3
-        }
+        "@t3rminal/bulletin-index": 3
     },
     "contracts": {
-        "929b5c63e2cb5202": {
-            "@t3rminal/bulletin-index": {
-                "version": 3,
-                "address": "0xD35CFc6E9F07B42Cc524A9Fa4A001F6ac90586E2",
-                "abi": [
-                    {
-                        "anonymous": false,
-                        "inputs": [
-                            { "indexed": true, "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
-                            { "indexed": true, "internalType": "string", "name": "date", "type": "string" },
-                            { "indexed": false, "internalType": "string", "name": "cid", "type": "string" },
-                            { "indexed": false, "internalType": "uint256", "name": "entryCount", "type": "uint256" },
-                            { "indexed": false, "internalType": "address", "name": "writer", "type": "address" }
-                        ],
-                        "name": "DailyReportStored",
-                        "type": "event"
-                    },
-                    {
-                        "inputs": [
-                            { "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
-                            { "internalType": "string", "name": "date", "type": "string" }
-                        ],
-                        "name": "dateExists",
-                        "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-                        "stateMutability": "view",
-                        "type": "function"
-                    },
-                    {
-                        "inputs": [{ "internalType": "bytes32", "name": "shopKey", "type": "bytes32" }],
-                        "name": "getAllDates",
-                        "outputs": [{ "internalType": "string[]", "name": "", "type": "string[]" }],
-                        "stateMutability": "view",
-                        "type": "function"
-                    },
-                    {
-                        "inputs": [
-                            { "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
-                            { "internalType": "string", "name": "date", "type": "string" }
-                        ],
-                        "name": "getCID",
-                        "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-                        "stateMutability": "view",
-                        "type": "function"
-                    },
-                    {
-                        "inputs": [
-                            { "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
-                            { "internalType": "string", "name": "date", "type": "string" }
-                        ],
-                        "name": "getMetadata",
-                        "outputs": [
-                            {
-                                "components": [
-                                    { "internalType": "string", "name": "cid", "type": "string" },
-                                    { "internalType": "uint256", "name": "entryCount", "type": "uint256" },
-                                    { "internalType": "uint256", "name": "publishedAt", "type": "uint256" },
-                                    { "internalType": "bool", "name": "exists", "type": "bool" }
-                                ],
-                                "internalType": "struct IT3rminalBulletinIndex.DayMetadata",
-                                "name": "",
-                                "type": "tuple"
-                            }
-                        ],
-                        "stateMutability": "view",
-                        "type": "function"
-                    },
-                    {
-                        "inputs": [{ "internalType": "bytes32", "name": "shopKey", "type": "bytes32" }],
-                        "name": "getReportCount",
-                        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-                        "stateMutability": "view",
-                        "type": "function"
-                    },
-                    {
-                        "inputs": [
-                            { "internalType": "bytes32", "name": "shopKey", "type": "bytes32" },
-                            { "internalType": "string", "name": "date", "type": "string" },
-                            { "internalType": "string", "name": "cid", "type": "string" },
-                            { "internalType": "uint256", "name": "entryCount", "type": "uint256" }
-                        ],
-                        "name": "storeDailyReport",
-                        "outputs": [],
-                        "stateMutability": "nonpayable",
-                        "type": "function"
-                    }
-                ],
-                "metadataCid": "bafk2bzacecs43cb4byqnwi4p7fj5iqzyrbluuwbp5aho2gxyxrzuqp5jkedn2"
-            }
+        "@t3rminal/bulletin-index": {
+            "version": 3,
+            "address": "0xD35CFc6E9F07B42Cc524A9Fa4A001F6ac90586E2",
+            "abi": [
+                {
+                    "anonymous": false,
+                    "inputs": [
+                        {
+                            "indexed": true,
+                            "internalType": "bytes32",
+                            "name": "shopKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "indexed": true,
+                            "internalType": "string",
+                            "name": "date",
+                            "type": "string"
+                        },
+                        {
+                            "indexed": false,
+                            "internalType": "string",
+                            "name": "cid",
+                            "type": "string"
+                        },
+                        {
+                            "indexed": false,
+                            "internalType": "uint256",
+                            "name": "entryCount",
+                            "type": "uint256"
+                        },
+                        {
+                            "indexed": false,
+                            "internalType": "address",
+                            "name": "writer",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "DailyReportStored",
+                    "type": "event"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "shopKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "date",
+                            "type": "string"
+                        }
+                    ],
+                    "name": "dateExists",
+                    "outputs": [
+                        {
+                            "internalType": "bool",
+                            "name": "",
+                            "type": "bool"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "shopKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "name": "getAllDates",
+                    "outputs": [
+                        {
+                            "internalType": "string[]",
+                            "name": "",
+                            "type": "string[]"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "shopKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "date",
+                            "type": "string"
+                        }
+                    ],
+                    "name": "getCID",
+                    "outputs": [
+                        {
+                            "internalType": "string",
+                            "name": "",
+                            "type": "string"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "shopKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "date",
+                            "type": "string"
+                        }
+                    ],
+                    "name": "getMetadata",
+                    "outputs": [
+                        {
+                            "components": [
+                                {
+                                    "internalType": "string",
+                                    "name": "cid",
+                                    "type": "string"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "entryCount",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "uint256",
+                                    "name": "publishedAt",
+                                    "type": "uint256"
+                                },
+                                {
+                                    "internalType": "bool",
+                                    "name": "exists",
+                                    "type": "bool"
+                                }
+                            ],
+                            "internalType": "struct IT3rminalBulletinIndex.DayMetadata",
+                            "name": "",
+                            "type": "tuple"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "shopKey",
+                            "type": "bytes32"
+                        }
+                    ],
+                    "name": "getReportCount",
+                    "outputs": [
+                        {
+                            "internalType": "uint256",
+                            "name": "",
+                            "type": "uint256"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "bytes32",
+                            "name": "shopKey",
+                            "type": "bytes32"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "date",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "string",
+                            "name": "cid",
+                            "type": "string"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "entryCount",
+                            "type": "uint256"
+                        }
+                    ],
+                    "name": "storeDailyReport",
+                    "outputs": [],
+                    "stateMutability": "nonpayable",
+                    "type": "function"
+                }
+            ],
+            "metadataCid": "bafk2bzacecs43cb4byqnwi4p7fj5iqzyrbluuwbp5aho2gxyxrzuqp5jkedn2"
         }
     }
 }

--- a/product-sdk/examples/contracts-demo/src/main.ts
+++ b/product-sdk/examples/contracts-demo/src/main.ts
@@ -36,7 +36,11 @@
 import type { SignerAccount } from "@parity/product-sdk-signer";
 import { SignerManager } from "@parity/product-sdk-signer";
 import { getChainAPI } from "@parity/product-sdk-chain-client";
-import { ContractManager, ensureContractAccountMapped } from "@parity/product-sdk-contracts";
+import {
+    ContractManager,
+    ensureContractAccountMapped,
+    type CdmJson,
+} from "@parity/product-sdk-contracts";
 import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
 
 import cdm from "./cdm.json";
@@ -272,7 +276,7 @@ async function init() {
         // upgrade. Pass the raw client + descriptor so it can wire up both
         // typed (extrinsics + storage) and unsafe (dry-run) paths.
         contractManager = ContractManager.fromClient(
-            cdm as never,
+            cdm as CdmJson,
             chain.raw.assetHub,
             paseo_asset_hub,
             { signerManager: manager },

--- a/product-sdk/examples/pvm-contracts-example/README.md
+++ b/product-sdk/examples/pvm-contracts-example/README.md
@@ -40,9 +40,10 @@ needs a live deployment. The next step is identical to the existing
 ```ts
 import { createContractFromClient } from "@parity/product-sdk-contracts";
 import { loadPvmContractAbi } from "@parity/product-sdk-contracts/pvm";
+import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
 
 const abi = await loadPvmContractAbi("./target/counter.release.abi.json");
-const counter = await createContractFromClient(client, "0xC472...", abi);
+const counter = createContractFromClient(client, paseo_asset_hub, "0xC472...", abi);
 
 const { value } = await counter.get.query();
 await counter.increment.tx(1, { signer });

--- a/product-sdk/packages/contracts/README.md
+++ b/product-sdk/packages/contracts/README.md
@@ -86,7 +86,7 @@ Update `origin`, `signer`, or `signerManager` after construction. Only the field
 
 ### `ContractManager.fromLive(cdmJson, runtime, options?)` / `fromLiveClient(cdmJson, client, descriptor, options?)`
 
-**Async** factories. Like `fromClient`, but before constructing the manager they resolve each installed contract's address from the **live CDM registry** instead of trusting the address baked into `cdm.json`. ABIs and versions still come from the installed snapshot — only addresses are refreshed.
+**Async** factories. Like `fromClient`, but before constructing the manager they resolve each installed contract's address from the **live CDM registry** instead of trusting the address baked into `cdm.json`. ABIs still come from the installed snapshot — only addresses are refreshed. Dependencies requested as `"latest"` resolve the registry's latest address; pinned numeric dependencies resolve `getAddressAtVersion(...)` so the live address stays aligned with the installed ABI/version.
 
 ```ts
 const manager = await ContractManager.fromLiveClient(cdmJson, client.raw.assetHub, paseo_asset_hub, {

--- a/product-sdk/packages/contracts/README.md
+++ b/product-sdk/packages/contracts/README.md
@@ -10,7 +10,7 @@ pnpm add @parity/product-sdk-contracts
 
 ## Quick start (with cdm.json)
 
-The `cdm.json` flow is the primary path. A `cdm.json` manifest in your project root pins each contract to an address + ABI per target chain; `ContractManager.fromClient(cdm, client, descriptor)` resolves them at runtime.
+The `cdm.json` flow is the primary path. A `cdm.json` manifest in your project root pins each installed contract to an address + ABI; `ContractManager.fromClient(cdm, client, descriptor)` resolves them at runtime.
 
 ```ts
 import { createChainClient } from "@parity/product-sdk-chain-client";
@@ -55,7 +55,6 @@ Synchronous factory. Builds a `ContractRuntime` internally that wires the typed 
 | `options.signerManager?` | `SignerManager` | Resolves signer + origin from the logged-in account |
 | `options.defaultOrigin?` | `SS58String` | Static fallback origin for queries |
 | `options.defaultSigner?` | `PolkadotSigner` | Static fallback signer for txs |
-| `options.targetHash?` | `string` | Pin to a specific target. Defaults to first target in the manifest. |
 
 ### `manager.getContract(library)`
 
@@ -75,7 +74,7 @@ await registry.publish.tx("domain", "ipfs://cid", 0);
 //                       ^ args typed
 ```
 
-Throws `ContractNotFoundError` if the library name isn't in the manifest for the active target.
+Throws `ContractNotFoundError` if the library name isn't in the manifest.
 
 ### `manager.getAddress(library)`
 
@@ -84,6 +83,25 @@ Returns the on-chain address. Useful for logging or display.
 ### `manager.setDefaults(defaults)`
 
 Update `origin`, `signer`, or `signerManager` after construction. Only the fields you pass are updated.
+
+### `ContractManager.fromLive(cdmJson, runtime, options?)` / `fromLiveClient(cdmJson, client, descriptor, options?)`
+
+**Async** factories. Like `fromClient`, but before constructing the manager they resolve each installed contract's address from the **live CDM registry** instead of trusting the address baked into `cdm.json`. ABIs and versions still come from the installed snapshot — only addresses are refreshed.
+
+```ts
+const manager = await ContractManager.fromLiveClient(cdmJson, client.raw.assetHub, paseo_asset_hub, {
+    signerManager,
+    // registryAddress?: HexString  — defaults to cdmJson.registry
+    // libraries?: string[]         — subset to resolve; defaults to every contract
+    // registryOrigin?: SS58String  — origin for the registry dry-run; defaults to defaultOrigin
+});
+```
+
+This path is **strict**: if `cdmJson.registry` (or `registryAddress`) is missing, or a contract isn't registered on-chain, or the registry query fails, the promise rejects with `ContractLiveAddressResolutionError` — it never silently falls back to the snapshot address. Use `fromClient` for snapshot-only behavior.
+
+### `withLiveContractAddresses(cdmJson, runtime, options?)`
+
+Standalone helper behind `fromLive`. Returns a **cloned** `cdm.json` whose contract addresses have been replaced with live registry addresses (the input is never mutated). Useful when you want the resolved manifest without immediately building a manager. Takes the same `LiveContractResolutionOptions` as `fromLive`.
 
 ## Signer / origin resolution
 
@@ -185,30 +203,21 @@ Top-level shape:
 
 ```jsonc
 {
-  "targets": {
-    "<targetHash>": {
-      "asset-hub": "wss://paseo-asset-hub-next-rpc.polkadot.io",
-      "bulletin": "https://paseo-bulletin-next-ipfs.polkadot.io"
-    }
-  },
+  "registry": "0xf62c2ece29cd8df2e10040ecfa5a894a5c5d9cb0",
   "dependencies": {
-    "<targetHash>": {
-      "@org/contract-name": "latest"
-    }
+    "@org/contract-name": "latest"
   },
   "contracts": {
-    "<targetHash>": {
-      "@org/contract-name": {
-        "version": 6,
-        "address": "0x4A37B123b0BA2A894cA5953f472264921d44e298",
-        "abi": [ /* Solidity-compatible ABI entries */ ]
-      }
+    "@org/contract-name": {
+      "version": 6,
+      "address": "0x4A37B123b0BA2A894cA5953f472264921d44e298",
+      "abi": [ /* Solidity-compatible ABI entries */ ]
     }
   }
 }
 ```
 
-`<targetHash>` is a 16-character hex string identifying a chain runtime + Bulletin gateway pairing. A manifest can declare multiple targets; `ContractManager` defaults to the first, or pin one via `options.targetHash`.
+`registry` is used by `ContractManager.fromLive(...)` / `withLiveContractAddresses(...)` to resolve current contract addresses from the live CDM registry. `ContractManager.fromClient(...)` uses the installed `contracts` snapshot directly.
 
 A real-world example: [`paritytech/playground-cli/cdm.json`](https://github.com/paritytech/playground-cli/blob/main/cdm.json).
 
@@ -237,8 +246,9 @@ Without codegen, `getContract()` still works — methods are accessible but unty
 
 | Error | When |
 | --- | --- |
-| `ContractNotFoundError` | `getContract(name)` and `name` isn't in the manifest for the active target |
+| `ContractNotFoundError` | `getContract(name)` and `name` isn't in the manifest |
 | `ContractSignerMissingError` | `.tx()` called with no signer + no signerManager + no defaultSigner |
+| `ContractLiveAddressResolutionError` | `fromLive(...)` / `withLiveContractAddresses(...)` couldn't resolve an address from the live CDM registry (no `registry` set, contract unregistered, or the registry query failed) |
 | `ContractDryRunFailedError` | `.tx()` pre-flight `ReviveApi.call` reported failure — `dispatchError` carries the chain's encoded error (e.g. `ContractReverted`, `OutOfGas`, `AccountNotMapped`) |
 | Generic | viem ABI decode failures, RPC errors, weight/storage-limit estimation failures — surface from the underlying PAPI typed API |
 
@@ -252,10 +262,12 @@ export {
     createContractFromClient,
     createContractRuntime,
     createContractRuntimeFromClient,
+    withLiveContractAddresses,
     ensureContractAccountMapped,
     ContractError,
     ContractSignerMissingError,
     ContractNotFoundError,
+    ContractLiveAddressResolutionError,
     ContractDryRunFailedError,
 };
 export type {
@@ -264,8 +276,8 @@ export type {
     ReviveDryRunResult,
     ReviveDryRunCall,
     CdmJson,
-    CdmJsonTarget,
     CdmJsonContract,
+    CdmJsonDependencyVersion,
     AbiParam,
     AbiEntry,
     Contract,
@@ -280,6 +292,7 @@ export type {
     ContractDefaults,
     ContractManagerOptions,
     ContractOptions,
+    LiveContractResolutionOptions,
 };
 
 // `@parity/product-sdk-contracts/codegen` (Node-only — build tooling)

--- a/product-sdk/packages/contracts/src/errors.ts
+++ b/product-sdk/packages/contracts/src/errors.ts
@@ -37,7 +37,10 @@ export class ContractLiveAddressResolutionError extends ContractError {
     readonly library: string | undefined;
     readonly detail: unknown;
 
-    constructor(message: string, options?: { library?: string; detail?: unknown; cause?: unknown }) {
+    constructor(
+        message: string,
+        options?: { library?: string; detail?: unknown; cause?: unknown },
+    ) {
         super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
         this.name = "ContractLiveAddressResolutionError";
         this.library = options?.library;

--- a/product-sdk/packages/contracts/src/errors.ts
+++ b/product-sdk/packages/contracts/src/errors.ts
@@ -24,13 +24,24 @@ export class ContractSignerMissingError extends ContractError {
 /** A contract was not found in the cdm.json manifest. */
 export class ContractNotFoundError extends ContractError {
     readonly library: string;
-    readonly targetHash: string;
 
-    constructor(library: string, targetHash: string) {
-        super(`Contract "${library}" not found in cdm.json for target ${targetHash}`);
+    constructor(library: string) {
+        super(`Contract "${library}" not found in cdm.json`);
         this.name = "ContractNotFoundError";
         this.library = library;
-        this.targetHash = targetHash;
+    }
+}
+
+/** Live CDM registry address resolution failed. */
+export class ContractLiveAddressResolutionError extends ContractError {
+    readonly library: string | undefined;
+    readonly detail: unknown;
+
+    constructor(message: string, options?: { library?: string; detail?: unknown; cause?: unknown }) {
+        super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+        this.name = "ContractLiveAddressResolutionError";
+        this.library = options?.library;
+        this.detail = options?.detail;
     }
 }
 
@@ -129,7 +140,8 @@ if (import.meta.vitest) {
 
         test("instanceof catches all contract errors", () => {
             expect(new ContractSignerMissingError()).toBeInstanceOf(ContractError);
-            expect(new ContractNotFoundError("@a/b", "abc")).toBeInstanceOf(ContractError);
+            expect(new ContractNotFoundError("@a/b")).toBeInstanceOf(ContractError);
+            expect(new ContractLiveAddressResolutionError("test")).toBeInstanceOf(ContractError);
             expect(new ContractDryRunFailedError("foo", "x")).toBeInstanceOf(ContractError);
             expect(new ContractRevertedError("foo", "0x" as HexString)).toBeInstanceOf(
                 ContractError,
@@ -147,12 +159,23 @@ if (import.meta.vitest) {
     });
 
     describe("ContractNotFoundError", () => {
-        test("includes library and target", () => {
-            const err = new ContractNotFoundError("@test/foo", "abc123");
+        test("includes library", () => {
+            const err = new ContractNotFoundError("@test/foo");
             expect(err.library).toBe("@test/foo");
-            expect(err.targetHash).toBe("abc123");
-            expect(err.message).toContain("@test/foo");
-            expect(err.message).toContain("abc123");
+            expect(err.message).toBe('Contract "@test/foo" not found in cdm.json');
+        });
+    });
+
+    describe("ContractLiveAddressResolutionError", () => {
+        test("captures library and detail", () => {
+            const detail = { success: false };
+            const err = new ContractLiveAddressResolutionError("failed", {
+                library: "@test/foo",
+                detail,
+            });
+            expect(err.name).toBe("ContractLiveAddressResolutionError");
+            expect(err.library).toBe("@test/foo");
+            expect(err.detail).toBe(detail);
         });
     });
 

--- a/product-sdk/packages/contracts/src/index.ts
+++ b/product-sdk/packages/contracts/src/index.ts
@@ -11,7 +11,12 @@
  *
  * @packageDocumentation
  */
-export { ContractManager, createContract, createContractFromClient } from "./manager.js";
+export {
+    ContractManager,
+    createContract,
+    createContractFromClient,
+    withLiveContractAddresses,
+} from "./manager.js";
 export {
     createContractRuntime,
     createContractRuntimeFromClient,
@@ -34,14 +39,15 @@ export {
     ContractError,
     ContractSignerMissingError,
     ContractNotFoundError,
+    ContractLiveAddressResolutionError,
     ContractDryRunFailedError,
     ContractRevertedError,
 } from "./errors.js";
 export type { ContractRevertInfo, DecodedContractRevert } from "./errors.js";
 export type {
     CdmJson,
-    CdmJsonTarget,
     CdmJsonContract,
+    CdmJsonDependencyVersion,
     AbiParam,
     AbiEntry,
     ContractDef,
@@ -56,4 +62,5 @@ export type {
     ContractDefaults,
     ContractManagerOptions,
     ContractOptions,
+    LiveContractResolutionOptions,
 } from "./types.js";

--- a/product-sdk/packages/contracts/src/manager.ts
+++ b/product-sdk/packages/contracts/src/manager.ts
@@ -20,12 +20,32 @@ import type {
 
 type ContractMap = Record<string, CdmJsonContract>;
 type OptionAddress = { isSome: boolean; value: HexString };
+type LiveVersionSpec = number | "latest";
 
 const CDM_REGISTRY_ABI: AbiEntry[] = [
     {
         type: "function",
         name: "getAddress",
         inputs: [{ name: "contract_name", type: "string" }],
+        outputs: [
+            {
+                name: "",
+                type: "tuple",
+                components: [
+                    { name: "isSome", type: "bool" },
+                    { name: "value", type: "address" },
+                ],
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "getAddressAtVersion",
+        inputs: [
+            { name: "contract_name", type: "string" },
+            { name: "version", type: "uint32" },
+        ],
         outputs: [
             {
                 name: "",
@@ -69,14 +89,37 @@ function patchContractAddress(cdmJson: CdmJson, library: string, address: HexStr
     contract.address = address;
 }
 
+function resolveLiveVersionSpec(
+    cdmJson: CdmJson,
+    library: string,
+    contract: CdmJsonContract,
+): LiveVersionSpec {
+    const requested = cdmJson.dependencies[library];
+    if (typeof requested === "number" && Number.isInteger(requested) && requested >= 0) {
+        return requested;
+    }
+    if (typeof requested === "string") {
+        if (requested === "latest") return "latest";
+        const parsed = Number(requested);
+        if (Number.isInteger(parsed) && parsed >= 0) return parsed;
+    }
+    return contract.version;
+}
+
 async function queryLiveAddress(
     registry: Contract<ContractDef>,
     library: string,
+    version: LiveVersionSpec,
 ): Promise<HexString> {
-    const result = await registry.getAddress.query(library);
+    const result =
+        version === "latest"
+            ? await registry.getAddress.query(library)
+            : await registry.getAddressAtVersion.query(library, version);
     if (!result.success) {
         throw new ContractLiveAddressResolutionError(
-            `Failed to resolve live address for "${library}" from the CDM registry`,
+            version === "latest"
+                ? `Failed to resolve live address for "${library}" from the CDM registry`
+                : `Failed to resolve live address for "${library}" version ${version} from the CDM registry`,
             { library, detail: result.value },
         );
     }
@@ -84,7 +127,9 @@ async function queryLiveAddress(
     const value = result.value as OptionAddress | undefined;
     if (!value?.isSome) {
         throw new ContractLiveAddressResolutionError(
-            `Contract "${library}" is not registered in the CDM registry`,
+            version === "latest"
+                ? `Contract "${library}" is not registered in the CDM registry`
+                : `Contract "${library}" version ${version} is not registered in the CDM registry`,
             { library, detail: result.value },
         );
     }
@@ -124,10 +169,10 @@ export async function withLiveContractAddresses(
         defaultOrigin: options?.registryOrigin,
     });
     const liveAddresses = await Promise.all(
-        libraries.map(async (library): Promise<readonly [string, HexString]> => [
-            library,
-            await queryLiveAddress(registry, library),
-        ]),
+        libraries.map(async (library): Promise<readonly [string, HexString]> => {
+            const version = resolveLiveVersionSpec(cdmJson, library, contracts[library]);
+            return [library, await queryLiveAddress(registry, library, version)];
+        }),
     );
 
     const resolved = cloneCdmJson(cdmJson);
@@ -433,27 +478,54 @@ if (import.meta.vitest) {
         } as unknown as ContractRuntime;
     }
 
-    async function registryRuntimeFor(value: OptionAddress): Promise<ContractRuntime> {
-        const { encodeFunctionResult, hexToBytes } = await import("viem");
-        const data = hexToBytes(
-            encodeFunctionResult({
-                abi: CDM_REGISTRY_ABI as any,
-                functionName: "getAddress",
-                result: value,
-            }) as `0x${string}`,
+    async function registryRuntimeFor(
+        value:
+            | OptionAddress
+            | ((call: { functionName: string; args: readonly unknown[] }) => OptionAddress),
+    ): Promise<{ runtime: ContractRuntime; calls: { functionName: string; args: unknown[] }[] }> {
+        const { bytesToHex, decodeFunctionData, encodeFunctionResult, hexToBytes } = await import(
+            "viem"
         );
+        const calls: { functionName: string; args: unknown[] }[] = [];
 
-        return {
+        const runtime = {
             ...fakeRuntime(),
-            dryRunCall: async () => ({
-                weight_consumed: { ref_time: 0n, proof_size: 0n },
-                weight_required: { ref_time: 1n, proof_size: 1n },
-                storage_deposit: { type: "Refund", value: 0n },
-                max_storage_deposit: { type: "Refund", value: 0n },
-                gas_consumed: 0n,
-                result: { success: true, value: { flags: 0, data } },
-            }),
+            dryRunCall: async (
+                _origin: unknown,
+                _dest: unknown,
+                _value: unknown,
+                _gasLimit: unknown,
+                _storageDepositLimit: unknown,
+                calldata: Uint8Array,
+            ) => {
+                const decoded = decodeFunctionData({
+                    abi: CDM_REGISTRY_ABI as any,
+                    data: bytesToHex(calldata),
+                });
+                const call = {
+                    functionName: decoded.functionName,
+                    args: [...(decoded.args ?? [])],
+                };
+                calls.push(call);
+                const resultValue = typeof value === "function" ? value(call) : value;
+                const data = hexToBytes(
+                    encodeFunctionResult({
+                        abi: CDM_REGISTRY_ABI as any,
+                        functionName: decoded.functionName,
+                        result: resultValue,
+                    }) as `0x${string}`,
+                );
+                return {
+                    weight_consumed: { ref_time: 0n, proof_size: 0n },
+                    weight_required: { ref_time: 1n, proof_size: 1n },
+                    storage_deposit: { type: "Refund" as const, value: 0n },
+                    max_storage_deposit: { type: "Refund" as const, value: 0n },
+                    gas_consumed: 0n,
+                    result: { success: true, value: { flags: 0, data } },
+                };
+            },
         };
+        return { runtime, calls };
     }
 
     describe("ContractManager — cdm.json resolution", () => {
@@ -484,20 +556,70 @@ if (import.meta.vitest) {
 
         test("strictly patches flattened manifests with live registry addresses", async () => {
             const liveAddress = "0x7777777777777777777777777777777777777777";
-            const runtime = await registryRuntimeFor({ isSome: true, value: liveAddress });
+            const { runtime, calls } = await registryRuntimeFor({
+                isSome: true,
+                value: liveAddress,
+            });
 
             const resolved = await withLiveContractAddresses(flattenedCdm, runtime, {
                 registryOrigin: "5LiveOrigin" as SS58String,
             });
 
             expect(resolved.contracts?.["@w3s/playground-registry"].address).toBe(liveAddress);
+            expect(calls[0]).toMatchObject({
+                functionName: "getAddress",
+                args: ["@w3s/playground-registry"],
+            });
             expect(flattenedCdm.contracts?.["@w3s/playground-registry"].address).toBe(
                 "0x4A37B123b0BA2A894cA5953f472264921d44e298",
             );
         });
 
+        test("uses versioned registry lookup for pinned dependencies", async () => {
+            const latestAddress = "0x7777777777777777777777777777777777777777";
+            const versionedAddress = "0x6666666666666666666666666666666666666666";
+            const { runtime, calls } = await registryRuntimeFor(({ functionName }) => ({
+                isSome: true,
+                value: functionName === "getAddressAtVersion" ? versionedAddress : latestAddress,
+            }));
+            const pinnedCdm: CdmJson = {
+                ...flattenedCdm,
+                dependencies: {
+                    "@w3s/playground-registry": 6,
+                },
+            };
+
+            const resolved = await withLiveContractAddresses(pinnedCdm, runtime);
+
+            expect(resolved.contracts?.["@w3s/playground-registry"].address).toBe(versionedAddress);
+            expect(calls[0]).toMatchObject({
+                functionName: "getAddressAtVersion",
+                args: ["@w3s/playground-registry", 6],
+            });
+        });
+
+        test("falls back to installed contract version when dependency entry is absent", async () => {
+            const versionedAddress = "0x5555555555555555555555555555555555555555";
+            const { runtime, calls } = await registryRuntimeFor({
+                isSome: true,
+                value: versionedAddress,
+            });
+            const missingDependencyCdm: CdmJson = {
+                ...flattenedCdm,
+                dependencies: {},
+            };
+
+            const resolved = await withLiveContractAddresses(missingDependencyCdm, runtime);
+
+            expect(resolved.contracts?.["@w3s/playground-registry"].address).toBe(versionedAddress);
+            expect(calls[0]).toMatchObject({
+                functionName: "getAddressAtVersion",
+                args: ["@w3s/playground-registry", 6],
+            });
+        });
+
         test("live registry resolution fails instead of falling back to the snapshot", async () => {
-            const runtime = await registryRuntimeFor({
+            const { runtime } = await registryRuntimeFor({
                 isSome: false,
                 value: "0x0000000000000000000000000000000000000000",
             });

--- a/product-sdk/packages/contracts/src/manager.ts
+++ b/product-sdk/packages/contracts/src/manager.ts
@@ -1,8 +1,8 @@
 // Copyright 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
-import type { HexString, PolkadotClient } from "polkadot-api";
+import type { HexString, PolkadotClient, SS58String } from "polkadot-api";
 import { wrapContract } from "./wrap.js";
-import { ContractNotFoundError } from "./errors.js";
+import { ContractLiveAddressResolutionError, ContractNotFoundError } from "./errors.js";
 import type { ContractRuntime, ContractRuntimeOptions } from "./runtime.js";
 import { createContractRuntimeFromClient } from "./runtime.js";
 import type {
@@ -15,7 +15,127 @@ import type {
     ContractManagerOptions,
     ContractOptions,
     Contracts,
+    LiveContractResolutionOptions,
 } from "./types.js";
+
+type ContractMap = Record<string, CdmJsonContract>;
+type OptionAddress = { isSome: boolean; value: HexString };
+
+const CDM_REGISTRY_ABI: AbiEntry[] = [
+    {
+        type: "function",
+        name: "getAddress",
+        inputs: [{ name: "contract_name", type: "string" }],
+        outputs: [
+            {
+                name: "",
+                type: "tuple",
+                components: [
+                    { name: "isSome", type: "bool" },
+                    { name: "value", type: "address" },
+                ],
+            },
+        ],
+        stateMutability: "view",
+    },
+];
+
+function cloneCdmJson(cdmJson: CdmJson): CdmJson {
+    const cloneContractMap = (contracts: ContractMap): ContractMap =>
+        Object.fromEntries(
+            Object.entries(contracts).map(([library, contract]) => [library, { ...contract }]),
+        );
+
+    return {
+        ...cdmJson,
+        dependencies: { ...cdmJson.dependencies },
+        contracts: cdmJson.contracts ? cloneContractMap(cdmJson.contracts) : undefined,
+    };
+}
+
+function resolveRegistryAddress(cdmJson: CdmJson, override?: HexString): HexString {
+    if (override) return override;
+    if (cdmJson.registry) return cdmJson.registry;
+    throw new ContractLiveAddressResolutionError(
+        "CDM registry address is required for live contract address resolution. Pass registryAddress or set cdm.json registry.",
+    );
+}
+
+function patchContractAddress(cdmJson: CdmJson, library: string, address: HexString): void {
+    const contract = cdmJson.contracts?.[library];
+    if (!contract) {
+        throw new ContractNotFoundError(library);
+    }
+    contract.address = address;
+}
+
+async function queryLiveAddress(
+    registry: Contract<ContractDef>,
+    library: string,
+): Promise<HexString> {
+    const result = await registry.getAddress.query(library);
+    if (!result.success) {
+        throw new ContractLiveAddressResolutionError(
+            `Failed to resolve live address for "${library}" from the CDM registry`,
+            { library, detail: result.value },
+        );
+    }
+
+    const value = result.value as OptionAddress | undefined;
+    if (!value?.isSome) {
+        throw new ContractLiveAddressResolutionError(
+            `Contract "${library}" is not registered in the CDM registry`,
+            { library, detail: result.value },
+        );
+    }
+
+    return value.value;
+}
+
+/**
+ * Return a cloned manifest whose installed contract addresses have been
+ * replaced by live addresses from the CDM registry.
+ *
+ * This is intentionally strict: if a requested library cannot be resolved
+ * from the registry, the promise rejects. Use `new ContractManager(...)` or
+ * `ContractManager.fromClient(...)` directly for snapshot-only behavior.
+ */
+export async function withLiveContractAddresses(
+    cdmJson: CdmJson,
+    runtime: ContractRuntime,
+    options?: LiveContractResolutionOptions,
+): Promise<CdmJson> {
+    const contracts = cdmJson.contracts;
+    if (!contracts || Object.keys(contracts).length === 0) {
+        throw new ContractLiveAddressResolutionError(
+            "No installed contracts found in cdm.json for live address resolution.",
+        );
+    }
+
+    const libraries = options?.libraries ?? Object.keys(contracts);
+    for (const library of libraries) {
+        if (!(library in contracts)) {
+            throw new ContractNotFoundError(library);
+        }
+    }
+
+    const registryAddress = resolveRegistryAddress(cdmJson, options?.registryAddress);
+    const registry = createContract(runtime, registryAddress, CDM_REGISTRY_ABI, {
+        defaultOrigin: options?.registryOrigin,
+    });
+    const liveAddresses = await Promise.all(
+        libraries.map(async (library): Promise<readonly [string, HexString]> => [
+            library,
+            await queryLiveAddress(registry, library),
+        ]),
+    );
+
+    const resolved = cloneCdmJson(cdmJson);
+    for (const [library, address] of liveAddresses) {
+        patchContractAddress(resolved, library, address);
+    }
+    return resolved;
+}
 
 /**
  * Manages typed contract interactions backed by a `cdm.json` manifest.
@@ -46,22 +166,13 @@ import type {
  * ```
  */
 export class ContractManager {
-    private cdmJson: CdmJson;
-    private targetHash: string;
+    private contracts: ContractMap | undefined;
     private runtime: ContractRuntime;
     private defaults: ContractDefaults;
 
     constructor(cdmJson: CdmJson, runtime: ContractRuntime, options?: ContractManagerOptions) {
-        this.cdmJson = cdmJson;
         this.runtime = runtime;
-
-        if (options?.targetHash) {
-            this.targetHash = options.targetHash;
-        } else {
-            const targets = Object.keys(cdmJson.targets);
-            if (targets.length === 0) throw new Error("No targets found in cdm.json");
-            this.targetHash = targets[0];
-        }
+        this.contracts = cdmJson.contracts;
 
         this.defaults = {
             signerManager: options?.signerManager,
@@ -104,12 +215,41 @@ export class ContractManager {
         );
     }
 
+    /**
+     * Create a manager after strictly resolving installed contract addresses
+     * from the live CDM registry. ABIs still come from the installed manifest.
+     */
+    static async fromLive(
+        cdmJson: CdmJson,
+        runtime: ContractRuntime,
+        options?: ContractManagerOptions & LiveContractResolutionOptions,
+    ): Promise<ContractManager> {
+        const resolved = await withLiveContractAddresses(cdmJson, runtime, {
+            ...options,
+            registryOrigin: options?.registryOrigin ?? (options?.defaultOrigin as SS58String),
+        });
+        return new ContractManager(resolved, runtime, options);
+    }
+
+    /**
+     * Convenience factory for {@link fromLive} when the caller has a raw
+     * `PolkadotClient` and descriptor.
+     */
+    static async fromLiveClient<TDescriptor>(
+        cdmJson: CdmJson,
+        client: PolkadotClient,
+        descriptor: TDescriptor,
+        options?: ContractManagerOptions & ContractRuntimeOptions & LiveContractResolutionOptions,
+    ): Promise<ContractManager> {
+        const runtime = createContractRuntimeFromClient(client, descriptor, options);
+        return ContractManager.fromLive(cdmJson, runtime, options);
+    }
+
     private getContractData(library: string): CdmJsonContract {
-        const contractsForTarget = this.cdmJson.contracts?.[this.targetHash];
-        if (!contractsForTarget || !(library in contractsForTarget)) {
-            throw new ContractNotFoundError(library, this.targetHash);
+        if (!this.contracts || !(library in this.contracts)) {
+            throw new ContractNotFoundError(library);
         }
-        return contractsForTarget[library];
+        return this.contracts[library];
     }
 
     /**
@@ -205,56 +345,72 @@ if (import.meta.vitest) {
 
     /**
      * Real-world cdm.json structure as it appears in
-     * `paritytech/playground-cli/cdm.json`. Used here as the reproducer
+     * current CDM installs. Used here as the reproducer
      * for the cdm-resolution flow: if `getContract()` works against
      * this manifest shape, it works against any consumer's manifest.
      *
      * Notable shape differences from the generated examples:
      *   - `metadataCid` is absent (made optional in 0.2.1)
-     *   - target hash is a single 16-char hex string
      *   - `dependencies` uses `"latest"` for version
      *   - contract addresses are 20-byte EVM-shaped (Polkadot Asset Hub
      *     uses Solidity-compatible addresses for Revive contracts)
      */
     const playgroundCdm: CdmJson = {
-        targets: {
-            acc2c3b5e912b762: {
-                "asset-hub": "wss://paseo-asset-hub-next-rpc.polkadot.io",
-                bulletin: "https://paseo-bulletin-next-ipfs.polkadot.io",
-            },
-        },
         dependencies: {
-            acc2c3b5e912b762: {
-                "@w3s/playground-registry": "latest",
-            },
+            "@w3s/playground-registry": "latest",
         },
         contracts: {
-            acc2c3b5e912b762: {
-                "@w3s/playground-registry": {
-                    version: 6,
-                    address: "0x4A37B123b0BA2A894cA5953f472264921d44e298",
-                    abi: [
-                        { type: "constructor", inputs: [], stateMutability: "nonpayable" },
-                        {
-                            type: "function",
-                            name: "publish",
-                            inputs: [
-                                { name: "domain", type: "string" },
-                                { name: "metadata_uri", type: "string" },
-                                { name: "visibility", type: "uint8" },
-                            ],
-                            outputs: [],
-                            stateMutability: "nonpayable",
-                        },
-                        {
-                            type: "function",
-                            name: "unpublish",
-                            inputs: [{ name: "domain", type: "string" }],
-                            outputs: [],
-                            stateMutability: "nonpayable",
-                        },
-                    ],
-                },
+            "@w3s/playground-registry": {
+                version: 6,
+                address: "0x4A37B123b0BA2A894cA5953f472264921d44e298",
+                abi: [
+                    { type: "constructor", inputs: [], stateMutability: "nonpayable" },
+                    {
+                        type: "function",
+                        name: "publish",
+                        inputs: [
+                            { name: "domain", type: "string" },
+                            { name: "metadata_uri", type: "string" },
+                            { name: "visibility", type: "uint8" },
+                        ],
+                        outputs: [],
+                        stateMutability: "nonpayable",
+                    },
+                    {
+                        type: "function",
+                        name: "unpublish",
+                        inputs: [{ name: "domain", type: "string" }],
+                        outputs: [],
+                        stateMutability: "nonpayable",
+                    },
+                ],
+            },
+        },
+    };
+
+    const flattenedCdm: CdmJson = {
+        registry: "0x9999999999999999999999999999999999999999",
+        dependencies: {
+            "@w3s/playground-registry": "latest",
+        },
+        contracts: {
+            "@w3s/playground-registry": {
+                version: 6,
+                address: "0x4A37B123b0BA2A894cA5953f472264921d44e298",
+                abi: [
+                    { type: "constructor", inputs: [], stateMutability: "nonpayable" },
+                    {
+                        type: "function",
+                        name: "publish",
+                        inputs: [
+                            { name: "domain", type: "string" },
+                            { name: "metadata_uri", type: "string" },
+                            { name: "visibility", type: "uint8" },
+                        ],
+                        outputs: [],
+                        stateMutability: "nonpayable",
+                    },
+                ],
             },
         },
     };
@@ -277,7 +433,80 @@ if (import.meta.vitest) {
         } as unknown as ContractRuntime;
     }
 
+    async function registryRuntimeFor(value: OptionAddress): Promise<ContractRuntime> {
+        const { encodeFunctionResult, hexToBytes } = await import("viem");
+        const data = hexToBytes(
+            encodeFunctionResult({
+                abi: CDM_REGISTRY_ABI as any,
+                functionName: "getAddress",
+                result: value,
+            }) as `0x${string}`,
+        );
+
+        return {
+            ...fakeRuntime(),
+            dryRunCall: async () => ({
+                weight_consumed: { ref_time: 0n, proof_size: 0n },
+                weight_required: { ref_time: 1n, proof_size: 1n },
+                storage_deposit: { type: "Refund", value: 0n },
+                max_storage_deposit: { type: "Refund", value: 0n },
+                gas_consumed: 0n,
+                result: { success: true, value: { flags: 0, data } },
+            }),
+        };
+    }
+
     describe("ContractManager — cdm.json resolution", () => {
+        test("constructs from a flat cdm.json", () => {
+            const manager = new ContractManager(flattenedCdm, fakeRuntime());
+            expect(manager.getAddress("@w3s/playground-registry")).toBe(
+                "0x4A37B123b0BA2A894cA5953f472264921d44e298",
+            );
+        });
+
+        test("getContract returns a typed handle from a flattened cdm.json", () => {
+            const manager = new ContractManager(flattenedCdm, fakeRuntime());
+            const registry = manager.getContract("@w3s/playground-registry") as unknown as Record<
+                string,
+                { query: unknown; tx: unknown }
+            >;
+
+            expect(typeof registry.publish.query).toBe("function");
+            expect(typeof registry.publish.tx).toBe("function");
+        });
+
+        test("getContract throws without target wording for a flattened cdm.json miss", () => {
+            const manager = new ContractManager(flattenedCdm, fakeRuntime());
+            expect(() => manager.getContract("@nonexistent/contract")).toThrow(
+                'Contract "@nonexistent/contract" not found in cdm.json',
+            );
+        });
+
+        test("strictly patches flattened manifests with live registry addresses", async () => {
+            const liveAddress = "0x7777777777777777777777777777777777777777";
+            const runtime = await registryRuntimeFor({ isSome: true, value: liveAddress });
+
+            const resolved = await withLiveContractAddresses(flattenedCdm, runtime, {
+                registryOrigin: "5LiveOrigin" as SS58String,
+            });
+
+            expect(resolved.contracts?.["@w3s/playground-registry"].address).toBe(liveAddress);
+            expect(flattenedCdm.contracts?.["@w3s/playground-registry"].address).toBe(
+                "0x4A37B123b0BA2A894cA5953f472264921d44e298",
+            );
+        });
+
+        test("live registry resolution fails instead of falling back to the snapshot", async () => {
+            const runtime = await registryRuntimeFor({
+                isSome: false,
+                value: "0x0000000000000000000000000000000000000000",
+            });
+
+            await expect(withLiveContractAddresses(flattenedCdm, runtime)).rejects.toThrow(
+                /not registered/,
+            );
+        });
+
         test("constructs from a real-world cdm.json without errors", () => {
             const manager = new ContractManager(playgroundCdm, fakeRuntime());
             expect(manager.getAddress("@w3s/playground-registry")).toBe(
@@ -304,13 +533,6 @@ if (import.meta.vitest) {
             );
         });
 
-        test("auto-selects the first target when no targetHash is provided", () => {
-            const manager = new ContractManager(playgroundCdm, fakeRuntime());
-            // Single-target manifest — should resolve cleanly without
-            // requiring an explicit targetHash.
-            expect(() => manager.getContract("@w3s/playground-registry")).not.toThrow();
-        });
-
         test("getAddress returns the manifest's recorded H160 for a library", () => {
             // Replaces the prior "passes the right address to inkSdk" test —
             // the new runtime doesn't take the address at construction time
@@ -320,56 +542,6 @@ if (import.meta.vitest) {
             expect(manager.getAddress("@w3s/playground-registry")).toBe(
                 "0x4A37B123b0BA2A894cA5953f472264921d44e298",
             );
-        });
-
-        test("explicit targetHash option selects the right contracts subtree", () => {
-            // Multi-target manifest: we should be able to pin to a specific
-            // target hash and have getContract resolve against it.
-            const multiTargetCdm: CdmJson = {
-                targets: {
-                    target_a: { "asset-hub": "wss://a", bulletin: "https://a" },
-                    target_b: { "asset-hub": "wss://b", bulletin: "https://b" },
-                },
-                dependencies: {
-                    target_a: { "@org/foo": "1.0" },
-                    target_b: { "@org/foo": "2.0" },
-                },
-                contracts: {
-                    target_a: {
-                        "@org/foo": {
-                            version: 1,
-                            address: "0x1111111111111111111111111111111111111111",
-                            abi: [],
-                        },
-                    },
-                    target_b: {
-                        "@org/foo": {
-                            version: 2,
-                            address: "0x2222222222222222222222222222222222222222",
-                            abi: [],
-                        },
-                    },
-                },
-            };
-
-            const aManager = new ContractManager(multiTargetCdm, fakeRuntime(), {
-                targetHash: "target_a",
-            });
-            const bManager = new ContractManager(multiTargetCdm, fakeRuntime(), {
-                targetHash: "target_b",
-            });
-
-            expect(aManager.getAddress("@org/foo")).toBe(
-                "0x1111111111111111111111111111111111111111",
-            );
-            expect(bManager.getAddress("@org/foo")).toBe(
-                "0x2222222222222222222222222222222222222222",
-            );
-        });
-
-        test("constructor throws when cdm.json has no targets", () => {
-            const emptyCdm: CdmJson = { targets: {}, dependencies: {} };
-            expect(() => new ContractManager(emptyCdm, fakeRuntime())).toThrow(/No targets found/);
         });
     });
 

--- a/product-sdk/packages/contracts/src/types.ts
+++ b/product-sdk/packages/contracts/src/types.ts
@@ -12,11 +12,7 @@ export type { TxResult, SubmitOptions, BatchableCall } from "@parity/product-sdk
 // cdm.json schema
 // ---------------------------------------------------------------------------
 
-/** Pins a target to specific asset-hub and Bulletin chain hashes in `cdm.json`. */
-export interface CdmJsonTarget {
-    "asset-hub": string;
-    bulletin: string;
-}
+export type CdmJsonDependencyVersion = number | string;
 
 /**
  * A deployed contract's on-chain address, ABI, and optional metadata CID.
@@ -32,11 +28,11 @@ export interface CdmJsonContract {
     metadataCid?: string;
 }
 
-/** A project's `cdm.json` manifest: declared targets, runtime dependencies, and per-target contract deployments. */
+/** A project's `cdm.json` manifest. */
 export interface CdmJson {
-    targets: Record<string, CdmJsonTarget>;
-    dependencies: Record<string, Record<string, number | string>>;
-    contracts?: Record<string, Record<string, CdmJsonContract>>;
+    dependencies: Record<string, CdmJsonDependencyVersion>;
+    contracts?: Record<string, CdmJsonContract>;
+    registry?: HexString;
 }
 
 // ---------------------------------------------------------------------------
@@ -182,9 +178,16 @@ export interface ContractOptions {
 }
 
 /** Options for {@link ContractManager} construction. */
-export interface ContractManagerOptions extends ContractOptions {
-    /** Explicit target hash to select from cdm.json. Defaults to the first target. */
-    targetHash?: string;
+export type ContractManagerOptions = ContractOptions;
+
+/** Options for resolving installed CDM contract addresses from the live CDM registry. */
+export interface LiveContractResolutionOptions {
+    /** CDM registry contract address. Defaults to `cdm.json.registry`. */
+    registryAddress?: HexString;
+    /** Subset of installed libraries to resolve. Defaults to every contract in the manifest. */
+    libraries?: readonly string[];
+    /** Origin used for CDM registry dry-run queries. Defaults to `defaultOrigin` in manager helpers. */
+    registryOrigin?: SS58String;
 }
 
 /**

--- a/product-sdk/skills/product-sdk-app-builder/references/project-templates.md
+++ b/product-sdk/skills/product-sdk-app-builder/references/project-templates.md
@@ -239,8 +239,9 @@ async function main() {
     const signerManager = new SignerManager();
     await signerManager.connect();
 
-    const counter = await createContractFromClient(
+    const counter = createContractFromClient(
         client.raw.assetHub,
+        paseo_asset_hub,
         "0xYourContractAddress...",
         counterAbi,
         { signerManager }

--- a/product-sdk/skills/product-sdk-contracts/SKILL.md
+++ b/product-sdk/skills/product-sdk-contracts/SKILL.md
@@ -23,7 +23,7 @@ const client = await createChainClient({
     rpcs: { assetHub: ["wss://paseo-asset-hub-next-rpc.polkadot.io"] },
 });
 
-const manager = await ContractManager.fromClient(cdmJson, client.raw.assetHub, {
+const manager = ContractManager.fromClient(cdmJson, client.raw.assetHub, paseo_asset_hub, {
     signerManager, // from @parity/product-sdk-signer
 });
 
@@ -57,8 +57,9 @@ const client = await createChainClient({
     rpcs: { assetHub: ["wss://paseo-asset-hub-next-rpc.polkadot.io"] },
 });
 
-const counter = await createContractFromClient(
+const counter = createContractFromClient(
     client.raw.assetHub,
+    paseo_asset_hub,
     "0xYourContractAddress...",
     abi,
     { signerManager }
@@ -164,7 +165,7 @@ const productRes = await signerManager.getProductAccount("your-app.dot", 0);
 if (!productRes.ok) throw productRes.error;
 const productAccount = productRes.value;
 
-const manager = await ContractManager.fromClient(cdmJson, client.raw.assetHub, {
+const manager = ContractManager.fromClient(cdmJson, client.raw.assetHub, paseo_asset_hub, {
     signerManager,
 });
 
@@ -179,7 +180,7 @@ for full end-to-end references.
 You can also set a default signer or origin:
 
 ```typescript
-const manager = await ContractManager.fromClient(cdmJson, client.raw.assetHub, {
+const manager = ContractManager.fromClient(cdmJson, client.raw.assetHub, paseo_asset_hub, {
     defaultSigner: mySigner,
     defaultOrigin: "0x...",
 });
@@ -234,6 +235,7 @@ import {
     loadPvmContractArtifacts,
 } from "@parity/product-sdk-contracts/pvm";
 import { createContractFromClient } from "@parity/product-sdk-contracts";
+import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
 
 // 1. In-memory (browser-safe)
 import abiJson from "./counter.release.abi.json" with { type: "json" };
@@ -246,7 +248,7 @@ const abi2 = await loadPvmContractAbi("./target/counter.release.abi.json");
 const { abi: abi3, bytecode } = await loadPvmContractArtifacts("./target/counter.release");
 
 // Hand the parsed ABI straight to the existing factories
-const counter = await createContractFromClient(client.raw.assetHub, "0xC472...", abi);
+const counter = createContractFromClient(client.raw.assetHub, paseo_asset_hub, "0xC472...", abi);
 const { value } = await counter.get.query();
 await counter.increment.tx(1n, { signer });
 ```
@@ -284,7 +286,7 @@ The typed-API factory `createContractRuntime(typedApi, { at })` is also exported
 
 3. **Wrong signer type** — Contract transactions need a `PolkadotSigner`. Don't confuse with `StatementSignerWithKey` (for statement-store).
 
-4. **Forgetting await** — Both `ContractManager.fromClient()` and `createContractFromClient()` return Promises.
+4. **Adding a spurious `await`** — `ContractManager.fromClient()` and `createContractFromClient()` are **synchronous**; don't `await` them. Only the live-resolution factories `ContractManager.fromLive()` / `fromLiveClient()` (and `withLiveContractAddresses()`) return Promises.
 
 5. **Assuming `tx()` only fails for signer/dispatch reasons** — `tx()` also throws `ContractRevertedError` when the dry-run shows the contract would revert. Catch it (or its base `ContractError`) if you're surfacing revert reasons to users.
 

--- a/product-sdk/skills/product-sdk-contracts/references/contracts-api.md
+++ b/product-sdk/skills/product-sdk-contracts/references/contracts-api.md
@@ -41,6 +41,34 @@ const manager = ContractManager.fromClient(cdmJson, client.raw.assetHub, paseo_a
 });
 ```
 
+#### fromLive / fromLiveClient
+
+**Async.** Resolve each installed contract's address from the live CDM registry before constructing the manager, instead of trusting the address baked into `cdm.json`. ABIs and versions still come from the installed snapshot — only addresses are refreshed. Strict: rejects with `ContractLiveAddressResolutionError` if an address can't be resolved (never falls back to the snapshot).
+
+```typescript
+static fromLive(
+    cdmJson: CdmJson,
+    runtime: ContractRuntime,
+    options?: ContractManagerOptions & LiveContractResolutionOptions,
+): Promise<ContractManager>
+
+static fromLiveClient<TDescriptor>(
+    cdmJson: CdmJson,
+    client: PolkadotClient,
+    descriptor: TDescriptor,
+    options?: ContractManagerOptions & ContractRuntimeOptions & LiveContractResolutionOptions,
+): Promise<ContractManager>
+```
+
+```typescript
+const manager = await ContractManager.fromLiveClient(
+    cdmJson,
+    client.raw.assetHub,
+    paseo_asset_hub,
+    { signerManager }, // registryAddress defaults to cdmJson.registry
+);
+```
+
 ### Instance Methods
 
 #### getContract
@@ -143,6 +171,27 @@ const counter = createContractFromClient(
 
 ---
 
+## withLiveContractAddresses
+
+Standalone helper behind `ContractManager.fromLive`. Returns a **cloned** `cdm.json` whose installed contract addresses have been replaced with live addresses from the CDM registry. The input manifest is never mutated. Strict — rejects with `ContractLiveAddressResolutionError` if any requested address can't be resolved.
+
+```typescript
+function withLiveContractAddresses(
+    cdmJson: CdmJson,
+    runtime: ContractRuntime,
+    options?: LiveContractResolutionOptions,
+): Promise<CdmJson>
+```
+
+```typescript
+const resolved = await withLiveContractAddresses(cdmJson, runtime, {
+    libraries: ["@example/counter"], // optional subset; defaults to all
+});
+const manager = new ContractManager(resolved, runtime);
+```
+
+---
+
 ## generateContractTypes
 
 Generate a TypeScript module augmentation for typed contract handles.
@@ -205,7 +254,19 @@ Thrown when `getContract()` is called with an unknown library name.
 
 ```typescript
 class ContractNotFoundError extends ContractError {
-    constructor(library: string, targetHash: string)
+    constructor(library: string)
+}
+```
+
+### ContractLiveAddressResolutionError
+
+Thrown by `ContractManager.fromLive` / `fromLiveClient` / `withLiveContractAddresses` when a live registry address can't be resolved (no `registry` configured, the contract isn't registered, or the registry query failed).
+
+```typescript
+class ContractLiveAddressResolutionError extends ContractError {
+    readonly library: string | undefined;
+    readonly detail: unknown;
+    constructor(message: string, options?: { library?: string; detail?: unknown; cause?: unknown })
 }
 ```
 
@@ -289,10 +350,24 @@ interface ContractDefaults {
 
 ```typescript
 interface ContractManagerOptions {
-    targetHash?: string;
     signerManager?: SignerManager;
     defaultOrigin?: HexString;
     defaultSigner?: PolkadotSigner;
+}
+```
+
+### LiveContractResolutionOptions
+
+Options for the live-resolution factories (`fromLive`, `fromLiveClient`, `withLiveContractAddresses`).
+
+```typescript
+interface LiveContractResolutionOptions {
+    /** CDM registry contract address. Defaults to `cdm.json.registry`. */
+    registryAddress?: HexString;
+    /** Subset of installed libraries to resolve. Defaults to every contract in the manifest. */
+    libraries?: readonly string[];
+    /** Origin used for CDM registry dry-run queries. Defaults to `defaultOrigin` in manager helpers. */
+    registryOrigin?: SS58String;
 }
 ```
 
@@ -312,18 +387,16 @@ The CDM manifest format.
 
 ```typescript
 interface CdmJson {
-    targets: Record<string, CdmJsonTarget>;
-    contracts?: Record<string, Record<string, CdmJsonContract>>;
-}
-
-interface CdmJsonTarget {
-    chainId: string;
-    rpc: string;
+    dependencies: Record<string, number | string>;
+    contracts?: Record<string, CdmJsonContract>;
+    registry?: HexString;
 }
 
 interface CdmJsonContract {
+    version: number;
     address: HexString;
     abi: AbiEntry[];
+    metadataCid?: string;
 }
 ```
 


### PR DESCRIPTION
## Summary

Brings `@parity/product-sdk-contracts` in line with the flattened `cdm.json` manifest shape, and adds live CDM registry address resolution.

- Flatten `cdm.json`: drop the target-hash buckets in favor of a flat shape — top-level `registry`, with `dependencies` and `contracts` keyed directly by library name.
- Remove `ContractManagerOptions.targetHash` and the `CdmJsonTarget` type; `ContractManager` resolves directly from the flat `contracts` map. `ContractNotFoundError` no longer carries a `targetHash`.
- Add `ContractManager.fromLive(...)` / `fromLiveClient(...)` and the standalone `withLiveContractAddresses(...)` helper to **strictly** resolve installed contract addresses from the live CDM registry (ABIs/versions still come from the installed snapshot). Backed by the new `LiveContractResolutionOptions` type and `ContractLiveAddressResolutionError`.
- Add the `CdmJsonDependencyVersion` type alias.
- Refresh README + skill docs (`SKILL.md`, `contracts-api.md`) for the new shape, and fix stale `fromClient` / `createContractFromClient` examples (missing `descriptor` arg + spurious `await` — both factories are synchronous).
- Add a changeset (minor bump).

## cdm.json shape change

Old (target-hash bucketed):

```jsonc
{
  "targets": {
    "<targetHash>": { "asset-hub": "wss://…", "bulletin": "https://…" }
  },
  "dependencies": {
    "<targetHash>": { "@org/foo": "latest" }
  },
  "contracts": {
    "<targetHash>": {
      "@org/foo": { "version": 6, "address": "0x…", "abi": [ /* … */ ] }
    }
  }
}
```

New (flat):

```jsonc
{
  "registry": "0x…",
  "dependencies": { "@org/foo": "latest" },
  "contracts": {
    "@org/foo": { "version": 6, "address": "0x…", "abi": [ /* … */ ] }
  }
}
```

## Pairs with

This pairs with paritytech/contract-dependency-manager#38, which produces the flat `cdm.json` shape this PR consumes.

## Checks

- `pnpm --filter @parity/product-sdk-contracts test`
- `pnpm --filter @parity/product-sdk-contracts build`