### PR TITLE
fix(terminal): derive slot-account pubkey from canonical sr25519 to_bytes form

### DIFF
--- a/product-sdk/packages/terminal/src/host-signer.ts
+++ b/product-sdk/packages/terminal/src/host-signer.ts
@@ -16,6 +16,26 @@ import type { TerminalAdapter } from "./adapter.js";
 import { type CachedAllocation, loadCache, readCacheEntry } from "./host-cache.js";
 import type { AllocatableResource } from "./host.js";
 
+function bytesToNumberLE(bytes: Uint8Array): bigint {
+    let n = 0n;
+    for (let i = bytes.length - 1; i >= 0; i--) n = (n << 8n) | BigInt(bytes[i]);
+    return n;
+}
+function numberToBytesLE(value: bigint, length: number): Uint8Array {
+    const out = new Uint8Array(length);
+    for (let i = 0; i < length; i++) out[i] = Number((value >> BigInt(8 * i)) & 0xffn);
+    return out;
+}
+
+// schnorrkel to_bytes() (canonical scalar) -> to_ed25519_bytes() form @scure expects (×8 cofactor).
+function canonicalSr25519SecretToEd25519Bytes(secret: Uint8Array): Uint8Array {
+    const ed25519Scalar = numberToBytesLE(bytesToNumberLE(secret.subarray(0, 32)) << 3n, 32);
+    const out = new Uint8Array(64);
+    out.set(ed25519Scalar, 0);
+    out.set(secret.subarray(32, 64), 32);
+    return out;
+}
+
 // Wire encoding for slotAccountKey isn't pinned: mobile may send a
 // 32-byte mini-secret or a 64-byte expanded secret. Detect length and
 // route; any other length throws.
@@ -29,9 +49,10 @@ function buildKeypair(secret: Uint8Array): {
         return { publicKey: keypair.publicKey, sign: (data) => keypair.sign(data) };
     }
     if (secret.length === 64) {
+        const ed25519Secret = canonicalSr25519SecretToEd25519Bytes(secret);
         return {
-            publicKey: sr25519.getPublicKey(secret),
-            sign: (data) => sr25519.sign(data, secret),
+            publicKey: sr25519.getPublicKey(ed25519Secret),
+            sign: (data) => sr25519.sign(data, ed25519Secret),
         };
     }
     throw new Error(
@@ -189,10 +210,9 @@ if (import.meta.vitest) {
         });
 
         test("64-byte expanded-secret form produces a valid signer", async () => {
-            // Pre-computed: @scure/sr25519's secretFromSeed(mnemonicToMiniSecret(DEV_PHRASE)).
-            // Public key must match the 32-byte path's derived key.
+            // Canonical schnorrkel to_bytes() for DEV_PHRASE (scalar + nonce), the mobile wire form.
             const SECRET_64_HEX =
-                "0x28b0ae221c6bb06856b287f60d7ea0d98552ea5a16db16956849aa371db3eb51fd190cce74df356432b410bd64682309d6dedb27c76845daf388557cbac3ca34";
+                "0x05d65584630d16cd4af6d0bec10f34bb504a5dcb62dba2122d49f5a663763d0afd190cce74df356432b410bd64682309d6dedb27c76845daf388557cbac3ca34";
 
             await saveCache(
                 "p",

--- a/product-sdk/packages/terminal/src/host-signer.ts
+++ b/product-sdk/packages/terminal/src/host-signer.ts
@@ -7,6 +7,7 @@
  *
  * @module
  */
+import { bytesToNumberLE, numberToBytesLE } from "@noble/curves/utils.js";
 import { fromHex } from "@polkadot-api/utils";
 import { createDerive, sr25519, sr25519Derive } from "@polkadot-labs/hdkd-helpers";
 import type { PolkadotSigner } from "polkadot-api";
@@ -15,17 +16,6 @@ import { getPolkadotSigner } from "polkadot-api/signer";
 import type { TerminalAdapter } from "./adapter.js";
 import { type CachedAllocation, loadCache, readCacheEntry } from "./host-cache.js";
 import type { AllocatableResource } from "./host.js";
-
-function bytesToNumberLE(bytes: Uint8Array): bigint {
-    let n = 0n;
-    for (let i = bytes.length - 1; i >= 0; i--) n = (n << 8n) | BigInt(bytes[i]);
-    return n;
-}
-function numberToBytesLE(value: bigint, length: number): Uint8Array {
-    const out = new Uint8Array(length);
-    for (let i = 0; i < length; i++) out[i] = Number((value >> BigInt(8 * i)) & 0xffn);
-    return out;
-}
 
 // schnorrkel to_bytes() (canonical scalar) -> to_ed25519_bytes() form @scure expects (×8 cofactor).
 function canonicalSr25519SecretToEd25519Bytes(secret: Uint8Array): Uint8Array {

--- a/product-sdk/pending-changesets/fix-slot-account-canonical-sr25519-derivation.md
+++ b/product-sdk/pending-changesets/fix-slot-account-canonical-sr25519-derivation.md
@@ -1,0 +1,17 @@
+---
+"@parity/product-sdk-terminal": patch
+---
+
+**Fix `createSlotAccountSigner` deriving the wrong public key from a 64-byte slot account key.**
+
+Mobile hosts return `slotAccountKey` as schnorrkel `SecretKey::to_bytes()` material —
+the canonical scalar (32 bytes) concatenated with the nonce (32 bytes). `buildKeypair`
+fed those 64 bytes straight into `@scure/sr25519`'s `getPublicKey`, which expects the
+`to_ed25519_bytes()` form where the scalar is pre-multiplied by the cofactor (×8).
+The mismatch produced a public key — and therefore an address and signatures — that
+did not match the slot account the host allocated, so submissions signed by the slot
+signer were rejected.
+
+The 64-byte branch now converts the canonical scalar to the cofactor-multiplied form
+before deriving, so the derived key matches the host's slot account. The 32-byte
+mini-secret path is unchanged.


### PR DESCRIPTION
## What

`createSlotAccountSigner` derived the wrong public key (and therefore wrong address + signatures) from a 64-byte slot account key, so submissions signed by the slot signer were rejected by the host.

Closes https://github.com/paritytech/product-sdk/issues/176

## Why

Mobile hosts return `slotAccountKey` as schnorrkel `SecretKey::to_bytes()` — canonical scalar (32 bytes) + nonce (32 bytes). See Android's `SlotAccountKey.kt`: *"32-byte sr25519 private key concatenated with 32-byte nonce"*.

`buildKeypair`'s 64-byte branch fed those bytes straight into `@scure/sr25519`'s `getPublicKey`, which expects the `to_ed25519_bytes()` form — where the scalar is pre-multiplied by the cofactor (×8) so its `decodeScalar` (`>> 3`) recovers the real scalar. Canonical bytes skip that ×8, so the derived key was off by the cofactor.


## Fix

Convert the canonical scalar to the cofactor-multiplied form before deriving. The 32-byte mini-secret path is unchanged.

```diff
 if (secret.length === 64) {
-    return {
-        publicKey: sr25519.getPublicKey(secret),
-        sign: (data) => sr25519.sign(data, secret),
-    };
+    const ed25519Secret = canonicalSr25519SecretToEd25519Bytes(secret);
+    return {
+        publicKey: sr25519.getPublicKey(ed25519Secret),
+        sign: (data) => sr25519.sign(data, ed25519Secret),
+    };
 }