### PR TITLE
fix(cloud-storage): drop redundant error log in checkAuthorization

### DIFF
--- a/product-sdk/packages/cloud-storage/src/authorization.ts
+++ b/product-sdk/packages/cloud-storage/src/authorization.ts
@@ -58,7 +58,11 @@ export async function checkAuthorization(
             Enum("Account", address),
         );
     } catch (error) {
-        log.error("checkAuthorization: query failed", { address, error });
+        // No log here — the thrown CloudStorageAuthorizationError carries the
+        // address and underlying error as `cause`. Logging before throwing
+        // would double-report transient failures (e.g. DisjointError) for
+        // callers that handle the throw (`.catch(() => null)`), spamming
+        // stderr they have no way to suppress.
         throw new CloudStorageAuthorizationError(address, error);
     }
 
@@ -360,6 +364,39 @@ if (import.meta.vitest) {
             expect(error.address).toBe("5GrwvaEF...");
             expect(error.cause).toBeInstanceOf(Error);
             expect((error.cause as Error).message).toBe("RPC connection lost");
+        });
+
+        test("does NOT emit any error-level log when the query fails (caller owns the throw)", async () => {
+            // Regression guard for the "double-report" UX bug: pre-fix,
+            // checkAuthorization logged at error level *before* throwing,
+            // so a caller catching the throw (e.g. `.catch(() => null)`)
+            // still got a scary stderr line they had no way to suppress.
+            // The throw carries the address + cause already; let the caller
+            // decide whether to log.
+            const { configure } = await import("@parity/product-sdk-logger");
+            type LogEntry = { level: string; namespace: string; message: string };
+            const entries: LogEntry[] = [];
+            configure({
+                level: "debug",
+                handler: (e) => entries.push(e as LogEntry),
+            });
+
+            const api = {
+                query: {
+                    TransactionStorage: {
+                        Authorizations: {
+                            getValue: vi.fn().mockRejectedValue(new Error("DisjointError")),
+                        },
+                    },
+                },
+            } as unknown as CloudStorageApi;
+
+            await checkAuthorization(api, "5GrwvaEF...").catch(() => null);
+
+            const errorLogs = entries.filter(
+                (e) => e.namespace === "cloudStorage" && e.level === "error",
+            );
+            expect(errorLogs).toEqual([]);
         });
 
         test("passes correct Enum key to the query", async () => {

--- a/product-sdk/pending-changesets/cloud-storage-checkauthorization-no-error-log.md
+++ b/product-sdk/pending-changesets/cloud-storage-checkauthorization-no-error-log.md
@@ -1,0 +1,11 @@
+---
+"@parity/product-sdk-cloud-storage": patch
+---
+
+**`checkAuthorization` no longer logs at `error` level before throwing.**
+
+`checkAuthorization` previously emitted `log.error("checkAuthorization: query failed", …)` from its catch block before throwing `CloudStorageAuthorizationError`. That doubled the failure report: once to the logger (stderr by default) and once as the thrown error. Callers handling the throw — e.g. a pre-flight quota check wrapped in `.catch(() => null)` — still got a scary stderr line they had no way to suppress.
+
+The thrown `CloudStorageAuthorizationError` already carries the `address` and the underlying error as `cause`, so the log line was strictly redundant. Removed. Callers that want a log on the failure path can attach their own handler — the SDK now stays quiet on a throw, matching the convention used by the rest of the cloud-storage error paths.
+
+Added a regression test asserting that no `cloudStorage`-namespace error-level entry is emitted on the query-failure path.


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                        
                                                            
  Fixes a UX double-report in `checkAuthorization`: previously it logged                                                                                                                                                                            
  at `error` level *before* throwing `CloudStorageAuthorizationError`,
  so callers handling the throw (e.g. `.catch(() => null)` for a pre-flight                                                                                                                                                                         
  quota check) still got a scary stderr line they had no way to suppress.                                                                                                                                                                           
                                                                                                                                                                                                                                                    
  Removed the redundant `log.error` from the catch block — the thrown                                                                                                                                                                               
  `CloudStorageAuthorizationError` already carries the `address` and
  underlying `cause`. Callers that want a failure-path log can attach                                                                                                                                                                               
  their own. 