### PR TITLE
docs(cloud-storage): update cloud-storage skill to the store()-builder API

### DIFF
--- a/product-sdk/packages/sdk/src/core/createApp.ts
+++ b/product-sdk/packages/sdk/src/core/createApp.ts
@@ -94,7 +94,9 @@ export async function createApp(config: AppConfig): Promise<App> {
     // The signer is wrapped lazily so the cloud storage client can be built before
     // an account is selected. Uploads will throw a clear error if no signer
     // is available at submission time. Reads (fetch / fetchJson) don't need
-    // a signer and work regardless.
+    // a signer, so they work regardless of whether an account is selected --
+    // but they are container-only and throw CloudStorageHostUnavailableError
+    // outside a host container (no IPFS-gateway fallback).
     const cloudStorageEnabled = config.cloudStorage !== false;
     const cloudStorageEnvironment =
         typeof config.cloudStorage === "object" ? config.cloudStorage.environment : "paseo";

--- a/product-sdk/skills/product-sdk-cloud-storage/SKILL.md
+++ b/product-sdk/skills/product-sdk-cloud-storage/SKILL.md
@@ -2,95 +2,118 @@
 name: product-sdk-cloud-storage
 description: >
   Use when uploading or retrieving data via Cloud Storage, working with
-  CID-based decentralized storage, IPFS gateway access, or the CloudStorageClient SDK.
-  Covers upload, batch upload, fetch, query, CID computation, and gateway utilities.
+  CID-based decentralized storage, or the CloudStorageClient SDK. Covers the
+  store() upload builder, chunked uploads, container-only reads (fetch/query),
+  CID helpers, and authorization.
 ---
 
 # Product SDK Cloud Storage
 
-`@parity/product-sdk-cloud-storage` is a TypeScript SDK for uploading and retrieving data via Cloud Storage -- a purpose-built parachain for decentralized data storage. Data is content-addressed using CIDv1 (blake2b-256 hash, raw codec) and retrievable via IPFS gateways.
+`@parity/product-sdk-cloud-storage` is a TypeScript SDK for uploading and retrieving data via Cloud Storage -- a purpose-built parachain for decentralized data storage. Data is content-addressed using CIDv1 (blake2b-256 hash, raw codec). It wraps `@parity/bulletin-sdk` (chunking, DAG-PB manifests, CID calculation, progress events) and routes reads through the host's preimage subscription.
 
 ## Key Concepts
 
 - **Content-addressed storage**: Data is identified by its CID (Content Identifier), computed deterministically from the bytes via blake2b-256.
-- **Two upload paths**: Inside a host container, uploads go through the host preimage API automatically. Standalone, a `PolkadotSigner` or dev signer is used.
-- **Two query paths**: Inside a host container, queries use the host preimage lookup. Standalone, data is fetched from an IPFS gateway.
-- **Environments**: `"polkadot"`, `"kusama"`, `"paseo"` -- currently only `"paseo"` has a live gateway.
+- **Uploads always need a signer**: Every `store(...)` submits a `TransactionStorage.store` extrinsic, so `create(...)` **requires** a `signer`. In-container vs standalone only changes *where the signer comes from* (the host's account vs a `PolkadotSigner` you supply) -- there is no signer-less host upload path.
+- **Reads are container-only**: `fetchBytes`/`fetchJson`/`queryBytes` resolve content through the host's preimage subscription and **require a host container**. Outside a container they **throw `CloudStorageHostUnavailableError`** -- the SDK does **not** fall back to a public IPFS gateway. A product that needs a standalone read path must branch on `isInsideContainer()` and perform its own gateway fetch.
+- **Environments**: `create({ environment })` accepts `"paseo"` and `"summit"` (the `CloudStorageEnvironment` presets -- keys of `CloudStorageNetworks`; both currently available). `"polkadot"`/`"kusama"` are not yet available (compile error, and `getChainAPI` throws).
 
 ## Quick Start: Upload and Fetch
 
 ```ts
-import { CloudStorageClient } from "@parity/product-sdk-cloud-storage";
+import { CloudStorageClient, createLazySigner } from "@parity/product-sdk-cloud-storage";
 
-// Create a client for the Paseo test network
-const cloudStorage = await CloudStorageClient.create("paseo");
+// Create a client for the Paseo test network. A signer is REQUIRED -- every
+// store() submits a transaction. createLazySigner defers signer resolution so
+// you can build the client before an account is selected.
+const cloudStorage = await CloudStorageClient.create({
+  environment: "paseo",
+  // getCurrentSigner returns the active `PolkadotSigner | null`
+  // (e.g. wrap your signer manager / host account here).
+  signer: createLazySigner(() => getCurrentSigner()),
+});
 
-// Upload data (MUST be Uint8Array, not a string)
+// Upload data (MUST be Uint8Array, not a string) via the store() builder
 const data = new TextEncoder().encode(JSON.stringify({ title: "Hello Cloud Storage" }));
-const result = await cloudStorage.upload(data);
-console.log("CID:", result.cid);
+const result = await cloudStorage.store(data).send();
+console.log("CID:", result.cid?.toString());        // result.cid is a CID object (undefined for chunked-without-manifest)
+console.log("block:", result.blockNumber, "size:", result.size);
 
-// Fetch it back as JSON
-const content = await cloudStorage.fetchJson<{ title: string }>(result.cid);
+// Fetch it back as JSON (requires a host container -- throws CloudStorageHostUnavailableError standalone)
+const content = await cloudStorage.fetchJson<{ title: string }>(result.cid!.toString());
 console.log(content.title); // "Hello Cloud Storage"
 ```
 
-> **WARNING**: `upload()` expects `Uint8Array`, not strings. Always convert with `new TextEncoder().encode(...)`.
+> **WARNING**: `store()` expects `Uint8Array`, not strings. Always convert with `new TextEncoder().encode(...)`.
 
 ## CloudStorageClient
 
-The `CloudStorageClient` class bundles a typed Cloud Storage API and IPFS gateway URL.
+The `CloudStorageClient` wraps the upstream `@parity/bulletin-sdk` client and adds network presets, container-routed read helpers, and a pre-flight authorization check.
 
 ### Creating a Client
 
 ```ts
-import { CloudStorageClient } from "@parity/product-sdk-cloud-storage";
+import { CloudStorageClient, CloudStorageNetworks, createLazySigner } from "@parity/product-sdk-cloud-storage";
 
-// From an environment name
-const client = await CloudStorageClient.create("paseo");
+// Environment shorthand (signer required)
+const client = await CloudStorageClient.create({ environment: "paseo", signer });
 
-// From explicit API and gateway (custom setups)
-import { getGateway } from "@parity/product-sdk-cloud-storage";
-const custom = CloudStorageClient.from(myApi, "https://my-gateway.example/ipfs/");
+// Explicit network / BYOD -- spread a preset (or supply your own genesisHash + descriptor)
+const custom = await CloudStorageClient.create({
+  ...CloudStorageNetworks.paseo,
+  signer,
+  config: { defaultChunkSize: 1 << 20 },
+});
+
+// From a pre-built AsyncBulletinClient + typed API (you own the connection lifecycle)
+const fromInner = CloudStorageClient.from(inner, api);
 ```
 
 ### When to use each entry point
 
-| Method | When to use | Size cost |
-|--------|-------------|-----------|
-| `CloudStorageClient.create("paseo")` | Quick prototyping | ~6.3 MB (all preset descriptors) |
-| `CloudStorageClient.from(api, gateway)` | Production apps, BYOD | Only the descriptors you import |
+| Method | When to use |
+|--------|-------------|
+| `create({ environment, signer })` | Quick start against a preset network |
+| `create({ ...descriptor, signer })` | Custom / BYOD network (explicit `genesisHash` + `descriptor`) |
+| `from(inner, api)` | You already own the `AsyncBulletinClient` and its connection lifecycle |
 
 ### Uploading Data
 
+Uploads use the fluent `store(data)` builder (re-exported from `@parity/bulletin-sdk`):
+
 ```ts
 const data = new TextEncoder().encode("raw file content");
-const result = await client.upload(data);
-// result.cid, result.kind, result.gatewayUrl
 
-// With explicit signer and options
-const result2 = await client.upload(data, mySigner, {
-  waitFor: "finalized",
-  timeoutMs: 60_000,
-});
+// Simple signed upload
+const result = await client.store(data).send();
+// result.cid (CID | undefined), result.size, result.blockNumber, result.extrinsicIndex
+
+// Chained options
+const result2 = await client
+  .store(data)
+  .withWaitFor("finalized")        // "in_block" | "finalized"
+  .send();
+
+// Pre-authorized content can be stored fee-free by anyone via an unsigned tx
+await client.authorizePreimage(contentHash, BigInt(data.length));
+const result3 = await client.store(data).sendUnsigned();
 ```
 
-### Batch Upload
+### Chunked Uploads (large files)
+
+There is no `batchUpload`. For large files, force the chunked path with `withChunkSize` -- a DAG-PB manifest (default) ties the chunks together and `result.cid` is the manifest CID:
 
 ```ts
-const items = [
-  { data: new TextEncoder().encode("file A"), label: "a.txt" },
-  { data: new TextEncoder().encode("file B"), label: "b.txt" },
-];
-
-const results = await client.batchUpload(items, undefined, {
-  onProgress: (completed, total, current) => {
-    console.log(`${completed}/${total}: ${current.label}`);
-  },
-});
+const result = await client
+  .store(largeFile)
+  .withChunkSize(1 << 20)             // 1 MiB chunks
+  .withCallback((evt) => console.log(evt))   // progress events
+  .send();
 ```
 
 ### Fetching Data
+
+`fetchBytes`/`fetchJson` are **instance methods** and **container-only** (host preimage lookup; throw `CloudStorageHostUnavailableError` standalone):
 
 ```ts
 // Raw bytes
@@ -103,17 +126,19 @@ const metadata = await client.fetchJson<{ name: string }>(cid);
 ### Utility Methods
 
 ```ts
-// Compute CID without uploading
-const cid = CloudStorageClient.computeCid(data);
+import { calculateCid } from "@parity/product-sdk-cloud-storage";
 
-// Check if CID exists
-const exists = await client.cidExists(cid);
+// Compute a CID without uploading (standalone helper -- async, returns a CID object)
+const cid = await calculateCid(data);
 
-// Build gateway URL
-const url = client.gatewayUrl(cid);
+// Confirm a CID landed on-chain at a known block (pass the block from a store() receipt)
+const entry = await client.verifyStored(result.cid!.toString(), { block: result.blockNumber! });
 
 // Pre-flight authorization check
 const auth = await client.checkAuthorization(address);
+
+// Estimate the authorization (transactions + bytes) a payload needs
+const need = client.estimateAuthorization(data.length);
 ```
 
 ## Standalone Functions
@@ -122,23 +147,27 @@ For advanced use cases:
 
 ```ts
 import {
-  upload,
-  batchUpload,
-  computeCid,
   cidToPreimageKey,
   hashToCid,
-  getGateway,
-  fetchBytes,
-  fetchJson,
+  calculateCid,   // async; returns a CID object
+  queryBytes,     // container-only read (host preimage); throws CloudStorageHostUnavailableError standalone
+  queryJson,      // container-only read (host preimage); throws CloudStorageHostUnavailableError standalone
+  executeQuery,
+  resolveQueryStrategy,
 } from "@parity/product-sdk-cloud-storage";
 ```
 
+> `upload`, `batchUpload`, `cidExists`, `gatewayUrl`, `getGateway`, and static `computeCid`/`hashToCid` **no
+> longer exist**. Uploads go through the `store(...)` builder; CID computation is the standalone async
+> `calculateCid`; `fetchBytes`/`fetchJson` are `CloudStorageClient` instance methods (container-only, no
+> gateway argument).
+
 ## Common Mistakes
 
-1. **Passing a string to upload instead of Uint8Array**
-2. **Forgetting that only `"paseo"` has a live gateway**
-3. **Not handling batch failures** - `batchUpload` does NOT throw on individual failures
-4. **Omitting signer in standalone mode** - Falls back to Alice dev signer (testnet only)
+1. **Passing a string to `store()` instead of `Uint8Array`** - convert with `new TextEncoder().encode(...)`.
+2. **Forgetting that `create()` requires a signer** - every `store()` submits a transaction; use `createLazySigner` if no account is selected yet.
+3. **Treating `result.cid` as a string** - it's a `CID` object (or `undefined` for chunked-without-manifest); call `.toString()`.
+4. **Expecting reads to work standalone** - `fetchBytes`/`fetchJson`/`queryBytes` are container-only and throw `CloudStorageHostUnavailableError` outside a host.
 
 ## Reference Files
 

--- a/product-sdk/skills/product-sdk-cloud-storage/references/cloud-storage-api.md
+++ b/product-sdk/skills/product-sdk-cloud-storage/references/cloud-storage-api.md
@@ -6,64 +6,60 @@ Package: `@parity/product-sdk-cloud-storage`
 
 ### Static Methods
 
-#### `CloudStorageClient.create(env)`
+#### `CloudStorageClient.create(options)`
 
 ```ts
-static async create(env: Environment): Promise<CloudStorageClient>
+static async create(options: CreateCloudStorageClientOptions): Promise<CloudStorageClient>
 ```
 
-Create from an environment name.
+Create a client from an environment shorthand (`{ environment, signer }`) or an explicit network (`{ genesisHash, descriptor, signer }`). A `signer` is always required.
 
-#### `CloudStorageClient.from(api, gateway)`
+#### `CloudStorageClient.from(inner, api)`
 
 ```ts
-static from(api: CloudStorageApi, gateway: string): CloudStorageClient
+static from(inner: AsyncBulletinClient, api: CloudStorageApi): CloudStorageClient
 ```
 
-Create from explicit API and gateway.
-
-#### `CloudStorageClient.computeCid(data)`
-
-```ts
-static computeCid(data: Uint8Array): string
-```
-
-Compute CID without uploading.
-
-#### `CloudStorageClient.hashToCid(hexHash, hashCode?, codec?)`
-
-```ts
-static hashToCid(hexHash: `0x${string}`, hashCode?: HashAlgorithm, codec?: CidCodec): string
-```
-
-Reconstruct CID from on-chain hex hash.
+Construct from a pre-built upstream client + typed API. The caller owns the connection lifecycle.
 
 ### Instance Methods
 
-#### `client.upload(data, signer?, options?)`
+#### `client.store(data)`
 
 ```ts
-async upload(
-    data: Uint8Array,
-    signer?: PolkadotSigner,
-    options?: UploadOptions,
-): Promise<UploadResult>
+store(data: Uint8Array): StoreBuilder
 ```
 
-#### `client.batchUpload(items, signer?, options?)`
+Build a store transaction. See [`StoreBuilder`](#storebuilder) for chained options and `send()` / `sendUnsigned()`.
+
+#### `client.authorizeAccount(who, transactions, bytes)`
 
 ```ts
-async batchUpload(
-    items: BatchUploadItem[],
-    signer?: PolkadotSigner,
-    options?: BatchUploadOptions,
-): Promise<BatchUploadResult[]>
+authorizeAccount(who: string, transactions: number, bytes: bigint): AuthCallBuilder
 ```
 
-#### `client.checkAuthorization(address)`
+Authorize an account to store data (sudo required on most networks).
+
+#### `client.authorizePreimage(contentHash, maxSize)`
 
 ```ts
-async checkAuthorization(address: string): Promise<AuthorizationStatus>
+authorizePreimage(contentHash: Uint8Array, maxSize: bigint): AuthCallBuilder
+```
+
+Authorize content storage by hash (anyone can then store it fee-free via `store(...).sendUnsigned()`).
+
+#### `client.renew(block, index)`
+
+```ts
+renew(block: number, index: number): CallBuilder
+```
+
+Renew a stored transaction by `(block, index)` (e.g. from a `StoreResult`).
+
+#### `client.estimateAuthorization(dataSize)`
+
+```ts
+estimateAuthorization(dataSize: number): { transactions: number; bytes: number }
 ```
 
 #### `client.fetchBytes(cid, options?)`
@@ -72,33 +68,65 @@ async checkAuthorization(address: string): Promise<AuthorizationStatus>
 async fetchBytes(cid: string, options?: QueryOptions): Promise<Uint8Array>
 ```
 
+Container-only -- resolves via the host preimage lookup; **throws `CloudStorageHostUnavailableError` outside a container**.
+
 #### `client.fetchJson<T>(cid, options?)`
 
 ```ts
 async fetchJson<T>(cid: string, options?: QueryOptions): Promise<T>
 ```
 
-#### `client.cidExists(cid)`
+Container-only -- same semantics as `fetchBytes`.
+
+#### `client.checkAuthorization(address)`
 
 ```ts
-async cidExists(cid: string): Promise<boolean>
+async checkAuthorization(address: string): Promise<AuthorizationStatus>
 ```
 
-#### `client.gatewayUrl(cid)`
+#### `client.verifyStored(cid, options)`
 
 ```ts
-gatewayUrl(cid: string): string
+async verifyStored(cid: string, options: VerifyStoredOptions): Promise<ChainStoredEntry | null>
+```
+
+Confirm a CID was recorded on-chain at a known block (no byte fetch). `options.block` is required.
+
+#### `client.destroy()`
+
+```ts
+async destroy(): Promise<void>
+```
+
+---
+
+## StoreBuilder
+
+Returned by `client.store(data)` (re-exported from `@parity/bulletin-sdk`). Chainable -- each `with*` returns `this`:
+
+```ts
+withCodec(codec: CidCodec | number): this
+withHashAlgorithm(algorithm: HashAlgorithm): this
+withWaitFor(waitFor: WaitFor): this          // "in_block" | "finalized"
+withCallback(callback: ProgressCallback): this
+withChunkSize(chunkSize: number): this       // forces the chunked path
+withManifest(enabled: boolean): this         // DAG-PB manifest for chunked uploads (default: true)
+
+send(): Promise<StoreResult>                 // signed transaction
+sendUnsigned(): Promise<StoreResult>         // for preimage-pre-authorized content (fee-free)
 ```
 
 ---
 
 ## Standalone Functions
 
-### `computeCid(data)`
+### `calculateCid(data, cidCodec?, hashAlgorithm?)`
 
 ```ts
-function computeCid(data: Uint8Array): string
+async function calculateCid(data: Uint8Array, cidCodec?: number, hashAlgorithm?: HashAlgorithm): Promise<CID>
 ```
+
+Compute a CID without uploading. Async; returns a `CID` object (re-exported from `@parity/bulletin-sdk`).
 
 ### `cidToPreimageKey(cid)`
 
@@ -112,59 +140,96 @@ function cidToPreimageKey(cid: string): `0x${string}`
 function hashToCid(hexHash: `0x${string}`, hashCode?: HashAlgorithm, codec?: CidCodec): string
 ```
 
-### `getGateway(env)`
+Reconstruct a CID string from an on-chain hex hash.
+
+### `queryBytes(cid, options?)`
 
 ```ts
-function getGateway(env: Environment): string
+async function queryBytes(cid: string, options?: QueryOptions): Promise<Uint8Array>
 ```
 
-### `fetchBytes(cid, gateway, options?)`
+Container-only -- resolves via the host preimage lookup; **throws `CloudStorageHostUnavailableError` outside a container**. No gateway argument.
+
+### `queryJson<T>(cid, options?)`
 
 ```ts
-async function fetchBytes(cid: string, gateway: string, options?: FetchOptions): Promise<Uint8Array>
+async function queryJson<T>(cid: string, options?: QueryOptions): Promise<T>
 ```
 
-### `fetchJson<T>(cid, gateway, options?)`
+Container-only -- same semantics as `queryBytes`.
 
-```ts
-async function fetchJson<T>(cid: string, gateway: string, options?: FetchOptions): Promise<T>
-```
+> Also standalone: `executeQuery`, `resolveQueryStrategy`, `verifyStored`, `authorizeAccount`, `checkAuthorization`, `createLazySigner`, and the `@parity/bulletin-sdk` re-exports (`cidFromBytes`, `cidToBytes`, `convertCid`, `parseCid`, `getContentHash`, `estimateAuthorization`, etc.). **Removed:** `getGateway`, static/standalone `computeCid`.
 
 ---
 
 ## Types
 
+### `CloudStorageEnvironment`
+
+```ts
+type CloudStorageEnvironment = "paseo" | "summit"   // keyof typeof CloudStorageNetworks
+```
+
+The `environment` shorthand accepted by `create(...)`. Both `"paseo"` and `"summit"` are currently available.
+
 ### `Environment`
 
 ```ts
-type Environment = "polkadot" | "kusama" | "paseo"
+// re-exported from @parity/product-sdk-chain-client
+type Environment = "polkadot" | "kusama" | "paseo" | "summit"
 ```
 
-### `UploadResult`
+Broader chain-client union; `getChainAPI("polkadot" | "kusama")` currently throws "not yet available".
+
+### `CreateCloudStorageClientOptions`
 
 ```ts
-type UploadResult =
-    | { kind: "transaction"; cid: string; blockHash: string; gatewayUrl?: string }
-    | { kind: "preimage"; cid: string; preimageKey: string; gatewayUrl?: string }
+type CreateCloudStorageClientOptions =
+    | { signer: PolkadotSigner; config?: Partial<ClientConfig>; environment: CloudStorageEnvironment }
+    | {
+        signer: PolkadotSigner;
+        config?: Partial<ClientConfig>;
+        genesisHash: `0x${string}`;
+        descriptor: (typeof CloudStorageNetworks)[CloudStorageEnvironment]["descriptor"];   // PAPI bulletin descriptor
+      }
 ```
 
-### `BatchUploadItem`
+`signer` is required on both shapes.
+
+### `StoreResult`
 
 ```ts
-interface BatchUploadItem {
-    data: Uint8Array;
-    label: string;
+interface StoreResult {
+    cid?: CID;              // multiformats CID object; undefined for chunked-without-manifest
+    size: number;
+    blockNumber?: number;
+    extrinsicIndex?: number;   // needed for renew()
+    chunks?: ChunkDetails;
 }
 ```
 
-### `UploadOptions`
+### `QueryOptions`
 
 ```ts
-interface UploadOptions {
-    gateway?: string;
-    waitFor?: "best-block" | "finalized";
-    timeoutMs?: number;
-    onStatus?: (status: TxStatus) => void;
+interface QueryOptions {
+    lookupTimeoutMs?: number;   // per-lookup host preimage subscription timeout; default 30_000
+    noReassemble?: boolean;     // return raw manifest bytes without recursing into chunks; default false
+}
+```
+
+### `VerifyStoredOptions` / `ChainStoredEntry`
+
+```ts
+interface VerifyStoredOptions {
+    block: number;    // required -- pass the blockNumber from a store() receipt
+    index?: number;   // optional -- narrow to an exact slot
+}
+
+interface ChainStoredEntry {
+    block: number;
+    index: number;
+    size: number;
+    blockChunks: number;
 }
 ```
 


### PR DESCRIPTION
### Description

The `product-sdk-cloud-storage` skill (`SKILL.md` + `references/cloud-storage-api.md`) documented a **pre-builder API that no released version exposes** (verified against both installed `0.5.3` and source `0.6.0`). Updated the stale examples, and the read-side described a standalone IPFS-gateway fallback that doesn't exist. This rewrites both files against the current source.

### Changes

- Switched every example to the current `store()` upload builder.
- Removed APIs that no longer exist: `upload`, `batchUpload`, `computeCid`, `cidExists`, `gatewayUrl`, `getGateway`.
- Made clear that reads only work inside a host container — no IPFS-gateway fallback.
- Fixed the environments list to `"paseo" | "summit"`.
- Brought the API-reference types and signatures in line with the source.

### Verification

- Docs/comments only - **no behavior change**. 
- Every documented symbol, signature, and enum value was checked against `packages/cloud-storage/src/{client,index,networks,types,verify,cid}.ts` and the `@parity/bulletin-sdk@0.3.0` d.ts. 