### PR TITLE
fix(host): make @novasamatech/* runtime deps

### DIFF
--- a/product-sdk/packages/host/package.json
+++ b/product-sdk/packages/host/package.json
@@ -20,24 +20,13 @@
         "clean": "rm -rf dist"
     },
     "dependencies": {
+        "@novasamatech/host-api": "catalog:",
+        "@novasamatech/host-api-wrapper": "catalog:",
         "@parity/product-sdk-logger": "workspace:*",
         "polkadot-api": "catalog:"
     },
-    "peerDependencies": {
-        "@novasamatech/host-api-wrapper": ">=0.8.0",
-        "@novasamatech/host-api": ">=0.8.0"
-    },
-    "peerDependenciesMeta": {
-        "@novasamatech/host-api-wrapper": {
-            "optional": true
-        },
-        "@novasamatech/host-api": {
-            "optional": true
-        }
-    },
     "devDependencies": {
-        "@novasamatech/host-api-wrapper": "catalog:",
-        "@novasamatech/host-api": "catalog:",
+        "tsup": "catalog:",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
     },

--- a/product-sdk/packages/host/tsup.config.ts
+++ b/product-sdk/packages/host/tsup.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
     define: {
         "import.meta.vitest": "undefined",
     },
-    // Mark novasama packages as external since they're optional peer dependencies
-    // that are dynamically imported or re-exported
+    // Mark novasama packages as external: they're runtime dependencies that are
+    // dynamically imported (host-api-wrapper) or statically re-exported (host-api),
+    // resolved from the consumer's node_modules rather than bundled.
     external: ["@novasamatech/host-api-wrapper", "@novasamatech/host-api"],
 });

--- a/product-sdk/pending-changesets/host-novasama-runtime-deps.md
+++ b/product-sdk/pending-changesets/host-novasama-runtime-deps.md
@@ -1,0 +1,14 @@
+---
+"@parity/product-sdk-host": minor
+"@parity/product-sdk": minor
+---
+
+**Make `@novasamatech/*` runtime dependencies instead of optional peer dependencies.**
+
+`@parity/product-sdk-host` now declares `@novasamatech/host-api` and
+`@novasamatech/host-api-wrapper` as regular `dependencies` (via the existing `catalog:`
+range) rather than optional `peerDependencies`. `host-api` was always required at runtime
+— its `enumValue` is statically imported by the published bundle — so the optional-peer
+declaration was incorrect; `host-api-wrapper` is loaded lazily by the host bridge and is
+now pulled transitively too. Consumers can reach the host APIs purely through
+`@parity/product-sdk-host` with no direct `@novasamatech/*` dependency of their own.

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -91,7 +91,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -113,7 +113,7 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -128,7 +128,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -150,7 +150,7 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -165,7 +165,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -187,7 +187,7 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -215,7 +215,7 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -249,7 +249,7 @@ importers:
         version: link:../../packages/contracts
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -265,13 +265,13 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -293,7 +293,7 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
@@ -321,7 +321,7 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -352,7 +352,7 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-address':
         specifier: workspace:*
         version: link:../../packages/address
@@ -370,7 +370,7 @@ importers:
         version: link:../../packages/tx
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -414,7 +414,7 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -430,7 +430,7 @@ importers:
     dependencies:
       '@parity/bulletin-sdk':
         specifier: ^0.3.0
-        version: 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2))
+        version: 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2))
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../chain-client
@@ -451,7 +451,7 @@ importers:
         version: 13.4.2
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -482,7 +482,7 @@ importers:
         version: 0.0.30
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
       viem:
         specifier: 'catalog:'
         version: 2.52.0(typescript@5.9.3)
@@ -523,7 +523,7 @@ importers:
     dependencies:
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.8.3
@@ -531,19 +531,22 @@ importers:
 
   packages/host:
     dependencies:
-      '@parity/product-sdk-logger':
-        specifier: workspace:*
-        version: link:../logger
-      polkadot-api:
-        specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
-    devDependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+      '@parity/product-sdk-logger':
+        specifier: workspace:*
+        version: link:../logger
+      polkadot-api:
+        specifier: 'catalog:'
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+    devDependencies:
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -573,7 +576,7 @@ importers:
         version: 2.2.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
       scale-ts:
         specifier: ^1.6.1
         version: 1.6.1
@@ -650,7 +653,7 @@ importers:
         version: link:../tx
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -684,7 +687,7 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -701,13 +704,13 @@ importers:
         version: 0.8.7-2
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
 
   packages/statement-store:
     dependencies:
       '@novasamatech/sdk-statement':
         specifier: 'catalog:'
-        version: 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.6.0(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../host
@@ -722,11 +725,11 @@ importers:
         version: 0.7.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)
@@ -750,10 +753,10 @@ importers:
         version: 2.2.0
       '@novasamatech/host-papp':
         specifier: ^0.8.7-2
-        version: 0.8.7-2(esbuild@0.27.7)
+        version: 0.8.7-2(esbuild@0.25.12)
       '@novasamatech/statement-store':
         specifier: ^0.8.7-2
-        version: 0.8.7-2(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.7-2(esbuild@0.25.12)(rxjs@7.8.2)
       '@novasamatech/storage-adapter':
         specifier: ^0.8.7-2
         version: 0.8.7-2
@@ -780,7 +783,7 @@ importers:
         version: 8.2.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -817,7 +820,7 @@ importers:
         version: 0.0.30
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -3931,14 +3934,14 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@novasamatech/host-api-wrapper@0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
+  '@novasamatech/host-api-wrapper@0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)':
     dependencies:
       '@novasamatech/host-api': 0.8.7-2
       '@polkadot-api/json-rpc-provider-proxy': 0.4.0
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
       neverthrow: 8.2.0
-      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@polkadot/api'
       - '@polkadot/util'
@@ -3964,21 +3967,21 @@ snapshots:
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
-  '@novasamatech/host-papp@0.8.7-2(esbuild@0.27.7)':
+  '@novasamatech/host-papp@0.8.7-2(esbuild@0.25.12)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
       '@novasamatech/host-api': 0.8.7-2
       '@novasamatech/scale': 0.8.7-2
-      '@novasamatech/statement-store': 0.8.7-2(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/statement-store': 0.8.7-2(esbuild@0.25.12)(rxjs@7.8.2)
       '@novasamatech/storage-adapter': 0.8.7-2
       '@polkadot-api/utils': 0.4.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
       nanoevents: 9.1.0
       nanoid: 5.1.11
       neverthrow: 8.2.0
-      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
       rxjs: 7.8.2
       scale-ts: 1.6.1
     transitivePeerDependencies:
@@ -3997,11 +4000,11 @@ snapshots:
       '@polkadot-api/utils': 0.4.0
       scale-ts: 1.6.1
 
-  '@novasamatech/sdk-statement@0.6.0(esbuild@0.27.7)(rxjs@7.8.2)':
+  '@novasamatech/sdk-statement@0.6.0(esbuild@0.25.12)(rxjs@7.8.2)':
     dependencies:
       '@polkadot-api/substrate-bindings': 0.20.1
       '@polkadot-api/utils': 0.4.0
-      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -4009,12 +4012,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/statement-store@0.8.7-2(esbuild@0.27.7)(rxjs@7.8.2)':
+  '@novasamatech/statement-store@0.8.7-2(esbuild@0.25.12)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
       '@novasamatech/scale': 0.8.7-2
-      '@novasamatech/sdk-statement': 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/sdk-statement': 0.6.0(esbuild@0.25.12)(rxjs@7.8.2)
       '@novasamatech/substrate-slot-sr25519-wasm': 0.8.7-2
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot-api/substrate-client': 0.7.0
@@ -4023,7 +4026,7 @@ snapshots:
       '@scure/sr25519': 2.2.0
       nanoid: 5.1.11
       neverthrow: 8.2.0
-      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
       scale-ts: 1.6.1
     transitivePeerDependencies:
       - bufferutil
@@ -4039,14 +4042,14 @@ snapshots:
 
   '@novasamatech/substrate-slot-sr25519-wasm@0.8.7-2': {}
 
-  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2))':
+  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2))':
     dependencies:
       '@ipld/dag-pb': 4.1.5
       '@noble/hashes': 2.2.0
       '@polkadot-labs/hdkd-helpers': 0.0.29
       ipfs-unixfs: 12.0.2
       multiformats: 13.4.2
-      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
 
   '@parity/host-api-test-sdk@0.9.0(@playwright/test@1.60.0)':
     dependencies:
@@ -4058,7 +4061,7 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
-  '@polkadot-api/cli@0.21.4(esbuild@0.27.7)':
+  '@polkadot-api/cli@0.21.4(esbuild@0.25.12)':
     dependencies:
       '@commander-js/extra-typings': 15.0.0(commander@15.0.0)
       '@polkadot-api/codegen': 0.22.5
@@ -4082,7 +4085,7 @@ snapshots:
       ora: 9.4.0
       read-pkg: 10.1.0
       rollup: 4.61.0
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.7)(rollup@4.61.0)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.61.0)
       rxjs: 7.8.2
       tsc-prog: 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -5560,9 +5563,9 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2):
+  polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2):
     dependencies:
-      '@polkadot-api/cli': 0.21.4(esbuild@0.27.7)
+      '@polkadot-api/cli': 0.21.4(esbuild@0.25.12)
       '@polkadot-api/ink-contracts': 0.6.3
       '@polkadot-api/json-rpc-provider': 0.2.0
       '@polkadot-api/known-chains': 0.11.5
@@ -5674,11 +5677,11 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.61.0):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.25.12)(rollup@4.61.0):
     dependencies:
       debug: 4.4.3
       es-module-lexer: 1.7.0
-      esbuild: 0.27.7
+      esbuild: 0.25.12
       get-tsconfig: 4.14.0
       rollup: 4.61.0
       unplugin-utils: 0.2.5


### PR DESCRIPTION
### Summary

`@parity/product-sdk-host` declared both `@novasamatech/host-api` and `@novasamatech/host-api-wrapper` as **optional `peerDependencies`**. This PR moves them to regular **`dependencies`** (via the existing `catalog:` range) and removes the `peerDependencies` / `peerDependenciesMeta` blocks and the redundant `devDependencies` entries. Also adds `tsup` to `devDependencies` (`catalog:`) so the package's own `build` script resolves it without relying on root hoisting — matching the other tsup-built packages.

### Why

- **`@novasamatech/host-api` was always required, not optional.** The shipped `dist/index.js` statically imports `enumValue` from it (line 2; also in `container.ts` and `truapi.ts`). Marking it an *optional* peer is incorrect - a consumer that omitted it would crash on `import '@parity/product-sdk-host'`.
- **`@novasamatech/host-api-wrapper`** is the host bridge, loaded lazily via `await import(...)`. As a regular dep it's still code-split (no main-bundle cost), and consumers no longer need to declare it.
- **Net effect:** host-embedded apps reach the host APIs purely through `@parity/product-sdk-host` with **no direct `@novasamatech/*` dependency** of their own.

### Singleton safety

The host-bridge transport must be a single instance. All product-sdk packages range `@novasamatech/* >=0.8.0` (catalog `^0.8.7-2`), so npm/pnpm dedupes to one hoisted copy - same single instance as the previous peer-hoisted layout.

### Heads-up for reviewers (version-pin tradeoff)

**Before:** `product-sdk-host` said *"I might need novasama, but I won't install it - the
app should bring its own version."* Each app picked its own.

**After:** `product-sdk-host` says *"I always need novasama, and I install this exact
version (`^0.8.7-2`) myself."* Every app using `product-sdk-host` now gets that version
handed to it automatically.

**The catch:** an app that already asks for a *different* novasama version would now have two requests in play - its own (`0.6.1`) and the one `product-sdk-host` brings (`0.8.7-2`). The package manager can't merge two versions, so it installs **both copies side by side**. That wastes space and can occasionally cause subtle bugs (two versions of the same library at once - e.g. the host "bridge" state split across them).


**Why it's fine:** those apps should be on the standard catalog version anyway; the fix doesn't break them, it just makes a pre-existing version mismatch visible. Please check whether any consumer ends up with a duplicate novasama after this and nudge it onto `^0.8.7-2`. This is a "glance and confirm," not a blocker.

### Testing

- `pnpm --filter @parity/product-sdk-host build`: dist still externalizes novasama.
- Throwaway consumer depending only on `@parity/product-sdk-host` (no novasama declared): novasama resolves transitively; `getTruApi` / `enumValue` work.
- `pnpm -r build` / `pnpm -r test` green.