### PR TITLE
feat(terminal): expose host-papp allowance service with CLI defaults

### DIFF
--- a/product-sdk/packages/terminal/README.md
+++ b/product-sdk/packages/terminal/README.md
@@ -112,9 +112,58 @@ File-based storage adapter for Node.js. Data persists in `storageDir` (defaults 
 
 Waits for the session list to emit at least one entry, or resolves with `[]` after `timeoutMs`.
 
-## Allowance management (`./host` subpath)
+## Allowance signers — the canonical path
 
-For CLIs that need to write to Bulletin / Statement Store / Asset Hub smart contracts: the QR-paired mobile wallet is the Account Holder, the CLI plays the Host role, and `@parity/product-sdk-terminal/host` exposes that Host-runner surface (the [RFC-10](https://github.com/paritytech/triangle-js-sdks/blob/valentunn-rfc-0010/docs/rfcs/0010-allowance.md) Accounts Protocol companion, an on-disk allowance-key cache, and a local sr25519 signer over the cached keys).
+For CLIs that need to write to Bulletin or publish to the Statement Store: ask the paired wallet for an allowance slot, get a `PolkadotSigner` back, sign extrinsics with it. This is what most consumers want.
+
+```ts
+import {
+    createTerminalAdapter,
+    getBulletinSigner,
+    getStatementStoreProver,
+    waitForSessions,
+} from "@parity/product-sdk-terminal";
+
+const adapter = createTerminalAdapter({ appId: "my-cli" });
+
+// ...QR pair the phone, wait for the session...
+await waitForSessions(adapter);
+
+// First call prompts the wallet for an allowance slot; subsequent calls
+// return the cached slot key — no wire round-trip.
+const bulletinSigner = await getBulletinSigner(adapter, "my-cli.dot");
+await bulletinClient.tx.TransactionStorage.store({ data }).signAndSubmit(bulletinSigner);
+
+// Same idea, returns a StatementProver for `@novasamatech/statement-store` writes.
+const prover = await getStatementStoreProver(adapter, "my-cli.dot");
+```
+
+### `getBulletinSigner(adapter, productId, sessionId?): Promise<PolkadotSigner>`
+
+### `getStatementStoreProver(adapter, productId, sessionId?): Promise<StatementProver>`
+
+Both default `sessionId` to the only paired session. With zero or more than one paired sessions and no explicit id, both throw `AllowanceError` with `reason: 'NoSession'`. Pass an explicit `sessionId` to disambiguate.
+
+Failures from the host (`Rejected`, `NotAvailable`, codec drift) surface as `AllowanceError`:
+
+```ts
+import { AllowanceError } from "@parity/product-sdk-terminal";
+
+try {
+    const signer = await getBulletinSigner(adapter, "my-cli.dot");
+} catch (err) {
+    if (err instanceof AllowanceError && err.reason === "Rejected") {
+        // user denied the allowance request on the phone
+    }
+    throw err;
+}
+```
+
+Behind the scenes both helpers wrap `adapter.allowance` (inherited from host-papp's `PappAdapter`) and unwrap its neverthrow `ResultAsync` into a throwing `Promise`. If you want to keep neverthrow's `.match()` / `.mapErr()` ergonomics or need explicit multi-session handling, call `adapter.allowance.getBulletinSigner(sessionId, productId)` / `getStatementStoreProver(...)` directly.
+
+## Allowance management — manual cache + AP control (`./host` subpath)
+
+For CLIs that need finer control — pre-allocating multiple resources in one wallet prompt, inspecting the cache before round-tripping, or building a signer over a cached key without consulting the wallet — the `@parity/product-sdk-terminal/host` subpath exposes the lower-level Host-runner surface (the [RFC-10](https://github.com/paritytech/triangle-js-sdks/blob/valentunn-rfc-0010/docs/rfcs/0010-allowance.md) Accounts Protocol companion, an on-disk allowance-key cache, and a local sr25519 signer over the cached keys). Most CLIs don't need this — start with `getBulletinSigner` / `getStatementStoreProver` above.
 
 ```ts
 import {

--- a/product-sdk/packages/terminal/README.md
+++ b/product-sdk/packages/terminal/README.md
@@ -161,6 +161,36 @@ try {
 
 Behind the scenes both helpers wrap `adapter.allowance` (inherited from host-papp's `PappAdapter`) and unwrap its neverthrow `ResultAsync` into a throwing `Promise`. If you want to keep neverthrow's `.match()` / `.mapErr()` ergonomics or need explicit multi-session handling, call `adapter.allowance.getBulletinSigner(sessionId, productId)` / `getStatementStoreProver(...)` directly.
 
+### Cache-only probes — `hasBulletinAllowance` / `hasStatementStoreAllowance`
+
+For paths that must run silently — login health checks, "would calling `getBulletinSigner` prompt the phone?" decisions, readiness probes — use the cache-only variants. They read host-papp's on-disk allowance file directly and **never** trigger a wallet prompt.
+
+```ts
+import {
+    getBulletinSigner,
+    hasBulletinAllowance,
+} from "@parity/product-sdk-terminal";
+
+if (await hasBulletinAllowance(adapter, "my-cli.dot")) {
+    // happy path — fetch the signer without risking a wallet prompt
+    const signer = await getBulletinSigner(adapter, "my-cli.dot");
+} else {
+    // tell the user a wallet prompt will fire, then call getBulletinSigner
+    console.log("Approve the allowance request on your phone…");
+    const signer = await getBulletinSigner(adapter, "my-cli.dot");
+}
+```
+
+#### `hasBulletinAllowance(adapter, productId, sessionId?): Promise<boolean>`
+
+#### `hasStatementStoreAllowance(adapter, productId, sessionId?): Promise<boolean>`
+
+Resolves `true` when a slot key for `(sessionId, productId, resource)` is already cached on disk; `false` when it is not (file absent, or present with no matching entry). Same `sessionId` defaulting as the fetching helpers: defaults to the only paired session, throws `AllowanceError('NoSession')` for zero or multiple paired sessions without an explicit id.
+
+Rejects only on decrypt or decode failures — a corrupted cache file is a real failure, not a "no allowance" signal.
+
+> The cache-only check uses an internal mirror of host-papp's `AllowanceRepository` codec because host-papp doesn't expose a public probe today. We'll switch to the upstream API when one ships; the public surface (`hasBulletinAllowance` / `hasStatementStoreAllowance`) won't change.
+
 ## Allowance management — manual cache + AP control (`./host` subpath)
 
 For CLIs that need finer control — pre-allocating multiple resources in one wallet prompt, inspecting the cache before round-tripping, or building a signer over a cached key without consulting the wallet — the `@parity/product-sdk-terminal/host` subpath exposes the lower-level Host-runner surface (the [RFC-10](https://github.com/paritytech/triangle-js-sdks/blob/valentunn-rfc-0010/docs/rfcs/0010-allowance.md) Accounts Protocol companion, an on-disk allowance-key cache, and a local sr25519 signer over the cached keys). Most CLIs don't need this — start with `getBulletinSigner` / `getStatementStoreProver` above.

--- a/product-sdk/packages/terminal/package.json
+++ b/product-sdk/packages/terminal/package.json
@@ -50,6 +50,7 @@
         "scale-ts": "^1.6.1"
     },
     "devDependencies": {
+        "@novasamatech/substrate-slot-sr25519-wasm": "^0.8.6",
         "@types/qrcode": "^1.5.5",
         "tsup": "catalog:",
         "typescript": "catalog:",

--- a/product-sdk/packages/terminal/src/allowance-cache.ts
+++ b/product-sdk/packages/terminal/src/allowance-cache.ts
@@ -1,0 +1,126 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Private mirror of host-papp's `AllowanceRepository` on-disk format.
+ *
+ * The repository codec + AES-GCM scheme are internal to host-papp — only the
+ * higher-level `AllowanceService` is on the public surface, and that service
+ * exposes no cache-only probe (its `getBulletinSigner` / `getStatementStoreProver`
+ * fall through to `requestResourceAllocation` on cache miss, which prompts the
+ * paired wallet). For "is there an allowance slot for this tuple on disk?"
+ * answers — needed by login-readiness checks that must not pop a phone
+ * dialog — we have to read the storage file ourselves.
+ *
+ * This module vendors:
+ *  - the SCALE codec for the `Vector(StoredAllowanceEntry)` blob host-papp
+ *    writes,
+ *  - the AES-GCM key + nonce derivation host-papp uses
+ *    (`blake2b(appId, 16)` / `blake2b("nonce", 32)`),
+ *  - the storage-key naming convention (`AllowanceKeys_<sessionId>`).
+ *
+ * Drift guards:
+ *  - `satisfies Codec<StoredAllowanceEntry>` catches type-shape drift at
+ *    build time.
+ *  - `allowance.interop.test.ts` round-trips an encoded entry through the
+ *    real host-papp `AllowanceService.getBulletinSigner` and asserts the
+ *    derived signer's pubkey matches — that catches byte-level drift at
+ *    test time.
+ *
+ * TODO: drop this mirror when host-papp's `AllowanceService` gains a
+ * cache-only check (e.g. `hasAllowance(sessionId, productId, resource)`)
+ * on its public surface. Until then we have to read the file ourselves.
+ *
+ * @module
+ */
+import { gcm } from "@noble/ciphers/aes.js";
+import { blake2b } from "@noble/hashes/blake2.js";
+import { fromHex, toHex } from "@polkadot-api/utils";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Bytes, type Codec, Enum, Struct, Vector, _void, str } from "scale-ts";
+
+import { sanitizeKey } from "./node-storage.js";
+
+/** Resource kinds host-papp allocates slot accounts for. */
+export type AllowanceResourceKind = "bulletin" | "statementStore";
+
+/** One entry in the persisted allowance list. */
+export type StoredAllowanceEntry = {
+    productId: string;
+    resource: { tag: AllowanceResourceKind; value: undefined };
+    slotAccountKey: Uint8Array;
+};
+
+const AllowanceResourceKindCodec = Enum({
+    bulletin: _void,
+    statementStore: _void,
+});
+
+const StoredAllowanceEntryCodec = Struct({
+    productId: str,
+    resource: AllowanceResourceKindCodec,
+    slotAccountKey: Bytes(),
+}) satisfies Codec<StoredAllowanceEntry>;
+
+const StoredAllowancesCodec = Vector(StoredAllowanceEntryCodec);
+
+/**
+ * AES-GCM key + nonce derivation host-papp uses for both the allowance
+ * repository and the user-secrets repository — same salt (appId) seeds both.
+ */
+function getAes(appId: string) {
+    const key = blake2b(new TextEncoder().encode(appId), { dkLen: 16 });
+    const nonce = blake2b(new TextEncoder().encode("nonce"), { dkLen: 32 });
+    return gcm(key, nonce);
+}
+
+/**
+ * Storage file path host-papp writes the allowance list to, derived from
+ * `appId` and `sessionId` via the same `sanitizeKey` rule the rest of the
+ * package uses.
+ */
+function allowanceFilePath(storageDir: string, appId: string, sessionId: string): string {
+    return join(storageDir, `${sanitizeKey(appId, `AllowanceKeys_${sessionId}`)}.json`);
+}
+
+/**
+ * Read and decrypt the allowance list for a session. Returns `[]` when the
+ * file is absent (the steady-state "never paired for this session" case);
+ * throws on decrypt or decode failure (a corrupted file is a real failure,
+ * not a "no allowance" signal — silently treating it as empty would mask
+ * a bug).
+ */
+export async function readStoredAllowances(
+    storageDir: string,
+    appId: string,
+    sessionId: string,
+): Promise<StoredAllowanceEntry[]> {
+    let hex: string;
+    try {
+        hex = await readFile(allowanceFilePath(storageDir, appId, sessionId), "utf-8");
+    } catch (err) {
+        // ENOENT is the only error we treat as "no entries".
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+            return [];
+        }
+        throw err;
+    }
+    const decrypted = getAes(appId).decrypt(fromHex(hex));
+    return StoredAllowancesCodec.dec(decrypted);
+}
+
+/**
+ * Encode + encrypt + write an allowance list to disk. Used by the interop
+ * test to pre-seed a cache entry without having to drive a wallet round-trip.
+ * Not exported from the package — internal to `*.interop.test.ts`.
+ */
+export async function writeStoredAllowances(
+    storageDir: string,
+    appId: string,
+    sessionId: string,
+    entries: StoredAllowanceEntry[],
+): Promise<void> {
+    const encoded = StoredAllowancesCodec.enc(entries);
+    const encrypted = toHex(getAes(appId).encrypt(encoded));
+    await writeFile(allowanceFilePath(storageDir, appId, sessionId), encrypted, "utf-8");
+}

--- a/product-sdk/packages/terminal/src/allowance.interop.test.ts
+++ b/product-sdk/packages/terminal/src/allowance.interop.test.ts
@@ -1,0 +1,269 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Interop test for the allowance convenience wrappers.
+ *
+ * Drives `getBulletinSigner` / `getStatementStoreProver` end-to-end through:
+ *   - our session id defaulting (`resolveSessionId`),
+ *   - host-papp's real `AllowanceService`,
+ *   - host-papp's real `AllowanceRepository` (decrypting + decoding a
+ *     synthesized cache entry on disk),
+ *   - host-papp's slot-account derivation (`deriveSlotAccountPublicKey`).
+ *
+ * A cache hit is the path we exercise here — we pre-write an encrypted
+ * `AllowanceKeys_<sessionId>.json` file using the same AES-GCM scheme
+ * host-papp uses for the user-secrets repository, so the allowance service
+ * finds a cached slot key and never reaches out to the (non-existent)
+ * paired wallet. That covers the steady-state CLI behaviour. Cache-miss
+ * + real wallet round-trip can only be exercised by a manual smoke test
+ * against a phone.
+ */
+import { gcm } from "@noble/ciphers/aes.js";
+import { blake2b } from "@noble/hashes/blake2.js";
+import { createPappAdapter, type UserSession } from "@novasamatech/host-papp";
+import {
+    deriveSlotAccountPublicKey,
+    ensureSubstrateSlotSr25519Ready,
+    type LazyClient,
+    type StatementStoreAdapter,
+} from "@novasamatech/statement-store";
+import { substrateSlotSecretFromSeedBytes } from "@novasamatech/substrate-slot-sr25519-wasm";
+import { toHex } from "@polkadot-api/utils";
+import { entropyToMiniSecret, mnemonicToEntropy } from "@polkadot-labs/hdkd-helpers";
+import { okAsync } from "neverthrow";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Bytes, Enum, Struct, Vector, _void, str } from "scale-ts";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { getBulletinSigner, getStatementStoreProver } from "./allowance.js";
+import { createNodeStorageAdapter, sanitizeKey } from "./node-storage.js";
+import { createTestSession } from "./testing.js";
+
+const APP_ID = "allowance-interop";
+const LOCAL_MNEMONIC = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+const REMOTE_MNEMONIC =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const PRODUCT_ID = "allowance-interop.dot";
+
+// Deterministic 64-byte slot account secret seed. The actual slot secret
+// is derived via `substrateSlotSecretFromSeedBytes` inside the test (which
+// requires the WASM to be initialised first). The official slot-WASM test
+// helper produces the canonical Substrate `Keypair::to_bytes()` form
+// (scalar || nonce) — an arbitrary Uint8Array(64) is rejected as "high-bit set".
+const SLOT_MNEMONIC = "legal winner thank year wave sausage worth useful legal winner thank yellow";
+const SLOT_SECRET_SEED = entropyToMiniSecret(mnemonicToEntropy(SLOT_MNEMONIC));
+
+// Mirror of host-papp's `AllowanceRepository` codec — vendored here for the
+// same reason `testing.ts` mirrors the session codec: the codec is internal
+// to host-papp and not exported. If host-papp changes the codec, this test
+// fails immediately rather than letting the change slip past CI.
+const AllowanceResourceKindCodec = Enum({
+    bulletin: _void,
+    statementStore: _void,
+});
+const StoredAllowanceEntryCodec = Struct({
+    productId: str,
+    resource: AllowanceResourceKindCodec,
+    slotAccountKey: Bytes(),
+});
+const StoredAllowancesCodec = Vector(StoredAllowanceEntryCodec);
+
+/**
+ * Mirror of host-papp's `AllowanceRepository` AES-GCM wrapper. Same key
+ * derivation as the user-secrets repository: blake2b(appId, 16) for the AES
+ * key, blake2b("nonce", 32) for the nonce. host-papp re-uses these for the
+ * allowance store so a single salt seeds both repositories on the same
+ * appId.
+ */
+function encryptAllowances(appId: string, plaintext: Uint8Array): string {
+    const key = blake2b(new TextEncoder().encode(appId), { dkLen: 16 });
+    const nonce = blake2b(new TextEncoder().encode("nonce"), { dkLen: 32 });
+    return toHex(gcm(key, nonce).encrypt(plaintext));
+}
+
+/**
+ * Pre-populate the allowance cache for a session so `adapter.allowance.*`
+ * hits the cache path instead of attempting a wire allocation. Mirrors what
+ * the SDK would have written on a previous run after the wallet allocated
+ * a slot.
+ */
+async function seedAllowanceCache({
+    storageDir,
+    appId,
+    sessionId,
+    productId,
+    resource,
+    slotAccountKey,
+}: {
+    storageDir: string;
+    appId: string;
+    sessionId: string;
+    productId: string;
+    resource: "bulletin" | "statementStore";
+    slotAccountKey: Uint8Array;
+}): Promise<void> {
+    const entries = [
+        {
+            productId,
+            resource: { tag: resource, value: undefined } as
+                | { tag: "bulletin"; value: undefined }
+                | { tag: "statementStore"; value: undefined },
+            slotAccountKey,
+        },
+    ];
+    const encoded = StoredAllowancesCodec.enc(entries);
+    const encrypted = encryptAllowances(appId, encoded);
+    // host-papp writes the allowance keys under `AllowanceKeys_<sessionId>`
+    // via the same `createKey` shape it uses for user secrets.
+    const fileName = `${sanitizeKey(appId, `AllowanceKeys_${sessionId}`)}.json`;
+    await writeFile(join(storageDir, fileName), encrypted, "utf-8");
+}
+
+// Shim adapters mirroring `testing.interop.test.ts` — none of these are
+// consulted on the cache-hit path, but `createTerminalAdapter` requires them
+// for construction.
+const neverCalled = () => {
+    throw new Error("test shim — should not be called");
+};
+const statementStoreShim: StatementStoreAdapter = {
+    queryStatements: () => okAsync([]),
+    subscribeStatements: () => () => {},
+    submitStatement: () => okAsync(undefined),
+};
+const lazyClientShim: LazyClient = {
+    getClient: neverCalled,
+    getRequestFn: () => neverCalled,
+    getSubscribeFn: () => neverCalled,
+    disconnect: () => {},
+} as unknown as LazyClient;
+
+function waitForFirstSession(
+    adapter: ReturnType<typeof createPappAdapter>,
+    timeoutMs = 5000,
+): Promise<UserSession> {
+    return new Promise((resolve, reject) => {
+        const unsub = adapter.sessions.sessions.subscribe((sessions: UserSession[]) => {
+            if (sessions.length > 0) {
+                unsub();
+                resolve(sessions[0]!);
+            }
+        });
+        setTimeout(() => {
+            unsub();
+            reject(new Error(`No session emitted within ${timeoutMs}ms`));
+        }, timeoutMs);
+    });
+}
+
+describe("allowance helpers — interop with the real host-papp AllowanceService", () => {
+    let storageDir: string;
+    let fakeSlotSecret: Uint8Array;
+
+    beforeEach(async () => {
+        storageDir = await mkdtemp(join(tmpdir(), "allowance-interop-"));
+        // Slot-account derivation goes through the substrate-slot-sr25519
+        // WASM module — make sure it's initialised before deriving the slot
+        // secret (and any signer derivation in the tests below).
+        await ensureSubstrateSlotSr25519Ready();
+        fakeSlotSecret = substrateSlotSecretFromSeedBytes(SLOT_SECRET_SEED);
+    });
+
+    afterEach(async () => {
+        await rm(storageDir, { recursive: true, force: true });
+    });
+
+    test("getBulletinSigner returns a PolkadotSigner whose pubkey matches the cached slot account", async () => {
+        const { sessionId } = await createTestSession({
+            appId: APP_ID,
+            storageDir,
+            localMnemonic: LOCAL_MNEMONIC,
+            remoteMnemonic: REMOTE_MNEMONIC,
+        });
+
+        await seedAllowanceCache({
+            storageDir,
+            appId: APP_ID,
+            sessionId,
+            productId: PRODUCT_ID,
+            resource: "bulletin",
+            slotAccountKey: fakeSlotSecret,
+        });
+
+        // `createPappAdapter` directly — same shape `createTerminalAdapter`
+        // wires up, but with test shims for the network-dependent pieces so
+        // the cache-hit path doesn't try to reach a real RPC or wallet.
+        const pappAdapter = createPappAdapter({
+            appId: APP_ID,
+            adapters: {
+                storage: createNodeStorageAdapter(APP_ID, storageDir),
+                statementStore: statementStoreShim,
+                lazyClient: lazyClientShim,
+            },
+        });
+
+        // Wait for the persisted session to surface so adapter.sessions.read()
+        // is non-empty when the convenience defaults its sessionId.
+        await waitForFirstSession(pappAdapter);
+
+        // Hand the pappAdapter to the convenience as a TerminalAdapter
+        // (structurally compatible; the convenience only reads
+        // `sessions.sessions.read()` and `allowance`).
+        const terminalAdapter = pappAdapter as unknown as Parameters<typeof getBulletinSigner>[0];
+        const signer = await getBulletinSigner(terminalAdapter, PRODUCT_ID);
+
+        // The convenience defaulted sessionId to the only paired session,
+        // host-papp's AllowanceService hit the cache, decoded our seeded
+        // entry, derived a signer over the slot key. publicKey on the
+        // returned PolkadotSigner must equal the slot-account public key
+        // derived from our fakeSlotSecret — proves the cache reached
+        // the signer without re-deriving from a wallet round-trip.
+        const expectedPubKey = deriveSlotAccountPublicKey(fakeSlotSecret);
+        expect(signer.publicKey).toEqual(expectedPubKey);
+
+        pappAdapter.sessions.dispose();
+    });
+
+    test("getStatementStoreProver returns a prover for the cached statementStore slot", async () => {
+        const { sessionId } = await createTestSession({
+            appId: APP_ID,
+            storageDir,
+            localMnemonic: LOCAL_MNEMONIC,
+            remoteMnemonic: REMOTE_MNEMONIC,
+        });
+
+        await seedAllowanceCache({
+            storageDir,
+            appId: APP_ID,
+            sessionId,
+            productId: PRODUCT_ID,
+            resource: "statementStore",
+            slotAccountKey: fakeSlotSecret,
+        });
+
+        const pappAdapter = createPappAdapter({
+            appId: APP_ID,
+            adapters: {
+                storage: createNodeStorageAdapter(APP_ID, storageDir),
+                statementStore: statementStoreShim,
+                lazyClient: lazyClientShim,
+            },
+        });
+
+        await waitForFirstSession(pappAdapter);
+        const terminalAdapter = pappAdapter as unknown as Parameters<
+            typeof getStatementStoreProver
+        >[0];
+        const prover = await getStatementStoreProver(terminalAdapter, PRODUCT_ID);
+
+        // StatementProver's public surface is `generateMessageProof` /
+        // `verifyMessageProof`. Asserting both are callable proves the
+        // wrapper unwrapped a real prover from the underlying ResultAsync
+        // (not a stub or shape mismatch).
+        expect(typeof prover.generateMessageProof).toBe("function");
+        expect(typeof prover.verifyMessageProof).toBe("function");
+
+        pappAdapter.sessions.dispose();
+    });
+});

--- a/product-sdk/packages/terminal/src/allowance.interop.test.ts
+++ b/product-sdk/packages/terminal/src/allowance.interop.test.ts
@@ -18,8 +18,6 @@
  * + real wallet round-trip can only be exercised by a manual smoke test
  * against a phone.
  */
-import { gcm } from "@noble/ciphers/aes.js";
-import { blake2b } from "@noble/hashes/blake2.js";
 import { createPappAdapter, type UserSession } from "@novasamatech/host-papp";
 import {
     deriveSlotAccountPublicKey,
@@ -28,17 +26,21 @@ import {
     type StatementStoreAdapter,
 } from "@novasamatech/statement-store";
 import { substrateSlotSecretFromSeedBytes } from "@novasamatech/substrate-slot-sr25519-wasm";
-import { toHex } from "@polkadot-api/utils";
 import { entropyToMiniSecret, mnemonicToEntropy } from "@polkadot-labs/hdkd-helpers";
 import { okAsync } from "neverthrow";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Bytes, Enum, Struct, Vector, _void, str } from "scale-ts";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { getBulletinSigner, getStatementStoreProver } from "./allowance.js";
-import { createNodeStorageAdapter, sanitizeKey } from "./node-storage.js";
+import {
+    getBulletinSigner,
+    getStatementStoreProver,
+    hasBulletinAllowance,
+    hasStatementStoreAllowance,
+} from "./allowance.js";
+import { type AllowanceResourceKind, writeStoredAllowances } from "./allowance-cache.js";
+import { createNodeStorageAdapter } from "./node-storage.js";
 import { createTestSession } from "./testing.js";
 
 const APP_ID = "allowance-interop";
@@ -55,39 +57,10 @@ const PRODUCT_ID = "allowance-interop.dot";
 const SLOT_MNEMONIC = "legal winner thank year wave sausage worth useful legal winner thank yellow";
 const SLOT_SECRET_SEED = entropyToMiniSecret(mnemonicToEntropy(SLOT_MNEMONIC));
 
-// Mirror of host-papp's `AllowanceRepository` codec — vendored here for the
-// same reason `testing.ts` mirrors the session codec: the codec is internal
-// to host-papp and not exported. If host-papp changes the codec, this test
-// fails immediately rather than letting the change slip past CI.
-const AllowanceResourceKindCodec = Enum({
-    bulletin: _void,
-    statementStore: _void,
-});
-const StoredAllowanceEntryCodec = Struct({
-    productId: str,
-    resource: AllowanceResourceKindCodec,
-    slotAccountKey: Bytes(),
-});
-const StoredAllowancesCodec = Vector(StoredAllowanceEntryCodec);
-
-/**
- * Mirror of host-papp's `AllowanceRepository` AES-GCM wrapper. Same key
- * derivation as the user-secrets repository: blake2b(appId, 16) for the AES
- * key, blake2b("nonce", 32) for the nonce. host-papp re-uses these for the
- * allowance store so a single salt seeds both repositories on the same
- * appId.
- */
-function encryptAllowances(appId: string, plaintext: Uint8Array): string {
-    const key = blake2b(new TextEncoder().encode(appId), { dkLen: 16 });
-    const nonce = blake2b(new TextEncoder().encode("nonce"), { dkLen: 32 });
-    return toHex(gcm(key, nonce).encrypt(plaintext));
-}
-
 /**
  * Pre-populate the allowance cache for a session so `adapter.allowance.*`
- * hits the cache path instead of attempting a wire allocation. Mirrors what
- * the SDK would have written on a previous run after the wallet allocated
- * a slot.
+ * hits the cache path instead of attempting a wire allocation. Thin wrapper
+ * over the shared `writeStoredAllowances` helper from `allowance-cache.ts`.
  */
 async function seedAllowanceCache({
     storageDir,
@@ -101,24 +74,12 @@ async function seedAllowanceCache({
     appId: string;
     sessionId: string;
     productId: string;
-    resource: "bulletin" | "statementStore";
+    resource: AllowanceResourceKind;
     slotAccountKey: Uint8Array;
 }): Promise<void> {
-    const entries = [
-        {
-            productId,
-            resource: { tag: resource, value: undefined } as
-                | { tag: "bulletin"; value: undefined }
-                | { tag: "statementStore"; value: undefined },
-            slotAccountKey,
-        },
-    ];
-    const encoded = StoredAllowancesCodec.enc(entries);
-    const encrypted = encryptAllowances(appId, encoded);
-    // host-papp writes the allowance keys under `AllowanceKeys_<sessionId>`
-    // via the same `createKey` shape it uses for user secrets.
-    const fileName = `${sanitizeKey(appId, `AllowanceKeys_${sessionId}`)}.json`;
-    await writeFile(join(storageDir, fileName), encrypted, "utf-8");
+    await writeStoredAllowances(storageDir, appId, sessionId, [
+        { productId, resource: { tag: resource, value: undefined }, slotAccountKey },
+    ]);
 }
 
 // Shim adapters mirroring `testing.interop.test.ts` — none of these are
@@ -263,6 +224,216 @@ describe("allowance helpers — interop with the real host-papp AllowanceService
         // (not a stub or shape mismatch).
         expect(typeof prover.generateMessageProof).toBe("function");
         expect(typeof prover.verifyMessageProof).toBe("function");
+
+        pappAdapter.sessions.dispose();
+    });
+
+    // ── Cache-only probes ──────────────────────────────────────────────────
+    //
+    // hasBulletinAllowance / hasStatementStoreAllowance read host-papp's
+    // encrypted AllowanceKeys file directly via the codec mirror in
+    // `allowance-cache.ts`. The interop test asserts the mirror's decode
+    // round-trips against a cache entry the SDK would have written: we use
+    // the shared `writeStoredAllowances` (encode + AES-GCM encrypt + write)
+    // to seed, then assert `has*Allowance` reads it back as `true`.
+    //
+    // Because the production code reads `adapter.appId` and `adapter.storageDir`
+    // (fields on `TerminalAdapter` but not `PappAdapter`), the cast object
+    // here augments the bare `PappAdapter` with both. The other adapter
+    // fields aren't touched by these helpers.
+
+    test("hasBulletinAllowance returns true when a slot key for the tuple is cached", async () => {
+        const { sessionId } = await createTestSession({
+            appId: APP_ID,
+            storageDir,
+            localMnemonic: LOCAL_MNEMONIC,
+            remoteMnemonic: REMOTE_MNEMONIC,
+        });
+        await seedAllowanceCache({
+            storageDir,
+            appId: APP_ID,
+            sessionId,
+            productId: PRODUCT_ID,
+            resource: "bulletin",
+            slotAccountKey: fakeSlotSecret,
+        });
+
+        const pappAdapter = createPappAdapter({
+            appId: APP_ID,
+            adapters: {
+                storage: createNodeStorageAdapter(APP_ID, storageDir),
+                statementStore: statementStoreShim,
+                lazyClient: lazyClientShim,
+            },
+        });
+        await waitForFirstSession(pappAdapter);
+        const terminalAdapter = Object.assign(pappAdapter, {
+            appId: APP_ID,
+            storageDir,
+        }) as unknown as Parameters<typeof hasBulletinAllowance>[0];
+
+        expect(await hasBulletinAllowance(terminalAdapter, PRODUCT_ID)).toBe(true);
+
+        pappAdapter.sessions.dispose();
+    });
+
+    test("hasBulletinAllowance returns false when no slot key is cached", async () => {
+        await createTestSession({
+            appId: APP_ID,
+            storageDir,
+            localMnemonic: LOCAL_MNEMONIC,
+            remoteMnemonic: REMOTE_MNEMONIC,
+        });
+        // Critically: no seedAllowanceCache call. The session exists but no
+        // allowance has been allocated for it yet.
+
+        const pappAdapter = createPappAdapter({
+            appId: APP_ID,
+            adapters: {
+                storage: createNodeStorageAdapter(APP_ID, storageDir),
+                statementStore: statementStoreShim,
+                lazyClient: lazyClientShim,
+            },
+        });
+        await waitForFirstSession(pappAdapter);
+        const terminalAdapter = Object.assign(pappAdapter, {
+            appId: APP_ID,
+            storageDir,
+        }) as unknown as Parameters<typeof hasBulletinAllowance>[0];
+
+        expect(await hasBulletinAllowance(terminalAdapter, PRODUCT_ID)).toBe(false);
+
+        pappAdapter.sessions.dispose();
+    });
+
+    test("hasBulletinAllowance returns false when the cached entry is for a different productId", async () => {
+        const { sessionId } = await createTestSession({
+            appId: APP_ID,
+            storageDir,
+            localMnemonic: LOCAL_MNEMONIC,
+            remoteMnemonic: REMOTE_MNEMONIC,
+        });
+        // Seed an entry for a DIFFERENT product — we're asserting `hasAllowance`
+        // matches on productId, not just any entry under the session.
+        await seedAllowanceCache({
+            storageDir,
+            appId: APP_ID,
+            sessionId,
+            productId: "some-other.dot",
+            resource: "bulletin",
+            slotAccountKey: fakeSlotSecret,
+        });
+
+        const pappAdapter = createPappAdapter({
+            appId: APP_ID,
+            adapters: {
+                storage: createNodeStorageAdapter(APP_ID, storageDir),
+                statementStore: statementStoreShim,
+                lazyClient: lazyClientShim,
+            },
+        });
+        await waitForFirstSession(pappAdapter);
+        const terminalAdapter = Object.assign(pappAdapter, {
+            appId: APP_ID,
+            storageDir,
+        }) as unknown as Parameters<typeof hasBulletinAllowance>[0];
+
+        expect(await hasBulletinAllowance(terminalAdapter, PRODUCT_ID)).toBe(false);
+
+        pappAdapter.sessions.dispose();
+    });
+
+    test("hasBulletinAllowance returns true after getBulletinSigner has populated the cache (login-readiness flow)", async () => {
+        // End-to-end-style: the exact sequence a CLI login health check
+        // would hit on a second run. First call (`getBulletinSigner`)
+        // pulls a slot key through host-papp's real AllowanceService and
+        // writes the encrypted `AllowanceKeys_<sessionId>.json` file.
+        // Second call (`hasBulletinAllowance`) reads that same file via
+        // the codec mirror in `allowance-cache.ts` and must report `true`
+        // without prompting a wallet. Catches drift between what
+        // host-papp writes and what our probe reads — the one place
+        // byte-level disagreement matters for the cache-only API.
+        const { sessionId } = await createTestSession({
+            appId: APP_ID,
+            storageDir,
+            localMnemonic: LOCAL_MNEMONIC,
+            remoteMnemonic: REMOTE_MNEMONIC,
+        });
+        await seedAllowanceCache({
+            storageDir,
+            appId: APP_ID,
+            sessionId,
+            productId: PRODUCT_ID,
+            resource: "bulletin",
+            slotAccountKey: fakeSlotSecret,
+        });
+
+        const pappAdapter = createPappAdapter({
+            appId: APP_ID,
+            adapters: {
+                storage: createNodeStorageAdapter(APP_ID, storageDir),
+                statementStore: statementStoreShim,
+                lazyClient: lazyClientShim,
+            },
+        });
+        await waitForFirstSession(pappAdapter);
+        const terminalAdapter = Object.assign(pappAdapter, {
+            appId: APP_ID,
+            storageDir,
+        }) as unknown as Parameters<typeof hasBulletinAllowance>[0];
+
+        // Step 1 — fetch the signer. This is the prompt-allowed path; on a
+        // cache hit (which we have, via seedAllowanceCache) host-papp re-
+        // reads + re-writes the same file. Asserting the pubkey matches
+        // confirms the signer actually came from the cached slot key.
+        const signer = await getBulletinSigner(terminalAdapter, PRODUCT_ID);
+        expect(signer.publicKey).toEqual(deriveSlotAccountPublicKey(fakeSlotSecret));
+
+        // Step 2 — the cache-only probe must agree. If the codec mirror in
+        // `allowance-cache.ts` ever drifts from what host-papp writes,
+        // this assertion flips to `false` and we catch it here rather
+        // than in production.
+        expect(await hasBulletinAllowance(terminalAdapter, PRODUCT_ID)).toBe(true);
+
+        pappAdapter.sessions.dispose();
+    });
+
+    test("hasStatementStoreAllowance distinguishes resource kinds for the same productId", async () => {
+        const { sessionId } = await createTestSession({
+            appId: APP_ID,
+            storageDir,
+            localMnemonic: LOCAL_MNEMONIC,
+            remoteMnemonic: REMOTE_MNEMONIC,
+        });
+        // Seed a bulletin entry, then query for statementStore — same product,
+        // different resource. The check must distinguish them.
+        await seedAllowanceCache({
+            storageDir,
+            appId: APP_ID,
+            sessionId,
+            productId: PRODUCT_ID,
+            resource: "bulletin",
+            slotAccountKey: fakeSlotSecret,
+        });
+
+        const pappAdapter = createPappAdapter({
+            appId: APP_ID,
+            adapters: {
+                storage: createNodeStorageAdapter(APP_ID, storageDir),
+                statementStore: statementStoreShim,
+                lazyClient: lazyClientShim,
+            },
+        });
+        await waitForFirstSession(pappAdapter);
+        const terminalAdapter = Object.assign(pappAdapter, {
+            appId: APP_ID,
+            storageDir,
+        }) as unknown as Parameters<typeof hasStatementStoreAllowance>[0];
+
+        // Bulletin: present.
+        expect(await hasBulletinAllowance(terminalAdapter, PRODUCT_ID)).toBe(true);
+        // StatementStore: not present.
+        expect(await hasStatementStoreAllowance(terminalAdapter, PRODUCT_ID)).toBe(false);
 
         pappAdapter.sessions.dispose();
     });

--- a/product-sdk/packages/terminal/src/allowance.ts
+++ b/product-sdk/packages/terminal/src/allowance.ts
@@ -1,0 +1,227 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Convenience wrappers around `adapter.allowance` for CLI consumers.
+ *
+ * The host-papp `AllowanceService` (exposed as `adapter.allowance`) returns
+ * neverthrow `ResultAsync` values and requires the caller to pass a
+ * `sessionId` explicitly. CLIs almost always run with one paired session at
+ * a time, so passing `sessionId` is redundant and the neverthrow envelope
+ * doesn't fit the rest of `@parity/product-sdk-terminal`'s throwy/async
+ * idiom (`createSessionSigner`, `requestResourceAllocation`).
+ *
+ * These helpers:
+ *  - default the `sessionId` to the single paired session when there's
+ *    exactly one (the common CLI case);
+ *  - unwrap the `ResultAsync` into a `Promise<T>` that throws an
+ *    {@link AllowanceError} on failure;
+ *  - leave the underlying `adapter.allowance` intact for callers who want
+ *    explicit multi-session handling or neverthrow's `.match` ergonomics.
+ *
+ * @module
+ */
+import { AllowanceError } from "@novasamatech/host-papp";
+import type { StatementProver } from "@novasamatech/statement-store";
+import type { PolkadotSigner } from "polkadot-api";
+
+import type { TerminalAdapter } from "./adapter.js";
+
+/**
+ * Pick the session id to use for an allowance request, defaulting to the
+ * single paired session when no explicit id is supplied.
+ *
+ * @throws {AllowanceError} `NoSession` when zero sessions or `>1` sessions
+ *   are paired without an explicit id — both cases are ambiguous and the
+ *   caller should resolve them before calling the convenience.
+ */
+function resolveSessionId(adapter: TerminalAdapter, sessionId?: string): string {
+    if (sessionId) return sessionId;
+    const sessions = adapter.sessions.sessions.read();
+    if (sessions.length === 0) {
+        // Same error class host-papp emits internally so catch-by-instanceof
+        // handlers behave identically for both paths.
+        throw new AllowanceError("NoSession", "No paired session — pair a phone first.");
+    }
+    if (sessions.length > 1) {
+        throw new AllowanceError(
+            "NoSession",
+            `Multiple paired sessions (${sessions.length}) — pass an explicit sessionId.`,
+        );
+    }
+    return sessions[0]!.id;
+}
+
+/**
+ * Get a `PolkadotSigner` for a Bulletin allowance slot.
+ *
+ * Allocates an allowance slot via the paired wallet (or returns the cached
+ * one), derives the slot-account keypair, and returns a `PolkadotSigner`
+ * that signs Bulletin extrinsics with it. Replaces the manual
+ * `requestResourceAllocation` + `createSlotAccountSigner` two-step for the
+ * common case.
+ *
+ * @param adapter Terminal adapter.
+ * @param productId The product id the slot is allocated under. Passed to the
+ *   host as the calling product id in the allowance request.
+ * @param sessionId Paired session to allocate against. Defaults to the only
+ *   paired session; throws `AllowanceError('NoSession')` when zero or more
+ *   than one sessions are paired and no explicit id is supplied.
+ * @throws {AllowanceError} On rejection, missing session, host-side failure,
+ *   or unexpected response shape.
+ *
+ * @example
+ * ```ts
+ * import { createTerminalAdapter, getBulletinSigner } from "@parity/product-sdk-terminal";
+ *
+ * const adapter = createTerminalAdapter({ appId: "my-cli" });
+ * // ... QR pair, wait for session ...
+ * const signer = await getBulletinSigner(adapter, "my-cli.dot");
+ * await client.bulletin.tx.TransactionStorage.store({ data }).signAndSubmit(signer);
+ * ```
+ */
+export async function getBulletinSigner(
+    adapter: TerminalAdapter,
+    productId: string,
+    sessionId?: string,
+): Promise<PolkadotSigner> {
+    const resolvedSessionId = resolveSessionId(adapter, sessionId);
+    return adapter.allowance.getBulletinSigner(resolvedSessionId, productId).match(
+        (signer) => signer,
+        (err) => {
+            throw err;
+        },
+    );
+}
+
+/**
+ * Get a `StatementProver` for a statement-store allowance slot.
+ *
+ * Allocates an allowance slot via the paired wallet (or returns the cached
+ * one) and returns the upstream `StatementProver` for the slot. Use when
+ * publishing statements through `@novasamatech/statement-store` without
+ * holding a long-lived key yourself.
+ *
+ * @param adapter Terminal adapter.
+ * @param productId The product id the slot is allocated under.
+ * @param sessionId Paired session to allocate against. Defaults to the only
+ *   paired session; throws `AllowanceError('NoSession')` when zero or more
+ *   than one sessions are paired and no explicit id is supplied.
+ * @throws {AllowanceError} On rejection, missing session, host-side failure,
+ *   or unexpected response shape.
+ */
+export async function getStatementStoreProver(
+    adapter: TerminalAdapter,
+    productId: string,
+    sessionId?: string,
+): Promise<StatementProver> {
+    const resolvedSessionId = resolveSessionId(adapter, sessionId);
+    return adapter.allowance.getStatementStoreProver(resolvedSessionId, productId).match(
+        (prover) => prover,
+        (err) => {
+            throw err;
+        },
+    );
+}
+
+// ── vitest in-source tests ─────────────────────────────────────────────────
+if (import.meta.vitest) {
+    const { describe, test, expect, vi } = import.meta.vitest;
+    const { ok, err } = await import("neverthrow");
+
+    type FakeSession = { id: string };
+
+    function makeAdapter(opts: {
+        sessions: FakeSession[];
+        getBulletinSigner?: ReturnType<typeof vi.fn>;
+        getStatementStoreProver?: ReturnType<typeof vi.fn>;
+    }): TerminalAdapter {
+        return {
+            sessions: {
+                sessions: {
+                    read: () => opts.sessions,
+                },
+            },
+            allowance: {
+                getBulletinSigner: opts.getBulletinSigner ?? vi.fn(() => ok({})),
+                getStatementStoreProver: opts.getStatementStoreProver ?? vi.fn(() => ok({})),
+            },
+            // The convenience never touches the rest of the adapter; leave it unstubbed.
+        } as unknown as TerminalAdapter;
+    }
+
+    describe("getBulletinSigner — sessionId defaulting", () => {
+        test("uses the only paired session when sessionId is omitted", async () => {
+            const fakeSigner = { _tag: "signer" };
+            const getBulletinSignerFn = vi.fn(() => ok(fakeSigner));
+            const adapter = makeAdapter({
+                sessions: [{ id: "sess-only" }],
+                getBulletinSigner: getBulletinSignerFn,
+            });
+
+            const result = await getBulletinSigner(adapter, "my-app.dot");
+            expect(result).toBe(fakeSigner);
+            expect(getBulletinSignerFn).toHaveBeenCalledWith("sess-only", "my-app.dot");
+        });
+
+        test("uses the explicit sessionId when supplied", async () => {
+            const fakeSigner = { _tag: "signer" };
+            const getBulletinSignerFn = vi.fn(() => ok(fakeSigner));
+            const adapter = makeAdapter({
+                sessions: [{ id: "sess-a" }, { id: "sess-b" }],
+                getBulletinSigner: getBulletinSignerFn,
+            });
+
+            await getBulletinSigner(adapter, "my-app.dot", "sess-b");
+            expect(getBulletinSignerFn).toHaveBeenCalledWith("sess-b", "my-app.dot");
+        });
+
+        test("throws AllowanceError('NoSession') when zero sessions and no id", async () => {
+            const adapter = makeAdapter({ sessions: [] });
+            await expect(getBulletinSigner(adapter, "my-app.dot")).rejects.toBeInstanceOf(
+                AllowanceError,
+            );
+            await expect(getBulletinSigner(adapter, "my-app.dot")).rejects.toMatchObject({
+                reason: "NoSession",
+            });
+        });
+
+        test("throws AllowanceError('NoSession') when multiple sessions and no id", async () => {
+            const adapter = makeAdapter({ sessions: [{ id: "a" }, { id: "b" }] });
+            await expect(getBulletinSigner(adapter, "my-app.dot")).rejects.toBeInstanceOf(
+                AllowanceError,
+            );
+            await expect(getBulletinSigner(adapter, "my-app.dot")).rejects.toMatchObject({
+                reason: "NoSession",
+            });
+        });
+    });
+
+    describe("getBulletinSigner — error unwrapping", () => {
+        test("rethrows the AllowanceError from the underlying service as a thrown exception", async () => {
+            const underlyingErr = new AllowanceError("Rejected", "user said no");
+            const adapter = makeAdapter({
+                sessions: [{ id: "s" }],
+                getBulletinSigner: vi.fn(() => err(underlyingErr)),
+            });
+            // The wrapper rethrows the original error instance — handlers
+            // catching by `instanceof AllowanceError` see the same object the
+            // underlying service produced.
+            await expect(getBulletinSigner(adapter, "p")).rejects.toBe(underlyingErr);
+        });
+    });
+
+    describe("getStatementStoreProver — same defaulting", () => {
+        test("uses the only paired session when sessionId is omitted", async () => {
+            const fakeProver = { _tag: "prover" };
+            const getStatementStoreProverFn = vi.fn(() => ok(fakeProver));
+            const adapter = makeAdapter({
+                sessions: [{ id: "sess-only" }],
+                getStatementStoreProver: getStatementStoreProverFn,
+            });
+
+            const result = await getStatementStoreProver(adapter, "my-app.dot");
+            expect(result).toBe(fakeProver);
+            expect(getStatementStoreProverFn).toHaveBeenCalledWith("sess-only", "my-app.dot");
+        });
+    });
+}

--- a/product-sdk/packages/terminal/src/allowance.ts
+++ b/product-sdk/packages/terminal/src/allowance.ts
@@ -25,6 +25,7 @@ import type { StatementProver } from "@novasamatech/statement-store";
 import type { PolkadotSigner } from "polkadot-api";
 
 import type { TerminalAdapter } from "./adapter.js";
+import { type AllowanceResourceKind, readStoredAllowances } from "./allowance-cache.js";
 
 /**
  * Pick the session id to use for an allowance request, defaulting to the
@@ -121,6 +122,89 @@ export async function getStatementStoreProver(
             throw err;
         },
     );
+}
+
+/**
+ * Cache-only probe: read host-papp's encrypted on-disk allowance list and
+ * resolve to whether an entry exists for `(sessionId, productId, resource)`.
+ *
+ * Never invokes `requestResourceAllocation`, so this is safe to call from
+ * paths that must not prompt the paired wallet (e.g. login health checks).
+ * Resolves `false` for: file absent, file present with no entry for the
+ * tuple. Rejects only on decrypt / decode failures — a corrupted cache
+ * file is a real failure that should not silently degrade into "no
+ * allowance."
+ *
+ * Reads the file at `<storageDir>/<appId>_AllowanceKeys_<sessionId>.json`
+ * — same path host-papp writes to from its `AllowanceRepository`. The
+ * decode is via a vendored mirror of host-papp's internal codec; see
+ * `allowance-cache.ts` for drift-detection guards.
+ */
+async function hasAllowanceForResource(
+    adapter: TerminalAdapter,
+    productId: string,
+    resource: AllowanceResourceKind,
+    sessionId?: string,
+): Promise<boolean> {
+    const resolvedSessionId = resolveSessionId(adapter, sessionId);
+    if (adapter.storageDir === undefined) {
+        // The on-disk cache only exists when the adapter knows where its files
+        // live. Without an explicit `storageDir` the production host-papp
+        // backend may write through a non-disk storage adapter that this
+        // helper can't read; we conservatively answer false so callers don't
+        // skip pairing on a missed cache.
+        return false;
+    }
+    const entries = await readStoredAllowances(
+        adapter.storageDir,
+        adapter.appId,
+        resolvedSessionId,
+    );
+    return entries.some(
+        (entry) => entry.productId === productId && entry.resource.tag === resource,
+    );
+}
+
+/**
+ * Cache-only probe for a Bulletin allowance slot. Resolves `true` when a
+ * slot key for `(sessionId, productId, bulletin)` is already cached on
+ * disk; `false` when it is not. Never prompts the paired wallet.
+ *
+ * Pair with {@link getBulletinSigner} for the "check first, fetch only
+ * if needed" flow:
+ *
+ * @example
+ * ```ts
+ * if (await hasBulletinAllowance(adapter, "my-cli.dot")) {
+ *     // happy path — fetch the signer without risking a wallet prompt
+ *     const signer = await getBulletinSigner(adapter, "my-cli.dot");
+ * } else {
+ *     // tell the user a wallet prompt will fire, then call getBulletinSigner
+ * }
+ * ```
+ */
+export async function hasBulletinAllowance(
+    adapter: TerminalAdapter,
+    productId: string,
+    sessionId?: string,
+): Promise<boolean> {
+    return hasAllowanceForResource(adapter, productId, "bulletin", sessionId);
+}
+
+/**
+ * Cache-only probe for a Statement Store allowance slot. Resolves `true`
+ * when a slot key for `(sessionId, productId, statementStore)` is already
+ * cached on disk; `false` when it is not. Never prompts the paired wallet.
+ *
+ * Pair with {@link getStatementStoreProver} for the "check first, fetch
+ * only if needed" flow.
+ */
+export async function hasStatementStoreAllowance(
+    adapter: TerminalAdapter,
+    productId: string,
+    sessionId?: string,
+): Promise<boolean> {
+    return hasAllowanceForResource(adapter, productId, "statementStore", sessionId);
 }
 
 // ── vitest in-source tests ─────────────────────────────────────────────────
@@ -222,6 +306,42 @@ if (import.meta.vitest) {
             const result = await getStatementStoreProver(adapter, "my-app.dot");
             expect(result).toBe(fakeProver);
             expect(getStatementStoreProverFn).toHaveBeenCalledWith("sess-only", "my-app.dot");
+        });
+    });
+
+    describe("has*Allowance — sessionId defaulting + storageDir fallback", () => {
+        // Cache-hit / cache-miss against real disk + the host-papp codec are
+        // covered by `allowance.interop.test.ts`. These unit tests cover the
+        // branches that don't reach the filesystem.
+
+        test("hasBulletinAllowance throws AllowanceError('NoSession') when zero sessions and no id", async () => {
+            const adapter = makeAdapter({ sessions: [] });
+            await expect(hasBulletinAllowance(adapter, "p")).rejects.toBeInstanceOf(AllowanceError);
+            await expect(hasBulletinAllowance(adapter, "p")).rejects.toMatchObject({
+                reason: "NoSession",
+            });
+        });
+
+        test("hasBulletinAllowance returns false (conservative) when storageDir is undefined", async () => {
+            // Production: a TerminalAdapter without an explicit storageDir
+            // may be backed by a non-disk StorageAdapter that this helper
+            // can't read. Returning false avoids the trap of "we report
+            // 'no allowance cached' confidently when we just couldn't read."
+            const adapter = makeAdapter({ sessions: [{ id: "sess-only" }] });
+            // Mock has no storageDir field — the helper should short-circuit.
+            expect(await hasBulletinAllowance(adapter, "p")).toBe(false);
+        });
+
+        test("hasStatementStoreAllowance throws AllowanceError('NoSession') when zero sessions and no id", async () => {
+            const adapter = makeAdapter({ sessions: [] });
+            await expect(hasStatementStoreAllowance(adapter, "p")).rejects.toBeInstanceOf(
+                AllowanceError,
+            );
+        });
+
+        test("hasStatementStoreAllowance returns false (conservative) when storageDir is undefined", async () => {
+            const adapter = makeAdapter({ sessions: [{ id: "sess-only" }] });
+            expect(await hasStatementStoreAllowance(adapter, "p")).toBe(false);
         });
     });
 }

--- a/product-sdk/packages/terminal/src/allowance.ts
+++ b/product-sdk/packages/terminal/src/allowance.ts
@@ -307,6 +307,49 @@ if (import.meta.vitest) {
             expect(result).toBe(fakeProver);
             expect(getStatementStoreProverFn).toHaveBeenCalledWith("sess-only", "my-app.dot");
         });
+
+        test("uses the explicit sessionId when supplied", async () => {
+            const fakeProver = { _tag: "prover" };
+            const getStatementStoreProverFn = vi.fn(() => ok(fakeProver));
+            const adapter = makeAdapter({
+                sessions: [{ id: "sess-a" }, { id: "sess-b" }],
+                getStatementStoreProver: getStatementStoreProverFn,
+            });
+
+            await getStatementStoreProver(adapter, "my-app.dot", "sess-b");
+            expect(getStatementStoreProverFn).toHaveBeenCalledWith("sess-b", "my-app.dot");
+        });
+
+        test("throws AllowanceError('NoSession') when zero sessions and no id", async () => {
+            const adapter = makeAdapter({ sessions: [] });
+            await expect(getStatementStoreProver(adapter, "my-app.dot")).rejects.toBeInstanceOf(
+                AllowanceError,
+            );
+            await expect(getStatementStoreProver(adapter, "my-app.dot")).rejects.toMatchObject({
+                reason: "NoSession",
+            });
+        });
+
+        test("throws AllowanceError('NoSession') when multiple sessions and no id", async () => {
+            const adapter = makeAdapter({ sessions: [{ id: "a" }, { id: "b" }] });
+            await expect(getStatementStoreProver(adapter, "my-app.dot")).rejects.toBeInstanceOf(
+                AllowanceError,
+            );
+            await expect(getStatementStoreProver(adapter, "my-app.dot")).rejects.toMatchObject({
+                reason: "NoSession",
+            });
+        });
+    });
+
+    describe("getStatementStoreProver — error unwrapping", () => {
+        test("rethrows the AllowanceError from the underlying service as a thrown exception", async () => {
+            const underlyingErr = new AllowanceError("Rejected", "user said no");
+            const adapter = makeAdapter({
+                sessions: [{ id: "s" }],
+                getStatementStoreProver: vi.fn(() => err(underlyingErr)),
+            });
+            await expect(getStatementStoreProver(adapter, "p")).rejects.toBe(underlyingErr);
+        });
     });
 
     describe("has*Allowance — sessionId defaulting + storageDir fallback", () => {

--- a/product-sdk/packages/terminal/src/index.ts
+++ b/product-sdk/packages/terminal/src/index.ts
@@ -12,6 +12,14 @@ export type { TerminalAdapterOptions, TerminalAdapter } from "./adapter.js";
 export { createSessionSigner, createSessionSignerForAccount } from "./signer.js";
 export type { ProductAccountRef } from "./signer.js";
 
+// Allowance service — `adapter.allowance` lives on every TerminalAdapter (inherited
+// from host-papp's PappAdapter). These helpers default the session id to the only
+// paired session and unwrap the underlying ResultAsync into a throw, matching the
+// idiom of the rest of this package.
+export { getBulletinSigner, getStatementStoreProver } from "./allowance.js";
+export { AllowanceError } from "@novasamatech/host-papp";
+export type { AllowanceService, AllowanceErrorReason } from "@novasamatech/host-papp";
+
 // Session helpers
 export { waitForSessions } from "./sessions.js";
 

--- a/product-sdk/packages/terminal/src/index.ts
+++ b/product-sdk/packages/terminal/src/index.ts
@@ -16,7 +16,16 @@ export type { ProductAccountRef } from "./signer.js";
 // from host-papp's PappAdapter). These helpers default the session id to the only
 // paired session and unwrap the underlying ResultAsync into a throw, matching the
 // idiom of the rest of this package.
-export { getBulletinSigner, getStatementStoreProver } from "./allowance.js";
+//
+// The `has*Allowance` variants are cache-only probes that never prompt the
+// paired wallet — safe to call from login health-check paths that must not
+// surface a phone dialog.
+export {
+    getBulletinSigner,
+    getStatementStoreProver,
+    hasBulletinAllowance,
+    hasStatementStoreAllowance,
+} from "./allowance.js";
 export { AllowanceError } from "@novasamatech/host-papp";
 export type { AllowanceService, AllowanceErrorReason } from "@novasamatech/host-papp";
 

--- a/product-sdk/pending-changesets/terminal-allowance-helpers.md
+++ b/product-sdk/pending-changesets/terminal-allowance-helpers.md
@@ -1,0 +1,27 @@
+---
+"@parity/product-sdk-terminal": minor
+---
+
+**Expose host-papp's allowance service through `@parity/product-sdk-terminal` with CLI-friendly defaults.**
+
+Two new helpers — `getBulletinSigner(adapter, productId, sessionId?)` and `getStatementStoreProver(adapter, productId, sessionId?)` — wrap host-papp's `adapter.allowance` for the common CLI case:
+
+- `sessionId` defaults to the only paired session. When zero or more than one sessions are paired and no id is supplied, both throw `AllowanceError` with `reason: 'NoSession'`.
+- The underlying neverthrow `ResultAsync` is unwrapped to a `Promise<T>` that throws `AllowanceError` on failure — matching the throwy/async idiom of `createSessionSigner` and `requestResourceAllocation`.
+
+`AllowanceError` (and the `AllowanceErrorReason` / `AllowanceService` types) are now re-exported from `@parity/product-sdk-terminal`, so consumers don't need a direct `@novasamatech/host-papp` import.
+
+```ts
+import {
+    createTerminalAdapter,
+    getBulletinSigner,
+    AllowanceError,
+} from "@parity/product-sdk-terminal";
+
+const adapter = createTerminalAdapter({ appId: "my-cli" });
+// ... QR pair, await waitForSessions(adapter) ...
+const signer = await getBulletinSigner(adapter, "my-cli.dot");
+await bulletinClient.tx.TransactionStorage.store({ data }).signAndSubmit(signer);
+```
+
+The existing `@parity/product-sdk-terminal/host` subpath (`ensureSlotAccountSigner`, `requestResourceAllocation`, `createSlotAccountSigner`, `getCachedAllocation`) is unchanged. Use the `./host` subpath when you need explicit multi-session handling, batched allocation requests, or cache inspection.

--- a/product-sdk/pending-changesets/terminal-allowance-helpers.md
+++ b/product-sdk/pending-changesets/terminal-allowance-helpers.md
@@ -2,12 +2,20 @@
 "@parity/product-sdk-terminal": minor
 ---
 
-**Expose host-papp's allowance service through `@parity/product-sdk-terminal` with CLI-friendly defaults.**
+**Expose host-papp's allowance service through `@parity/product-sdk-terminal` with CLI-friendly defaults — including cache-only probes that never trigger a wallet prompt.**
 
-Two new helpers — `getBulletinSigner(adapter, productId, sessionId?)` and `getStatementStoreProver(adapter, productId, sessionId?)` — wrap host-papp's `adapter.allowance` for the common CLI case:
+Four new helpers:
 
-- `sessionId` defaults to the only paired session. When zero or more than one sessions are paired and no id is supplied, both throw `AllowanceError` with `reason: 'NoSession'`.
-- The underlying neverthrow `ResultAsync` is unwrapped to a `Promise<T>` that throws `AllowanceError` on failure — matching the throwy/async idiom of `createSessionSigner` and `requestResourceAllocation`.
+- `getBulletinSigner(adapter, productId, sessionId?): Promise<PolkadotSigner>` — prompt-allowed fetch (cache hit, or wallet round-trip on miss).
+- `getStatementStoreProver(adapter, productId, sessionId?): Promise<StatementProver>` — same for the statement-store path.
+- `hasBulletinAllowance(adapter, productId, sessionId?): Promise<boolean>` — **cache-only probe**, never prompts the wallet. Resolves `true` when an allowance slot for `(sessionId, productId, bulletin)` is already cached on disk; `false` when it isn't. Use for login health checks, readiness probes, or any path that must not surface a phone dialog.
+- `hasStatementStoreAllowance(adapter, productId, sessionId?): Promise<boolean>` — same for statement-store.
+
+All four share the same defaulting + error idiom:
+
+- `sessionId` defaults to the only paired session. When zero or more than one sessions are paired and no id is supplied, all four throw `AllowanceError` with `reason: 'NoSession'`.
+- The fetching helpers (`getBulletinSigner` / `getStatementStoreProver`) unwrap host-papp's neverthrow `ResultAsync` to a `Promise<T>` that throws `AllowanceError` on failure — matching the throwy/async idiom of `createSessionSigner` and `requestResourceAllocation`.
+- The cache-only helpers (`has*Allowance`) read host-papp's encrypted on-disk allowance file directly via a vendored mirror of host-papp's `AllowanceRepository` codec. The mirror will be retired once host-papp exposes a cache-only probe on its public surface; the public surface here won't change.
 
 `AllowanceError` (and the `AllowanceErrorReason` / `AllowanceService` types) are now re-exported from `@parity/product-sdk-terminal`, so consumers don't need a direct `@novasamatech/host-papp` import.
 
@@ -15,13 +23,22 @@ Two new helpers — `getBulletinSigner(adapter, productId, sessionId?)` and `get
 import {
     createTerminalAdapter,
     getBulletinSigner,
+    hasBulletinAllowance,
     AllowanceError,
 } from "@parity/product-sdk-terminal";
 
 const adapter = createTerminalAdapter({ appId: "my-cli" });
 // ... QR pair, await waitForSessions(adapter) ...
-const signer = await getBulletinSigner(adapter, "my-cli.dot");
-await bulletinClient.tx.TransactionStorage.store({ data }).signAndSubmit(signer);
+
+if (await hasBulletinAllowance(adapter, "my-cli.dot")) {
+    // happy path — no wallet prompt risk
+    const signer = await getBulletinSigner(adapter, "my-cli.dot");
+    await bulletinClient.tx.TransactionStorage.store({ data }).signAndSubmit(signer);
+} else {
+    console.log("Approve the allowance request on your phone…");
+    const signer = await getBulletinSigner(adapter, "my-cli.dot");
+    // …
+}
 ```
 
 The existing `@parity/product-sdk-terminal/host` subpath (`ensureSlotAccountSigner`, `requestResourceAllocation`, `createSlotAccountSigner`, `getCachedAllocation`) is unchanged. Use the `./host` subpath when you need explicit multi-session handling, batched allocation requests, or cache inspection.

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -187,7 +187,7 @@ importers:
         version: 0.8.6
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -215,7 +215,7 @@ importers:
         version: 0.8.6
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -293,7 +293,7 @@ importers:
         version: 0.8.6
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
@@ -321,7 +321,7 @@ importers:
         version: 0.8.6
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -788,6 +788,9 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1
     devDependencies:
+      '@novasamatech/substrate-slot-sr25519-wasm':
+        specifier: ^0.8.6
+        version: 0.8.6
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.6
@@ -3766,6 +3769,23 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)':
+    dependencies:
+      '@novasamatech/host-api': 0.8.6
+      '@polkadot-api/json-rpc-provider-proxy': 0.4.0
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
+      neverthrow: 8.2.0
+      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@polkadot/api'
+      - '@polkadot/util'
+      - bufferutil
+      - esbuild
+      - rxjs
+      - supports-color
+      - utf-8-validate
+
   '@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@novasamatech/host-api': 0.8.6
@@ -3879,6 +3899,41 @@ snapshots:
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@polkadot-api/cli@0.21.4(esbuild@0.25.12)':
+    dependencies:
+      '@commander-js/extra-typings': 15.0.0(commander@15.0.0)
+      '@polkadot-api/codegen': 0.22.5
+      '@polkadot-api/ink-contracts': 0.6.3
+      '@polkadot-api/json-rpc-provider': 0.2.0
+      '@polkadot-api/known-chains': 0.11.5
+      '@polkadot-api/metadata-compatibility': 0.6.3
+      '@polkadot-api/observable-client': 0.18.7(rxjs@7.8.2)
+      '@polkadot-api/sm-provider': 0.3.5(@polkadot-api/smoldot@0.4.4)
+      '@polkadot-api/smoldot': 0.4.4
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot-api/substrate-client': 0.7.0
+      '@polkadot-api/utils': 0.4.0
+      '@polkadot-api/wasm-executor': 0.2.3
+      '@polkadot-api/ws-middleware': 0.3.4(rxjs@7.8.2)
+      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
+      '@types/node': 25.9.1
+      commander: 15.0.0
+      execa: 9.6.1
+      fs.promises.exists: 1.1.4
+      ora: 9.4.0
+      read-pkg: 10.1.0
+      rollup: 4.61.0
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.61.0)
+      rxjs: 7.8.2
+      tsc-prog: 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+      write-package: 7.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - esbuild
+      - supports-color
+      - utf-8-validate
 
   '@polkadot-api/cli@0.21.4(esbuild@0.27.7)':
     dependencies:
@@ -5305,6 +5360,34 @@ snapshots:
 
   pngjs@5.0.0: {}
 
+  polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2):
+    dependencies:
+      '@polkadot-api/cli': 0.21.4(esbuild@0.25.12)
+      '@polkadot-api/ink-contracts': 0.6.3
+      '@polkadot-api/json-rpc-provider': 0.2.0
+      '@polkadot-api/known-chains': 0.11.5
+      '@polkadot-api/logs-provider': 0.2.0
+      '@polkadot-api/metadata-builders': 0.14.3
+      '@polkadot-api/metadata-compatibility': 0.6.3
+      '@polkadot-api/observable-client': 0.18.7(rxjs@7.8.2)
+      '@polkadot-api/pjs-signer': 0.7.3
+      '@polkadot-api/polkadot-signer': 0.1.6
+      '@polkadot-api/signer': 0.3.3
+      '@polkadot-api/sm-provider': 0.3.5(@polkadot-api/smoldot@0.4.4)
+      '@polkadot-api/smoldot': 0.4.4
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot-api/substrate-client': 0.7.0
+      '@polkadot-api/utils': 0.4.0
+      '@polkadot-api/ws-middleware': 0.3.4(rxjs@7.8.2)
+      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
+      '@rx-state/core': 0.1.4(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - esbuild
+      - supports-color
+      - utf-8-validate
+
   polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2):
     dependencies:
       '@polkadot-api/cli': 0.21.4(esbuild@0.27.7)
@@ -5412,6 +5495,17 @@ snapshots:
       signal-exit: 4.1.0
 
   reusify@1.1.0: {}
+
+  rollup-plugin-esbuild@6.2.1(esbuild@0.25.12)(rollup@4.61.0):
+    dependencies:
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      esbuild: 0.25.12
+      get-tsconfig: 4.14.0
+      rollup: 4.61.0
+      unplugin-utils: 0.2.5
+    transitivePeerDependencies:
+      - supports-color
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.61.0):
     dependencies:


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                                            
  Surfaces host-papp's `adapter.allowance` through `@parity/product-sdk-terminal` with four convenience helpers that match the rest of the package's idiom.                                                                                         
   
  **Prompt-allowed fetch (cache hit, or wallet round-trip on miss):**                                                                                                                                                                               
  - `getBulletinSigner(adapter, productId, sessionId?): Promise<PolkadotSigner>`
  - `getStatementStoreProver(adapter, productId, sessionId?): Promise<StatementProver>`                                                                                                                                                             
                                                            
  **Cache-only probes (never prompt the paired wallet):**                                                                                                                                                                                           
  - `hasBulletinAllowance(adapter, productId, sessionId?): Promise<boolean>`
  - `hasStatementStoreAllowance(adapter, productId, sessionId?): Promise<boolean>`                                                                                                                                                                  
                                                                                                                                                                                                                                                    
  `sessionId` defaults to the only paired session; zero or multiple sessions without an explicit id throw `AllowanceError('NoSession')` for all four. The fetching helpers unwrap host-papp's `ResultAsync` to a throwing `Promise`, matching       
  `createSessionSigner` / `requestResourceAllocation`. The cache-only probes resolve `true`/`false` from host-papp's on-disk allowance file via a private codec mirror — intended for CLI login health checks and readiness probes that must not    
  surface a phone dialog. When `adapter.storageDir` is undefined (non-disk `StorageAdapter`), the probes return `false` conservatively rather than claim "no allowance" off a path they can't read.                                                 
                                                            
  The mirror vendors host-papp's `AllowanceRepository` SCALE codec + AES-GCM scheme into a private module guarded by `satisfies Codec<…>` (build-time drift) and a round-trip interop test against the real `AllowanceService` (byte-level drift).  
  Both guards retire when host-papp's public surface gains a cache-only probe; the public surface here won't change.
                                                                                                                                                                                                                                                    
  `AllowanceError`, `AllowanceErrorReason`, and `AllowanceService` are re-exported from `@parity/product-sdk-terminal` so consumers don't need a direct `@novasamatech/host-papp` import.                                                           
   
  The existing `@parity/product-sdk-terminal/host` subpath (`ensureSlotAccountSigner`, `requestResourceAllocation`, `createSlotAccountSigner`, `getCachedAllocation`) is unchanged. README repositions it as the lower-level escape hatch.          
                                                            
  ```ts                                                                                                                                                                                                                                             
  import {                                                  
      createTerminalAdapter,
      getBulletinSigner,
      hasBulletinAllowance,                                                                                                                                                                                                                         
  } from "@parity/product-sdk-terminal";
                                                                                                                                                                                                                                                    
  const adapter = createTerminalAdapter({ appId: "my-cli" });
  await waitForSessions(adapter);                                                                                                                                                                                                                   
   
  if (await hasBulletinAllowance(adapter, "my-cli.dot")) {                                                                                                                                                                                          
      // happy path — no wallet prompt risk                 
      const signer = await getBulletinSigner(adapter, "my-cli.dot");
      await client.bulletin.tx.TransactionStorage.store({ data }).signAndSubmit(signer);                                                                                                                                                            
  } else {
      console.log("Approve the allowance request on your phone…");                                                                                                                                                                                  
      const signer = await getBulletinSigner(adapter, "my-cli.dot");
      // …                                                                                                                                                                                                                                          
  }                                                         
  ```
