### PR TITLE
fix(ci): correct create-pull-request path in @novasamatech deps-check

### DIFF
--- a/.github/workflows/product-sdk-deps-check.yml
+++ b/.github/workflows/product-sdk-deps-check.yml
@@ -114,10 +114,9 @@ jobs:
               uses: peter-evans/create-pull-request@v7
               with:
                   token: ${{ steps.app-token.outputs.token }}
-                  path: product-sdk
                   add-paths: |
-                      pnpm-workspace.yaml
-                      pnpm-lock.yaml
+                      product-sdk/pnpm-workspace.yaml
+                      product-sdk/pnpm-lock.yaml
                   branch: deps/novasamatech-updates
                   delete-branch: true
                   commit-message: "chore(deps): bump @novasamatech catalog deps"


### PR DESCRIPTION
## Problem

The `Check @novasamatech updates` workflow fails every run on the
**Create Pull Request** step with:

​```
Error: ENOENT: no such file or directory, open
'/home/runner/work/product-sdk/product-sdk/product-sdk/home/runner/work/product-sdk/product-sdk/.git/config'
​```

## Fix

- Remove `path: product-sdk` so the action operates on the real repo root.
- Re-root `add-paths` at `product-sdk/pnpm-workspace.yaml` and
  `product-sdk/pnpm-lock.yaml` so the staged files resolve from the repo root.
