### PR TITLE
ci(security): address zizmor findings — SHA-pin actions, lock down permissions, add concurrency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@
 # `versioning-strategy: increase-if-necessary`, which raises the
 # package.json `^X.Y.Z` floor in lockstep with the lockfile so the two
 # stay in sync.
+#
+# Cooldown: zizmor flags missing cooldown, but cooldown only applies to
+# routine version-update PRs (which are already suppressed at limit 0).
+# We declare a defensive cooldown anyway in case `open-pull-requests-limit`
+# is ever raised — it won't affect security PRs, which Dependabot opens
+# without cooldown by design.
 
 version: 2
 updates:
@@ -20,6 +26,8 @@ updates:
       schedule:
           interval: "weekly"
       versioning-strategy: "increase-if-necessary"
+      cooldown:
+          default-days: 7
       commit-message:
           prefix: "chore(deps)"
           include: "scope"
@@ -31,6 +39,8 @@ updates:
       schedule:
           interval: "weekly"
       versioning-strategy: "increase-if-necessary"
+      cooldown:
+          default-days: 7
       commit-message:
           prefix: "chore(deps)"
           include: "scope"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,15 +1,26 @@
 name: "docs: Deploy (Bulletin + Pages)"
 
+# Triggered by either:
+#   1. The release workflow finishing successfully (so a fresh @parity/product-sdk
+#      tag exists on HEAD), or
+#   2. A manual dispatch (for hotfix re-deploys without a release).
+#
+# `workflow_run` is flagged by zizmor as a dangerous trigger because it is
+# attacker-controllable on PRs from forks. We are safe here because the
+# `gate` step rejects any HEAD that does not carry a fresh umbrella tag,
+# so a malicious PR run that completes successfully still won't deploy
+# unless it also produces an `@parity/product-sdk@X.Y.Z` git tag — which
+# requires write access we don't grant to forks.
 on:
     workflow_run:
         workflows: ["product-sdk: Release"]
         types: [completed]
     workflow_dispatch:
 
+# Default workflow scope: read-only. Per-job grants below scope the Pages
+# write permissions to the one job that actually deploys.
 permissions:
     contents: read
-    pages: write
-    id-token: write
 
 concurrency:
     group: docs-deploy
@@ -19,18 +30,32 @@ jobs:
     deploy:
         if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            # Required by `actions/deploy-pages` to publish the static site.
+            pages: write
+            # Required by `actions/deploy-pages` to mint the OIDC token GitHub
+            # Pages uses to authenticate the deployment.
+            id-token: write
         environment:
             name: github-pages
             url: ${{ steps.pages-deploy.outputs.page_url }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
                   fetch-depth: 0
+                  persist-credentials: false
 
             - name: Check for umbrella tag at HEAD
               id: gate
+              # `github.event_name` is a hardened GitHub-provided value drawn from
+              # the workflow event metadata (not user input), so the template
+              # expansion is safe. Routed through an env var for defence in
+              # depth and to keep zizmor's `template-injection` audit clean.
+              env:
+                  EVENT_NAME: ${{ github.event_name }}
               run: |
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                  if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
                     echo "skip=false" >> $GITHUB_OUTPUT
                     exit 0
                   fi
@@ -43,12 +68,12 @@ jobs:
                   fi
 
             - if: steps.gate.outputs.skip != 'true'
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               with:
                   version: 10
 
             - if: steps.gate.outputs.skip != 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: "22"
                   cache: "pnpm"
@@ -87,7 +112,7 @@ jobs:
 
             - name: Deploy to Bulletin Chain
               if: steps.gate.outputs.skip != 'true'
-              uses: nick-fields/retry@v3
+              uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
               with:
                   timeout_minutes: 10
                   max_attempts: 3
@@ -102,15 +127,15 @@ jobs:
 
             - name: Configure GitHub Pages
               if: steps.gate.outputs.skip != 'true'
-              uses: actions/configure-pages@v5
+              uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
             - name: Upload Pages artifact
               if: steps.gate.outputs.skip != 'true'
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
               with:
                   path: docs/out
 
             - name: Deploy to GitHub Pages
               id: pages-deploy
               if: steps.gate.outputs.skip != 'true'
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -14,21 +14,32 @@ on:
             - "docs/**"
             - ".github/workflows/docs-verify.yml"
 
+# Read-only build: only needs to clone the repo to verify it builds.
 permissions:
     contents: read
+
+# Cancel in-flight runs on the same PR / ref so a quick succession of pushes
+# doesn't queue a backlog of redundant verifies.
+concurrency:
+    group: docs-verify-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
     build:
         name: "docs: Verify Generate & Build"
         runs-on: parity-default
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  # Verify-only job; clear the token from .git/config after checkout
+                  # so subsequent steps can't accidentally exfiltrate it.
+                  persist-credentials: false
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               with:
                   version: 10
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: "22"
                   cache: "pnpm"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,6 +9,10 @@ on:
       - edited
       - synchronize
 
+# No write access needed at workflow level — the validate action only reads PR
+# metadata. Per-job grants below.
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -16,11 +20,12 @@ concurrency:
 jobs:
   validate-title:
     permissions:
+      # Read-only access to PR title + metadata; no write needed.
       pull-requests: read
     name: Validate PR Title
     runs-on: parity-default
     steps:
       - name: semantic-pull-request
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/product-sdk-bundle-size.yml
+++ b/.github/workflows/product-sdk-bundle-size.yml
@@ -7,20 +7,33 @@ on:
       - "product-sdk/**"
       - ".github/workflows/product-sdk-bundle-size.yml"
 
+# Read-only by default; the comment-posting job grants write below.
+permissions:
+  contents: read
+
+# Cancel in-flight runs on the same PR so a quick succession of pushes
+# doesn't queue redundant measurements.
+concurrency:
+  group: product-sdk-bundle-size-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   measure-base:
     name: "Measure base"
     runs-on: parity-default
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "pnpm"
@@ -46,7 +59,7 @@ jobs:
             echo '{"version":1,"packages":{},"generatedAt":"base","node":"n/a","esbuild":"n/a"}' > bundle-size.base.json
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bundle-size-base
           path: bundle-size.base.json
@@ -55,14 +68,18 @@ jobs:
   measure-head:
     name: "Measure head"
     runs-on: parity-default
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "pnpm"
@@ -82,7 +99,7 @@ jobs:
           (cd product-sdk && node scripts/bench-bundle.mjs measure --out bundle-size.head.json)
           mv product-sdk/bundle-size.head.json ./bundle-size.head.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bundle-size-head
           path: bundle-size.head.json
@@ -94,11 +111,15 @@ jobs:
     needs: [measure-base, measure-head]
     permissions:
       contents: read
+      # Needed by marocchino/sticky-pull-request-comment to upsert the bundle-size
+      # diff comment on the PR.
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
 
@@ -113,12 +134,12 @@ jobs:
 
       # Download both artifacts to the repo root (artifacts contain the JSON
       # files at their root since we staged them flat in the measure jobs).
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bundle-size-base
           path: .
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: bundle-size-head
           path: .
@@ -180,13 +201,15 @@ jobs:
 
       - name: Post sticky PR comment
         if: always()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: product-sdk-bundle-size
           path: product-sdk/bundle-size.diff.md
 
       - name: Fail on regression
         if: steps.compare.outputs.compare-exit != '0'
+        env:
+          COMPARE_EXIT: ${{ steps.compare.outputs.compare-exit }}
         run: |
-          echo "Bundle size regression exceeds fail threshold (script exit ${{ steps.compare.outputs.compare-exit }})."
+          echo "Bundle size regression exceeds fail threshold (script exit $COMPARE_EXIT)."
           exit 1

--- a/.github/workflows/product-sdk-ci.yml
+++ b/.github/workflows/product-sdk-ci.yml
@@ -12,6 +12,17 @@ on:
       - "product-sdk/**"
       - ".github/workflows/product-sdk-ci.yml"
 
+# Read-only build/test pipeline: only needs to clone the repo. Per-job grants
+# below if anything ever needs to write.
+permissions:
+  contents: read
+
+# Cancel in-flight runs on the same PR / ref so a quick succession of pushes
+# doesn't queue a backlog of redundant CI runs.
+concurrency:
+  group: product-sdk-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: product-sdk
@@ -21,13 +32,15 @@ jobs:
     name: "product-sdk: Lint & Format"
     runs-on: parity-default
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "pnpm"
@@ -43,13 +56,15 @@ jobs:
     name: "product-sdk: Build"
     runs-on: parity-default
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "pnpm"
@@ -65,13 +80,15 @@ jobs:
     name: "product-sdk: Test"
     runs-on: parity-default
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "pnpm"

--- a/.github/workflows/product-sdk-deps-check.yml
+++ b/.github/workflows/product-sdk-deps-check.yml
@@ -13,6 +13,12 @@ concurrency:
     group: deps-check
     cancel-in-progress: false
 
+# No write access at workflow level. The bumper job below requests `contents:
+# write` for the App-token-authenticated push and `pull-requests: write` for
+# `peter-evans/create-pull-request`.
+permissions:
+    contents: read
+
 defaults:
     run:
         working-directory: product-sdk
@@ -22,23 +28,34 @@ jobs:
         runs-on: parity-default
         environment: main
         timeout-minutes: 10
+        permissions:
+            # Push the bump branch and open a PR via the App token.
+            contents: write
+            pull-requests: write
         steps:
             - name: Generate GitHub App token
               id: app-token
-              uses: actions/create-github-app-token@v1
+              # Limit the app token's installation permissions to what this job
+              # actually does: push a branch and open a PR.
+              uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
               with:
                   app-id: ${{ secrets.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-pull-requests: write
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
                   token: ${{ steps.app-token.outputs.token }}
+                  # The token IS persisted intentionally here — subsequent git
+                  # operations (commit + push the bump branch) need it.
+                  persist-credentials: true
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               with:
                   version: 10
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: "22"
                   cache: "pnpm"
@@ -111,7 +128,7 @@ jobs:
             # skips. The push itself still uses the App token.
             - name: Create Pull Request
               if: steps.changes.outputs.changed == 'true'
-              uses: peter-evans/create-pull-request@v7
+              uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
               with:
                   token: ${{ steps.app-token.outputs.token }}
                   add-paths: |

--- a/.github/workflows/product-sdk-descriptors-drift.yml
+++ b/.github/workflows/product-sdk-descriptors-drift.yml
@@ -23,23 +23,30 @@ defaults:
     run:
         working-directory: product-sdk
 
+# Default workflow scope: read-only. The drift-check job below requests
+# `issues: write` for upserting the tracking issue.
 permissions:
     contents: read
-    issues: write
 
 jobs:
     check:
         name: "Check descriptor drift"
         runs-on: parity-default
         timeout-minutes: 15
+        permissions:
+            contents: read
+            # Upsert / close the descriptors-drift tracking issue via `gh issue`.
+            issues: write
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  persist-credentials: false
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               with:
                   version: 10
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: "22"
                   cache: "pnpm"
@@ -113,7 +120,9 @@ jobs:
             # same condition.
             - name: Warn on full-outage runs
               if: steps.probe.outputs.unreachable_count == steps.probe.outputs.total
-              run: echo "::warning::all ${{ steps.probe.outputs.total }} chains unreachable — skipping issue update"
+              env:
+                  TOTAL: ${{ steps.probe.outputs.total }}
+              run: echo "::warning::all ${TOTAL} chains unreachable — skipping issue update"
 
             # Body is written to a file (not GITHUB_OUTPUT) so the backticks
             # and ${{ }} substitutions don't get re-evaluated by the shell

--- a/.github/workflows/product-sdk-e2e.yml
+++ b/.github/workflows/product-sdk-e2e.yml
@@ -12,6 +12,17 @@ on:
       - "product-sdk/**"
       - ".github/workflows/product-sdk-e2e.yml"
 
+# Read-only test pipeline: only needs to clone the repo. Artifact uploads use
+# the ephemeral run-scoped token and don't need extra permissions.
+permissions:
+  contents: read
+
+# Cancel in-flight runs on the same PR / ref so a quick succession of pushes
+# doesn't queue a backlog of redundant E2E runs (each takes ~30min).
+concurrency:
+  group: product-sdk-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: product-sdk
@@ -22,13 +33,15 @@ jobs:
     runs-on: parity-default
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "pnpm"
@@ -47,7 +60,7 @@ jobs:
         run: pnpm test:e2e
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/product-sdk-release.yml
+++ b/.github/workflows/product-sdk-release.yml
@@ -1,13 +1,24 @@
 name: "product-sdk: Release"
 
+# Triggered after a successful CI run on `main`. `workflow_run` is flagged by
+# zizmor as dangerous because of how PRs from forks can game it; we are safe
+# because (a) `branches: [main]` gates the trigger to the main branch, where
+# PRs from forks cannot push, and (b) the `bot` step below short-circuits on
+# the version-bump commit so the release loop can't recurse.
 on:
     workflow_run:
         workflows: ["product-sdk: CI"]
         types: [completed]
         branches: [main]
 
+# Default workflow scope: read-only. The release job below requests
+# `contents: write` explicitly for pushing version-bump commits + tags.
 permissions:
-    contents: write
+    contents: read
+
+concurrency:
+    group: product-sdk-release
+    cancel-in-progress: false
 
 defaults:
     run:
@@ -18,18 +29,29 @@ jobs:
         if: github.event.workflow_run.conclusion == 'success'
         runs-on: parity-default
         environment: main
+        permissions:
+            # Required to push the `chore: version packages` commit + per-package
+            # release tags. Token comes from the App below; this permission scope
+            # applies if/when a step falls back to `secrets.GITHUB_TOKEN`.
+            contents: write
         steps:
             - name: Generate GitHub App token
               id: app-token
-              uses: actions/create-github-app-token@v1
+              # Constrain the App token's installation permissions to what this
+              # job actually does: push version commits + tags to `main`.
+              uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
               with:
                   app-id: ${{ secrets.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
+                  permission-contents: write
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
                   fetch-depth: 0
                   token: ${{ steps.app-token.outputs.token }}
+                  # The token IS persisted intentionally — subsequent git push
+                  # operations (version-bump commit + tags) need it.
+                  persist-credentials: true
 
             # Skip if the triggering commit was a version bump by the bot
             - name: Check if bot commit
@@ -53,12 +75,12 @@ jobs:
                   fi
 
             - if: steps.bot.outputs.skip != 'true' && steps.changesets.outputs.found == 'true'
-              uses: pnpm/action-setup@v6
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               with:
                   version: 10
 
             - if: steps.bot.outputs.skip != 'true' && steps.changesets.outputs.found == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: "22"
                   registry-url: "https://registry.npmjs.org"
@@ -83,12 +105,17 @@ jobs:
               if: steps.bot.outputs.skip != 'true' && steps.changesets.outputs.found == 'true'
               run: pnpm format
 
-            # Commit version bumps
+            # Commit version bumps. `secrets.APP_ID` is a numeric App ID we own
+            # (not user input) — interpolated through an env var to keep
+            # zizmor's `template-injection` audit clean and to avoid any future
+            # shell-quoting surprises.
             - name: Commit version changes
               if: steps.bot.outputs.skip != 'true' && steps.changesets.outputs.found == 'true'
+              env:
+                  APP_ID: ${{ secrets.APP_ID }}
               run: |
                   git config user.name "product-sdk-release-bot[bot]"
-                  git config user.email "${{ secrets.APP_ID }}+product-sdk-release-bot[bot]@users.noreply.github.com"
+                  git config user.email "${APP_ID}+product-sdk-release-bot[bot]@users.noreply.github.com"
                   git add -A
                   git diff --cached --quiet || git commit -m "chore: version packages"
                   git pull --rebase
@@ -121,7 +148,7 @@ jobs:
 
             - name: Upload package artifacts
               if: steps.bot.outputs.skip != 'true' && steps.changesets.outputs.found == 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: packages
                   path: product-sdk/artifacts/*.tgz
@@ -129,7 +156,7 @@ jobs:
             # Dispatch to npm_publish_automation for publishing
             - name: Publish via npm_publish_automation
               if: steps.bot.outputs.skip != 'true' && steps.changesets.outputs.found == 'true'
-              uses: octokit/request-action@v2.x
+              uses: octokit/request-action@02f5e7c637a73a3b12ed81015fa7fb5f11cc5d7d # v2.x
               with:
                   route: POST /repos/paritytech/npm_publish_automation/actions/workflows/publish.yml/dispatches
                   ref: main


### PR DESCRIPTION
closes: https://github.com/paritytech/product-sdk/issues/149

## Description                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                    
  Addresses the zizmor security audit (103 findings) across all GitHub Actions workflows.
                                                                                                                                                                                                                                                    
## What changed                                              
                                                                                                                                                                                                                                                    
  - SHA-pin every action uses: reference. 51/51 actions now pinned to immutable commit hashes with a # vN comment for readability.
  - Add explicit permissions: blocks at workflow scope (read-only by default) and minimal write grants at job scope where actually needed.                                                                                                          
  - Add persist-credentials: false to read-only actions/checkout steps. Kept persist-credentials: true on the release + deps-check checkouts (those push commits via the token) with comments explaining why.
  - Add per-PR concurrency: groups with cancel-in-progress: true so quick-succession pushes cancel obsolete runs (verify, ci, e2e, bundle-size).                                                                                                    
  - Add permission-* inputs to actions/create-github-app-token in release + deps-check so the minted token's installation scope is constrained to what each job needs.
  - Route github.event_name and secrets.APP_ID through env vars instead of inline template expansion — false positives for template injection, but env-var routing satisfies the audit at zero cost.                                                
  - Add defensive cooldown.default-days: 7 to both Dependabot ecosystems.                                                                                                                                                                           
  - New: github-actions Dependabot entry so the SHA pins get auto-bumped weekly and don't rot.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            