### PR TITLE
feat(catalog): bump @novasamatech/host-api family to 0.8.7-2

### DIFF
--- a/product-sdk/packages/terminal/package.json
+++ b/product-sdk/packages/terminal/package.json
@@ -35,9 +35,9 @@
         "@noble/ciphers": "^2.1.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.2.0",
-        "@novasamatech/host-papp": "^0.8.6",
-        "@novasamatech/statement-store": "^0.8.6",
-        "@novasamatech/storage-adapter": "^0.8.6",
+        "@novasamatech/host-papp": "^0.8.7-2",
+        "@novasamatech/statement-store": "^0.8.7-2",
+        "@novasamatech/storage-adapter": "^0.8.7-2",
         "@parity/product-sdk-logger": "workspace:*",
         "@polkadot-api/substrate-bindings": "^0.20.2",
         "@polkadot-api/utils": "^0.4.0",
@@ -50,7 +50,7 @@
         "scale-ts": "^1.6.1"
     },
     "devDependencies": {
-        "@novasamatech/substrate-slot-sr25519-wasm": "^0.8.6",
+        "@novasamatech/substrate-slot-sr25519-wasm": "^0.8.7-2",
         "@types/qrcode": "^1.5.5",
         "tsup": "catalog:",
         "typescript": "catalog:",

--- a/product-sdk/packages/terminal/src/testing.ts
+++ b/product-sdk/packages/terminal/src/testing.ts
@@ -51,6 +51,12 @@ import { sanitizeKey } from "./node-storage.js";
 // `identityAccountId`, `identityChatPublicKey`, and `ssoEncPubKey` — all
 // three are now required — and appended `rootEntropySource: Bytes(32)`,
 // the layer-1 entropy the host consumes via `deriveProductEntropyFromSource`.
+//
+// host-papp 0.8.7-1 (PR #212) appended `deviceEncPubKey: Bytes(65)` — the
+// paired phone's long-lived ECDH key, lifted from `HandshakeResponseV2.
+// deviceEncPubKey`, used by the host's device-sync channel to address
+// the paired device. The storage key was renamed `SsoSessionsV2 → SsoSessionsV3`
+// in the same release; the old graceful-degrade for V2 blobs is gone.
 const storedUserSessionCodec = Struct({
     id: str,
     localAccount: LocalSessionAccountCodec,
@@ -60,6 +66,7 @@ const storedUserSessionCodec = Struct({
     identityChatPublicKey: Bytes(65),
     ssoEncPubKey: Bytes(65),
     rootEntropySource: Bytes(32),
+    deviceEncPubKey: Bytes(65),
 }) satisfies Codec<StoredUserSession>;
 const sessionsCodec = Vector(storedUserSessionCodec);
 
@@ -160,9 +167,9 @@ export interface TestSession {
  *   tracked via on-chain attestation state. See above for how expiry-path
  *   tests still work in practice.
  * - **Corrupted-session cases** don't need a helper — write garbage to
- *   `<storageDir>/<appId>_SsoSessionsV2.json` with `fs.writeFile` directly.
+ *   `<storageDir>/<appId>_SsoSessionsV3.json` with `fs.writeFile` directly.
  * - **Repeated calls replace the session list.** Each call writes a fresh
- *   single-entry `SsoSessionsV2` file, so calling twice on the same
+ *   single-entry `SsoSessionsV3` file, so calling twice on the same
  *   `storageDir`+`appId` leaves only the second session on disk. Use a
  *   fresh `mkdtempSync` per test to keep cases isolated.
  *
@@ -209,11 +216,13 @@ export async function createTestSession(options: CreateTestSessionOptions): Prom
 
     // host-papp 0.8.6 (RFC-0007) requires all of identityAccountId,
     // identityChatPublicKey, ssoEncPubKey, and rootEntropySource on the
-    // persisted session. For a synthesized test session we collapse the
-    // identity-side keys onto the remote account (the wallet doubles as
-    // identity), reuse the peer's P-256 encryption pubkey for both chat
-    // and SSO transports, and use the remote entropy as the RFC-0007
-    // root entropy source so the value is reproducible.
+    // persisted session. host-papp 0.8.7-1 added `deviceEncPubKey` (the
+    // peer device's long-lived ECDH key). For a synthesized test session
+    // we collapse the identity-side keys onto the remote account (the
+    // wallet doubles as identity), reuse the peer's P-256 encryption
+    // pubkey for chat, SSO, and the new device-sync transport, and use
+    // the remote entropy as the RFC-0007 root entropy source so the value
+    // is reproducible.
     const session = {
         id: sessionId,
         localAccount: createLocalSessionAccount(createAccountId(localPublicKey), undefined),
@@ -227,10 +236,11 @@ export async function createTestSession(options: CreateTestSessionOptions): Prom
         identityChatPublicKey: remoteEncrPublicKey,
         ssoEncPubKey: remoteEncrPublicKey,
         rootEntropySource: remoteEntropy,
+        deviceEncPubKey: remoteEncrPublicKey,
     };
 
     await writeFile(
-        join(options.storageDir, `${sanitizeKey(options.appId, "SsoSessionsV2")}.json`),
+        join(options.storageDir, `${sanitizeKey(options.appId, "SsoSessionsV3")}.json`),
         toHex(sessionsCodec.enc([session])),
         "utf-8",
     );
@@ -295,7 +305,7 @@ if (import.meta.vitest) {
     });
 
     describe("createTestSession", () => {
-        test("writes both SsoSessionsV2 and UserSecretsV2 files by default", async () => {
+        test("writes both SsoSessionsV3 and UserSecretsV2 files by default", async () => {
             const result = await createTestSession({
                 appId: "my-app",
                 storageDir,
@@ -303,7 +313,7 @@ if (import.meta.vitest) {
                 remoteMnemonic: REMOTE_MNEMONIC,
             });
 
-            const sessions = await readFile(join(storageDir, "my-app_SsoSessionsV2.json"), "utf-8");
+            const sessions = await readFile(join(storageDir, "my-app_SsoSessionsV3.json"), "utf-8");
             expect(sessions).toMatch(/^0x[0-9a-f]+$/);
 
             const secrets = await readFile(
@@ -323,7 +333,7 @@ if (import.meta.vitest) {
             });
 
             await expect(
-                readFile(join(storageDir, "my-app_SsoSessionsV2.json"), "utf-8"),
+                readFile(join(storageDir, "my-app_SsoSessionsV3.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
 
             await expect(
@@ -334,7 +344,7 @@ if (import.meta.vitest) {
             ).rejects.toThrow(/ENOENT/);
         });
 
-        test("SsoSessionsV2 file decodes with the host-papp session codec shape", async () => {
+        test("SsoSessionsV3 file decodes with the host-papp session codec shape", async () => {
             const result = await createTestSession({
                 appId: "my-app",
                 storageDir,
@@ -343,7 +353,7 @@ if (import.meta.vitest) {
                 sessionId: "stable-test-id",
             });
 
-            const hex = await readFile(join(storageDir, "my-app_SsoSessionsV2.json"), "utf-8");
+            const hex = await readFile(join(storageDir, "my-app_SsoSessionsV3.json"), "utf-8");
             const decoded = sessionsCodec.dec(fromHex(hex));
 
             expect(decoded).toHaveLength(1);
@@ -401,10 +411,10 @@ if (import.meta.vitest) {
             await createTestSession({ appId: "app-b", storageDir, sessionId: "id" });
 
             await expect(
-                readFile(join(storageDir, "app-a_SsoSessionsV2.json"), "utf-8"),
+                readFile(join(storageDir, "app-a_SsoSessionsV3.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
             await expect(
-                readFile(join(storageDir, "app-b_SsoSessionsV2.json"), "utf-8"),
+                readFile(join(storageDir, "app-b_SsoSessionsV3.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
         });
 
@@ -415,7 +425,7 @@ if (import.meta.vitest) {
                 sessionId: "id",
             });
             await expect(
-                readFile(join(storageDir, "app_with_spaces_SsoSessionsV2.json"), "utf-8"),
+                readFile(join(storageDir, "app_with_spaces_SsoSessionsV3.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
         });
 
@@ -423,7 +433,7 @@ if (import.meta.vitest) {
             const nested = join(storageDir, "does", "not", "exist");
             await createTestSession({ appId: "my-app", storageDir: nested });
             await expect(
-                readFile(join(nested, "my-app_SsoSessionsV2.json"), "utf-8"),
+                readFile(join(nested, "my-app_SsoSessionsV3.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
         });
 
@@ -477,7 +487,7 @@ if (import.meta.vitest) {
                 sessionId: "second",
             });
 
-            const hex = await readFile(join(storageDir, "my-app_SsoSessionsV2.json"), "utf-8");
+            const hex = await readFile(join(storageDir, "my-app_SsoSessionsV3.json"), "utf-8");
             const decoded = sessionsCodec.dec(fromHex(hex));
             expect(decoded).toHaveLength(1);
             expect(decoded[0].id).toBe("second");

--- a/product-sdk/pending-changesets/bump-host-papp-0.8.7-2.md
+++ b/product-sdk/pending-changesets/bump-host-papp-0.8.7-2.md
@@ -1,0 +1,45 @@
+---
+"@parity/product-sdk-terminal": minor
+"@parity/product-sdk-host": patch
+"@parity/product-sdk-signer": patch
+"@parity/product-sdk-statement-store": patch
+"@parity/product-sdk": minor
+---
+
+**Bump `@novasamatech/host-api` family from `^0.8.6` to `^0.8.7-2`.** Picks up the upstream `deviceEncPubKey` addition on the V2 session schema (PR #212), the statement-store allowance-slot-prover fix (PR #214 — `createSr25519Prover` → `createSlotAccountProver`), and the `ExpiryTooLow` retry fix in `submitWithRetry`.
+
+One consumer-visible behavioral change worth flagging up front:
+
+> **CLI consumers using `@parity/product-sdk-terminal`** — host-papp `0.8.7-1` renamed the on-disk session storage key (`SsoSessionsV2` → `SsoSessionsV3`) and added a required `deviceEncPubKey: Bytes(65)` field on the persisted session. Sessions persisted from a previous CLI run will be invisible after upgrading; users will need to re-pair their phone the first time they launch the upgraded CLI. The `UserSecretsV2_<sessionId>.json` file format is unchanged.
+
+### What's new
+
+**Upstream catalog bump.** `@novasamatech/host-api`, `@novasamatech/host-api-wrapper`, `@novasamatech/host-papp`, `@novasamatech/statement-store`, `@novasamatech/storage-adapter`, and `@novasamatech/substrate-slot-sr25519-wasm` move from `^0.8.6` to `^0.8.7-2`. Headlines from upstream (between `release: 0.8.6 (#208)` and `chore(release): publish 0.8.7-2`):
+
+- **`deviceEncPubKey` on the V2 session schema** (upstream PR #212). The persisted session codec gains a required `deviceEncPubKey: Bytes(65)` — the paired phone's long-lived ECDH key, lifted from `HandshakeResponseV2.deviceEncPubKey`, used by the host's device-sync channel. The storage key was renamed `SsoSessionsV2 → SsoSessionsV3` in the same release; the old graceful-degrade for V2 blobs is gone.
+- **Statement-store allowance-slot-prover fix** (upstream PR #214). `AllowanceService.getStatementStoreProver` now uses `createSlotAccountProver` instead of `createSr25519Prover` — fixes a signature-scheme mismatch when proving slot-account-derived secrets. No public API change on our side (our `getStatementStoreProver` wrapper passes through unchanged), but the proofs the returned prover emits are now of the correct scheme.
+- **`ExpiryTooLow` retry handling in `submitWithRetry`** (upstream `73cb870`). Internal to host-papp/statement-store retry logic; no consumer-side change.
+
+### `@parity/product-sdk-terminal`
+
+Internal codec mirror used by `createTestSession` updated to match host-papp 0.8.7-2's reshaped session schema:
+
+- Appended `deviceEncPubKey: Bytes(65)` to the mirrored codec; the synthesized field reuses the remote peer's P-256 encryption pubkey (same value already used for `identityChatPublicKey` and `ssoEncPubKey`).
+- Storage-key rename: `SsoSessionsV2.json` → `SsoSessionsV3.json`. The in-source unit tests and TSDoc references all updated.
+
+No public-API change; `createTestSession`'s signature is unchanged. The interop test continues to round-trip the synthesized session through the real `SsoSessionManager` and `UserSecretRepository` to catch upstream drift early — both interop suites pass against host-papp 0.8.7-2.
+
+### `@parity/product-sdk-host`, `@parity/product-sdk-signer`, `@parity/product-sdk-statement-store`
+
+Patch-bumped to signal "tested against host-api(-wrapper) 0.8.7-2" via the published peer-dep / catalog resolution. No source change; runtime behavior is unchanged.
+
+### Migration
+
+**`@parity/product-sdk-terminal` — existing sessions need to be re-paired.** No source change required, but any sessions persisted to disk by a previous CLI run will be invisible after upgrading. host-papp 0.8.7-2 reads from `<storageDir>/<appId>_SsoSessionsV3.json`; the previous `SsoSessionsV2.json` path is no longer consulted, and the old graceful-degrade for stale blobs is gone.
+
+What this means in practice:
+
+- A user upgrading the CLI will see the same UX they'd see on a fresh install — `waitForSessions` returns no sessions until they complete a QR pairing.
+- The old `SsoSessionsV2.json` file is not deleted, just ignored. Optional cleanup: surface a one-liner to the user ("we updated the session format, please re-pair") and `fs.unlink` the legacy path.
+- The `UserSecretsV2_<sessionId>.json` file format is unchanged; legacy secrets files become orphaned (the new session has a different `sessionId`) but don't cause errors.
+- Synthesized test sessions emitted by `createTestSession` automatically write to the new path — no test code change needed unless your tests asserted on the old filenames.

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@novasamatech/host-api':
-      specifier: ^0.8.6
-      version: 0.8.6
+      specifier: ^0.8.7-2
+      version: 0.8.7-2
     '@novasamatech/host-api-wrapper':
-      specifier: ^0.8.6
-      version: 0.8.6
+      specifier: ^0.8.7-2
+      version: 0.8.7-2
     '@novasamatech/sdk-statement':
       specifier: ^0.6.0
       version: 0.6.0
@@ -42,6 +42,9 @@ catalogs:
     vite:
       specifier: ^6.3.0
       version: 6.4.2
+    vitest:
+      specifier: ^3.1.4
+      version: 3.2.6
 
 overrides:
   '@polkadot-api/json-rpc-provider': ^0.2.0
@@ -70,10 +73,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -88,7 +91,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -107,10 +110,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -125,7 +128,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -144,10 +147,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -162,7 +165,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -181,10 +184,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -209,10 +212,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -246,7 +249,7 @@ importers:
         version: link:../../packages/contracts
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -259,16 +262,16 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -287,10 +290,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
@@ -315,10 +318,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -346,10 +349,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-address':
         specifier: workspace:*
         version: link:../../packages/address
@@ -367,7 +370,7 @@ importers:
         version: link:../../packages/tx
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -411,7 +414,7 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -427,7 +430,7 @@ importers:
     dependencies:
       '@parity/bulletin-sdk':
         specifier: ^0.3.0
-        version: 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2))
+        version: 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2))
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../chain-client
@@ -448,7 +451,7 @@ importers:
         version: 13.4.2
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -479,7 +482,7 @@ importers:
         version: 0.0.30
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       viem:
         specifier: 'catalog:'
         version: 2.52.0(typescript@5.9.3)
@@ -520,7 +523,7 @@ importers:
     dependencies:
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.8.3
@@ -533,14 +536,14 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -570,7 +573,7 @@ importers:
         version: 2.2.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       scale-ts:
         specifier: ^1.6.1
         version: 1.6.1
@@ -647,7 +650,7 @@ importers:
         version: link:../tx
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -681,7 +684,7 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -695,16 +698,16 @@ importers:
     optionalDependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.6
+        version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
 
   packages/statement-store:
     dependencies:
       '@novasamatech/sdk-statement':
         specifier: 'catalog:'
-        version: 0.6.0(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../host
@@ -719,11 +722,11 @@ importers:
         version: 0.7.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)
@@ -746,14 +749,14 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@novasamatech/host-papp':
-        specifier: ^0.8.6
-        version: 0.8.6(esbuild@0.25.12)
+        specifier: ^0.8.7-2
+        version: 0.8.7-2(esbuild@0.27.7)
       '@novasamatech/statement-store':
-        specifier: ^0.8.6
-        version: 0.8.6(esbuild@0.25.12)(rxjs@7.8.2)
+        specifier: ^0.8.7-2
+        version: 0.8.7-2(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/storage-adapter':
-        specifier: ^0.8.6
-        version: 0.8.6
+        specifier: ^0.8.7-2
+        version: 0.8.7-2
       '@parity/product-sdk-logger':
         specifier: workspace:*
         version: link:../logger
@@ -777,7 +780,7 @@ importers:
         version: 8.2.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -786,8 +789,8 @@ importers:
         version: 1.6.1
     devDependencies:
       '@novasamatech/substrate-slot-sr25519-wasm':
-        specifier: ^0.8.6
-        version: 0.8.6
+        specifier: ^0.8.7-2
+        version: 0.8.7-2
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.6
@@ -814,7 +817,7 @@ importers:
         version: 0.0.30
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -1419,29 +1422,35 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@novasamatech/host-api-wrapper@0.8.6':
-    resolution: {integrity: sha512-CaSjhLDBdIQYpK7qVMAM4Bj586axJGlbKCbeICzIhkO3WljZPjfoMU8/CnNaCDC3Z4JgoquLqCCsD0JzgDuCmg==}
+  '@novasamatech/host-api-wrapper@0.8.7-2':
+    resolution: {integrity: sha512-5ViapiRdi6Q8kp6KZigvxWT1SyyF9Zd4DW0tLd9iL5ehookIjlP7K4ZENwJFOm0q0nd+7TZG5u3yNJBzGkTniA==}
 
   '@novasamatech/host-api@0.8.6':
     resolution: {integrity: sha512-DayCRwOncCcYO/Hc+pYQaBXsTYOn8h/2dl/hAFy1yVgG/LEBLcZrUmhUpotUFEhgWvfc0/KQa59P7T11H49AWA==}
 
-  '@novasamatech/host-papp@0.8.6':
-    resolution: {integrity: sha512-H1Wyu9TIcwUQONPH/iuaRfNzGjhqaDR/zTG5dHk02TDfmGdZxZm55nsQQZgnGQ96BcRmJ2GWJPo+O1AdYSvxnw==}
+  '@novasamatech/host-api@0.8.7-2':
+    resolution: {integrity: sha512-7PrCZ0hROTjB53RnEc2AJW955QSodzTmV70nrv+cDTcFitHqmA7yTKT6gmebHucAqsp+YmTMvT6DAsHTJ3ilzA==}
+
+  '@novasamatech/host-papp@0.8.7-2':
+    resolution: {integrity: sha512-bkaQIVHtxiJQtZH2pBBJ++dtNFuzE8NzEUbhkTkFogdOXPDmSbDE3lbRzfY/e5sfAA7pLyiFAzbE7P85icwWFQ==}
 
   '@novasamatech/scale@0.8.6':
     resolution: {integrity: sha512-XsiNMntDVUmwQYieowid2s5t1THk/Asb4JohmWOrIFetj5ZdaD8mjLCt42WTWxaZaJyYyCjjGBssnUbcLyTWFw==}
 
+  '@novasamatech/scale@0.8.7-2':
+    resolution: {integrity: sha512-iReejsNQVq4vqeZ6+VTVqPrshsdiP36lklRjlMYwN1bMbQiGqYxVF1INx03X8xNiTYNILPbjWQHgszMK67PzgQ==}
+
   '@novasamatech/sdk-statement@0.6.0':
     resolution: {integrity: sha512-NTqM+yS45iHgy87lVSWIpFozrTfCUWb7r4ZpsDtN1eFnfixXpDKpPXDWQsvPs+nh18r/jmoMgtlTjUltrS6mYQ==}
 
-  '@novasamatech/statement-store@0.8.6':
-    resolution: {integrity: sha512-8ai2QEBk+twJsNHQF34XXgteQskyS0O3QR6+3qvJ3kX2jQlzC8VAKhdMeOLrYNF6ErDdzGFV6ydXHAXWiCD1bw==}
+  '@novasamatech/statement-store@0.8.7-2':
+    resolution: {integrity: sha512-pOdnJxGvfWT3oQcN8bMktcicqfWh9AwBZzOpgA5HgdmZE/ncBRlrMLnv4AibjWaX8zOJVS6gy7nY0vHGnV6S0Q==}
 
-  '@novasamatech/storage-adapter@0.8.6':
-    resolution: {integrity: sha512-YYLI3DVAkF/r8Yi62yhywHzzuFgSBfScsUgjH9ALP3/QK8+bmJRGPAl5eUkcY9wP5GTRMjfHY10mqHKLI3WyYQ==}
+  '@novasamatech/storage-adapter@0.8.7-2':
+    resolution: {integrity: sha512-kR3cVH/v59KGOzD+3UCW5jCmmPCSjNuWg8GysoH3/+9cMhyOxcVYO+q6ykG50yxKK4ceFsZm8lz0YoEFKRVz5w==}
 
-  '@novasamatech/substrate-slot-sr25519-wasm@0.8.6':
-    resolution: {integrity: sha512-GdbsekRopYPCM9a7TrrK9Jc7QpAzBkgLr/LM1H+oo24/t/vr5wYRbQ1IlU42Jxa2zLFzLLu3VzdBo4sw5t0i3A==}
+  '@novasamatech/substrate-slot-sr25519-wasm@0.8.7-2':
+    resolution: {integrity: sha512-wvHJA0z0FO2ONWkJXyLtv7e7hst5lWmZIaGgTMnlkrOtmGNuERM6q5hognmlkHZHbmKNYajzqwjrDV0EMDR7AQ==}
 
   '@parity/bulletin-sdk@0.3.0':
     resolution: {integrity: sha512-sxVwBzyH/egXze1muPXbaGwQuOkP8efVB4Lxunshixf18gJ6WT2tedgUy08QOfQ1848BDQS4wVpRRQfPfb09/g==}
@@ -3922,14 +3931,14 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/host-api-wrapper@0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
-      '@novasamatech/host-api': 0.8.6
+      '@novasamatech/host-api': 0.8.7-2
       '@polkadot-api/json-rpc-provider-proxy': 0.4.0
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
       neverthrow: 8.2.0
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@polkadot/api'
       - '@polkadot/util'
@@ -3947,21 +3956,29 @@ snapshots:
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
-  '@novasamatech/host-papp@0.8.6(esbuild@0.25.12)':
+  '@novasamatech/host-api@0.8.7-2':
+    dependencies:
+      '@novasamatech/scale': 0.8.7-2
+      nanoevents: 9.1.0
+      nanoid: 5.1.11
+      neverthrow: 8.2.0
+      scale-ts: 1.6.1
+
+  '@novasamatech/host-papp@0.8.7-2(esbuild@0.27.7)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
-      '@novasamatech/host-api': 0.8.6
-      '@novasamatech/scale': 0.8.6
-      '@novasamatech/statement-store': 0.8.6(esbuild@0.25.12)(rxjs@7.8.2)
-      '@novasamatech/storage-adapter': 0.8.6
+      '@novasamatech/host-api': 0.8.7-2
+      '@novasamatech/scale': 0.8.7-2
+      '@novasamatech/statement-store': 0.8.7-2(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/storage-adapter': 0.8.7-2
       '@polkadot-api/utils': 0.4.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
       nanoevents: 9.1.0
       nanoid: 5.1.11
       neverthrow: 8.2.0
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       rxjs: 7.8.2
       scale-ts: 1.6.1
     transitivePeerDependencies:
@@ -3975,11 +3992,16 @@ snapshots:
       '@polkadot-api/utils': 0.4.0
       scale-ts: 1.6.1
 
-  '@novasamatech/sdk-statement@0.6.0(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/scale@0.8.7-2':
+    dependencies:
+      '@polkadot-api/utils': 0.4.0
+      scale-ts: 1.6.1
+
+  '@novasamatech/sdk-statement@0.6.0(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@polkadot-api/substrate-bindings': 0.20.1
       '@polkadot-api/utils': 0.4.0
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -3987,13 +4009,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/statement-store@0.8.6(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/statement-store@0.8.7-2(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      '@novasamatech/scale': 0.8.6
-      '@novasamatech/sdk-statement': 0.6.0(esbuild@0.25.12)(rxjs@7.8.2)
-      '@novasamatech/substrate-slot-sr25519-wasm': 0.8.6
+      '@novasamatech/scale': 0.8.7-2
+      '@novasamatech/sdk-statement': 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/substrate-slot-sr25519-wasm': 0.8.7-2
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot-api/substrate-client': 0.7.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
@@ -4001,7 +4023,7 @@ snapshots:
       '@scure/sr25519': 2.2.0
       nanoid: 5.1.11
       neverthrow: 8.2.0
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       scale-ts: 1.6.1
     transitivePeerDependencies:
       - bufferutil
@@ -4010,21 +4032,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/storage-adapter@0.8.6':
+  '@novasamatech/storage-adapter@0.8.7-2':
     dependencies:
       nanoevents: 9.1.0
       neverthrow: 8.2.0
 
-  '@novasamatech/substrate-slot-sr25519-wasm@0.8.6': {}
+  '@novasamatech/substrate-slot-sr25519-wasm@0.8.7-2': {}
 
-  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2))':
+  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2))':
     dependencies:
       '@ipld/dag-pb': 4.1.5
       '@noble/hashes': 2.2.0
       '@polkadot-labs/hdkd-helpers': 0.0.29
       ipfs-unixfs: 12.0.2
       multiformats: 13.4.2
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
 
   '@parity/host-api-test-sdk@0.9.0(@playwright/test@1.60.0)':
     dependencies:
@@ -4036,7 +4058,7 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
-  '@polkadot-api/cli@0.21.4(esbuild@0.25.12)':
+  '@polkadot-api/cli@0.21.4(esbuild@0.27.7)':
     dependencies:
       '@commander-js/extra-typings': 15.0.0(commander@15.0.0)
       '@polkadot-api/codegen': 0.22.5
@@ -4060,7 +4082,7 @@ snapshots:
       ora: 9.4.0
       read-pkg: 10.1.0
       rollup: 4.61.0
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.61.0)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.7)(rollup@4.61.0)
       rxjs: 7.8.2
       tsc-prog: 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -5538,9 +5560,9 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2):
+  polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2):
     dependencies:
-      '@polkadot-api/cli': 0.21.4(esbuild@0.25.12)
+      '@polkadot-api/cli': 0.21.4(esbuild@0.27.7)
       '@polkadot-api/ink-contracts': 0.6.3
       '@polkadot-api/json-rpc-provider': 0.2.0
       '@polkadot-api/known-chains': 0.11.5
@@ -5652,11 +5674,11 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.25.12)(rollup@4.61.0):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.61.0):
     dependencies:
       debug: 4.4.3
       es-module-lexer: 1.7.0
-      esbuild: 0.25.12
+      esbuild: 0.27.7
       get-tsconfig: 4.14.0
       rollup: 4.61.0
       unplugin-utils: 0.2.5

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -4,8 +4,8 @@ packages:
   - "scripts/bench-consumer"
 
 catalog:
-  "@novasamatech/host-api": ^0.8.6
-  "@novasamatech/host-api-wrapper": ^0.8.6
+  "@novasamatech/host-api": ^0.8.7-2
+  "@novasamatech/host-api-wrapper": ^0.8.7-2
   "@novasamatech/sdk-statement": ^0.6.0
   "@parity/host-api-test-sdk": ^0.9.0
   "@playwright/test": ^1.60.0


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                         
  Bumps the `@novasamatech/host-api` family from `^0.8.6` to `^0.8.7-2` and updates the codec mirror in `@parity/product-sdk-terminal` to match the new session schema.                                                                             
   
  Upstream changes picked up:                                                                                                                                                                                                                       
  - **`deviceEncPubKey` on the V2 session** (PR #212) — required `Bytes(65)` field; storage key renamed `SsoSessionsV2` → `SsoSessionsV3`.
  - **Allowance-slot-prover fix** (PR #214) — `createSr25519Prover` → `createSlotAccountProver` in `getStatementStoreProver`.                                                                                                                       
  - **`ExpiryTooLow` retry fix** in `submitWithRetry`.                                                                                                                                                                                              
                                                                                                                                                                                                                                                    
  ## Migration                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                    
  CLI consumers using `@parity/product-sdk-terminal` will need to re-pair their phone — sessions persisted before the upgrade will be invisible (`SsoSessionsV2.json` is no longer consulted, no graceful-degrade). `UserSecretsV2_<sessionId>.json`
   is unchanged.