### PR TITLE
fix(workspace): migrate pnpm config for pnpm 11 compatibility

### DIFF
--- a/product-sdk/package.json
+++ b/product-sdk/package.json
@@ -17,11 +17,6 @@
     "bench:update": "node scripts/bench-bundle.mjs measure --out bundle-size.json --md bundle-size.md",
     "bench:compare": "node scripts/bench-bundle.mjs compare --base bundle-size.base.json --head bundle-size.json --md bundle-size.diff.md --strict"
   },
-  "pnpm": {
-    "overrides": {
-      "@polkadot-api/json-rpc-provider": "^0.2.0"
-    }
-  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@changesets/cli": "^2.28.1",

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -19,5 +19,13 @@ catalog:
   vite: ^6.3.0
   vitest: ^3.1.4
 
+overrides:
+  "@polkadot-api/json-rpc-provider": "^0.2.0"
+
 onlyBuiltDependencies:
   - "@biomejs/biome"
+  - "esbuild"
+
+allowBuilds:
+  "@biomejs/biome": true
+  esbuild: true


### PR DESCRIPTION
Migrated pnpm config for pnpm 11 compatibility. Moved overrides out of package.json (silently ignored by pnpm 11) into pnpm-workspace.yaml, and added an allowBuilds: block so esbuild/biome postinstalls run cleanly on both pnpm 10 and 11.

closes: https://github.com/paritytech/product-sdk/issues/154