### PR TITLE
feat(catalog): bump @novasamatech/host-api family to stable 0.8.7

### DIFF
--- a/product-sdk/packages/terminal/package.json
+++ b/product-sdk/packages/terminal/package.json
@@ -35,9 +35,9 @@
         "@noble/ciphers": "^2.1.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.2.0",
-        "@novasamatech/host-papp": "^0.8.7-2",
-        "@novasamatech/statement-store": "^0.8.7-2",
-        "@novasamatech/storage-adapter": "^0.8.7-2",
+        "@novasamatech/host-papp": "^0.8.7",
+        "@novasamatech/statement-store": "^0.8.7",
+        "@novasamatech/storage-adapter": "^0.8.7",
         "@parity/product-sdk-logger": "workspace:*",
         "@polkadot-api/substrate-bindings": "^0.20.2",
         "@polkadot-api/utils": "^0.4.0",
@@ -50,7 +50,7 @@
         "scale-ts": "^1.6.1"
     },
     "devDependencies": {
-        "@novasamatech/substrate-slot-sr25519-wasm": "^0.8.7-2",
+        "@novasamatech/substrate-slot-sr25519-wasm": "^0.8.7",
         "@types/qrcode": "^1.5.5",
         "tsup": "catalog:",
         "typescript": "catalog:",

--- a/product-sdk/pending-changesets/bump-novasama-0.8.7-stable.md
+++ b/product-sdk/pending-changesets/bump-novasama-0.8.7-stable.md
@@ -1,0 +1,19 @@
+---
+"@parity/product-sdk-terminal": patch
+"@parity/product-sdk-host": patch
+"@parity/product-sdk-signer": patch
+"@parity/product-sdk-statement-store": patch
+---
+
+**Bump `@novasamatech/host-api` family from `^0.8.7-2` to `^0.8.7` (stable).**
+
+Stable `0.8.7` is now published across the family (`host-api`, `host-api-wrapper`, `host-papp`, `statement-store`, `storage-adapter`, `substrate-slot-sr25519-wasm`). This bump removes the prerelease specifier from the published artifact — consumers see a cleaner semver range and get the same upstream code we've been testing against.
+
+### Delta vs `0.8.7-2`
+
+- **`MAX_SSO_REQUEST_SIZE` raised** in `host-papp`: 256 KiB → 500 KiB. Larger Mobile-SSO statements now flow without splitting.
+- **`ExpiryTooLowError` / `AccountFullError` constructors** in `statement-store` accept `bigint` instead of `number`. Internal — our code doesn't construct these directly.
+- **New additive exports** in `statement-store`: `PRIORITY_EPOCH_OFFSET`, `createExpiryAllocator`, `ExpiryAllocator`, `submitWithRetry`, `isPriorityTooLow`, `SubmitRetryOptions`, `signAndSubmitStatement`, `submitStatementOnce`, `SubmitStatementParams`. Not consumed by product-sdk; opt-in for downstream callers.
+- **No session/secrets codec changes.** The `testing.ts` codec mirror in `@parity/product-sdk-terminal` continues to round-trip through the real `SsoSessionManager` and `UserSecretRepository` against 0.8.7 — both interop tests pass.
+
+No public API change on the product-sdk side; no migration needed.

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@novasamatech/host-api':
-      specifier: ^0.8.7-2
-      version: 0.8.7-2
+      specifier: ^0.8.7
+      version: 0.8.7
     '@novasamatech/host-api-wrapper':
-      specifier: ^0.8.7-2
-      version: 0.8.7-2
+      specifier: ^0.8.7
+      version: 0.8.7
     '@novasamatech/sdk-statement':
       specifier: ^0.6.0
       version: 0.6.0
@@ -73,10 +73,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -91,7 +91,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -110,10 +110,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -128,7 +128,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -147,10 +147,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -165,7 +165,7 @@ importers:
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -184,10 +184,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -212,10 +212,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -249,7 +249,7 @@ importers:
         version: link:../../packages/contracts
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -262,16 +262,16 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -290,10 +290,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
@@ -318,10 +318,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -349,10 +349,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-address':
         specifier: workspace:*
         version: link:../../packages/address
@@ -370,7 +370,7 @@ importers:
         version: link:../../packages/tx
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
@@ -414,7 +414,7 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -430,7 +430,7 @@ importers:
     dependencies:
       '@parity/bulletin-sdk':
         specifier: ^0.3.0
-        version: 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2))
+        version: 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2))
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../chain-client
@@ -451,7 +451,7 @@ importers:
         version: 13.4.2
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -482,7 +482,7 @@ importers:
         version: 0.0.30
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       viem:
         specifier: 'catalog:'
         version: 2.52.0(typescript@5.9.3)
@@ -523,7 +523,7 @@ importers:
     dependencies:
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.8.3
@@ -533,16 +533,16 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-logger':
         specifier: workspace:*
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -576,7 +576,7 @@ importers:
         version: 2.2.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       scale-ts:
         specifier: ^1.6.1
         version: 1.6.1
@@ -653,7 +653,7 @@ importers:
         version: link:../tx
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -687,7 +687,7 @@ importers:
         version: link:../logger
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -701,16 +701,16 @@ importers:
     optionalDependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.7-2
+        version: 0.8.7
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
 
   packages/statement-store:
     dependencies:
       '@novasamatech/sdk-statement':
         specifier: 'catalog:'
-        version: 0.6.0(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../host
@@ -725,11 +725,11 @@ importers:
         version: 0.7.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)
@@ -752,14 +752,14 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@novasamatech/host-papp':
-        specifier: ^0.8.7-2
-        version: 0.8.7-2(esbuild@0.25.12)
+        specifier: ^0.8.7
+        version: 0.8.7(esbuild@0.27.7)
       '@novasamatech/statement-store':
-        specifier: ^0.8.7-2
-        version: 0.8.7-2(esbuild@0.25.12)(rxjs@7.8.2)
+        specifier: ^0.8.7
+        version: 0.8.7(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/storage-adapter':
-        specifier: ^0.8.7-2
-        version: 0.8.7-2
+        specifier: ^0.8.7
+        version: 0.8.7
       '@parity/product-sdk-logger':
         specifier: workspace:*
         version: link:../logger
@@ -783,7 +783,7 @@ importers:
         version: 8.2.0
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -792,8 +792,8 @@ importers:
         version: 1.6.1
     devDependencies:
       '@novasamatech/substrate-slot-sr25519-wasm':
-        specifier: ^0.8.7-2
-        version: 0.8.7-2
+        specifier: ^0.8.7
+        version: 0.8.7
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.6
@@ -820,7 +820,7 @@ importers:
         version: 0.0.30
       polkadot-api:
         specifier: 'catalog:'
-        version: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -1425,35 +1425,29 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@novasamatech/host-api-wrapper@0.8.7-2':
-    resolution: {integrity: sha512-5ViapiRdi6Q8kp6KZigvxWT1SyyF9Zd4DW0tLd9iL5ehookIjlP7K4ZENwJFOm0q0nd+7TZG5u3yNJBzGkTniA==}
+  '@novasamatech/host-api-wrapper@0.8.7':
+    resolution: {integrity: sha512-dER9Nx+HFMvRIEQiG1wCfM196HtUnkRMXyUNPG8fqCOdcu4UIoTzZ1Msu1axi37Kj4z7q3uJIMhdPJkgC6paRA==}
 
-  '@novasamatech/host-api@0.8.6':
-    resolution: {integrity: sha512-DayCRwOncCcYO/Hc+pYQaBXsTYOn8h/2dl/hAFy1yVgG/LEBLcZrUmhUpotUFEhgWvfc0/KQa59P7T11H49AWA==}
+  '@novasamatech/host-api@0.8.7':
+    resolution: {integrity: sha512-Kjvo5Y3Ad8EGDQPfEUnotS9hPl2SOBHNavw2+I8t+wQDPYepSTNIQZxzKOF2iS8JXhHTVuwIiaM1AM/OvfS8+A==}
 
-  '@novasamatech/host-api@0.8.7-2':
-    resolution: {integrity: sha512-7PrCZ0hROTjB53RnEc2AJW955QSodzTmV70nrv+cDTcFitHqmA7yTKT6gmebHucAqsp+YmTMvT6DAsHTJ3ilzA==}
+  '@novasamatech/host-papp@0.8.7':
+    resolution: {integrity: sha512-og8wsnquiZIU+qJC1zzhGldujT1Jy9kB2psdpf94V2UkTa7BbkqFI9lBdI9n3gO2T7elTnFqf9rs/rrU2s7ZXQ==}
 
-  '@novasamatech/host-papp@0.8.7-2':
-    resolution: {integrity: sha512-bkaQIVHtxiJQtZH2pBBJ++dtNFuzE8NzEUbhkTkFogdOXPDmSbDE3lbRzfY/e5sfAA7pLyiFAzbE7P85icwWFQ==}
-
-  '@novasamatech/scale@0.8.6':
-    resolution: {integrity: sha512-XsiNMntDVUmwQYieowid2s5t1THk/Asb4JohmWOrIFetj5ZdaD8mjLCt42WTWxaZaJyYyCjjGBssnUbcLyTWFw==}
-
-  '@novasamatech/scale@0.8.7-2':
-    resolution: {integrity: sha512-iReejsNQVq4vqeZ6+VTVqPrshsdiP36lklRjlMYwN1bMbQiGqYxVF1INx03X8xNiTYNILPbjWQHgszMK67PzgQ==}
+  '@novasamatech/scale@0.8.7':
+    resolution: {integrity: sha512-t9p5YyXkGzXvUaT2mltgcnTHdt32XB3kodNEhWAty9uFZiVfwLB6PYNRsW/CHUviof7Gqqjgw/LrPZQmys8jdg==}
 
   '@novasamatech/sdk-statement@0.6.0':
     resolution: {integrity: sha512-NTqM+yS45iHgy87lVSWIpFozrTfCUWb7r4ZpsDtN1eFnfixXpDKpPXDWQsvPs+nh18r/jmoMgtlTjUltrS6mYQ==}
 
-  '@novasamatech/statement-store@0.8.7-2':
-    resolution: {integrity: sha512-pOdnJxGvfWT3oQcN8bMktcicqfWh9AwBZzOpgA5HgdmZE/ncBRlrMLnv4AibjWaX8zOJVS6gy7nY0vHGnV6S0Q==}
+  '@novasamatech/statement-store@0.8.7':
+    resolution: {integrity: sha512-vRlcTHpdI0UqUHq5lvWG4WhSTbbvf/fW7nfTJmF2k97pdI4bR0VPGlGdvHNyIKFHXx4OPQWGzA5Cdbf85d7sWA==}
 
-  '@novasamatech/storage-adapter@0.8.7-2':
-    resolution: {integrity: sha512-kR3cVH/v59KGOzD+3UCW5jCmmPCSjNuWg8GysoH3/+9cMhyOxcVYO+q6ykG50yxKK4ceFsZm8lz0YoEFKRVz5w==}
+  '@novasamatech/storage-adapter@0.8.7':
+    resolution: {integrity: sha512-cA8VL6ghEETja1Q4rt11/njW3mCvkT9HdgQo5Hv7WBrRTcyb0rV34sdQvsbr+PpLBem/xLYBRTXzOK518ce8ww==}
 
-  '@novasamatech/substrate-slot-sr25519-wasm@0.8.7-2':
-    resolution: {integrity: sha512-wvHJA0z0FO2ONWkJXyLtv7e7hst5lWmZIaGgTMnlkrOtmGNuERM6q5hognmlkHZHbmKNYajzqwjrDV0EMDR7AQ==}
+  '@novasamatech/substrate-slot-sr25519-wasm@0.8.7':
+    resolution: {integrity: sha512-FLjoXY05IBKGIF9KHO3488NFkSGBg5yqL8jl47VaC4YE8CiW5E5rxLRH55l0FXMnYPc8gdP/fvI7JH3wt6ac4g==}
 
   '@parity/bulletin-sdk@0.3.0':
     resolution: {integrity: sha512-sxVwBzyH/egXze1muPXbaGwQuOkP8efVB4Lxunshixf18gJ6WT2tedgUy08QOfQ1848BDQS4wVpRRQfPfb09/g==}
@@ -1595,8 +1589,8 @@ packages:
   '@polkadot-labs/hdkd@0.0.28':
     resolution: {integrity: sha512-LpdqtQRpcgZQ5Mr8J0ddMA5ZufsbI4W3KuJkVdoYMnSmWs4179LigDb1rTYAOtyCg2jWUjf7rWP0mGxQQvNrHw==}
 
-  '@polkadot-labs/schnorrkel-wasm@0.0.8':
-    resolution: {integrity: sha512-N5XuBPsabi2XLJiazwnMH7J3DrK2Zkv7P4T6SEebTsOrvONyDX8Ort2MutxPtJgTviRHZMs2xc+FmqDqDRCECA==}
+  '@polkadot-labs/schnorrkel-wasm@0.0.9':
+    resolution: {integrity: sha512-MWO28z29OgKihdXjybvbuECASAIu52KZfBMFNZtK7jeyoFvA8ZrpJzYxPgFaBIsk1hHM488q7EXHckaMnZ1xng==}
 
   '@polkadot/api-augment@16.5.6':
     resolution: {integrity: sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==}
@@ -3934,9 +3928,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@novasamatech/host-api-wrapper@0.8.7-2(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/host-api-wrapper@0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)':
     dependencies:
-      '@novasamatech/host-api': 0.8.7-2
+      '@novasamatech/host-api': 0.8.7
       '@polkadot-api/json-rpc-provider-proxy': 0.4.0
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
@@ -3951,37 +3945,46 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/host-api@0.8.6':
+  '@novasamatech/host-api-wrapper@0.8.7(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
-      '@novasamatech/scale': 0.8.6
+      '@novasamatech/host-api': 0.8.7
+      '@polkadot-api/json-rpc-provider-proxy': 0.4.0
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
+      neverthrow: 8.2.0
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@polkadot/api'
+      - '@polkadot/util'
+      - bufferutil
+      - esbuild
+      - rxjs
+      - supports-color
+      - utf-8-validate
+
+  '@novasamatech/host-api@0.8.7':
+    dependencies:
+      '@novasamatech/scale': 0.8.7
       nanoevents: 9.1.0
       nanoid: 5.1.11
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
-  '@novasamatech/host-api@0.8.7-2':
-    dependencies:
-      '@novasamatech/scale': 0.8.7-2
-      nanoevents: 9.1.0
-      nanoid: 5.1.11
-      neverthrow: 8.2.0
-      scale-ts: 1.6.1
-
-  '@novasamatech/host-papp@0.8.7-2(esbuild@0.25.12)':
+  '@novasamatech/host-papp@0.8.7(esbuild@0.27.7)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
-      '@novasamatech/host-api': 0.8.7-2
-      '@novasamatech/scale': 0.8.7-2
-      '@novasamatech/statement-store': 0.8.7-2(esbuild@0.25.12)(rxjs@7.8.2)
-      '@novasamatech/storage-adapter': 0.8.7-2
+      '@novasamatech/host-api': 0.8.7
+      '@novasamatech/scale': 0.8.7
+      '@novasamatech/statement-store': 0.8.7(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/storage-adapter': 0.8.7
       '@polkadot-api/utils': 0.4.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
       nanoevents: 9.1.0
       nanoid: 5.1.11
       neverthrow: 8.2.0
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       rxjs: 7.8.2
       scale-ts: 1.6.1
     transitivePeerDependencies:
@@ -3990,21 +3993,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/scale@0.8.6':
+  '@novasamatech/scale@0.8.7':
     dependencies:
       '@polkadot-api/utils': 0.4.0
       scale-ts: 1.6.1
 
-  '@novasamatech/scale@0.8.7-2':
-    dependencies:
-      '@polkadot-api/utils': 0.4.0
-      scale-ts: 1.6.1
-
-  '@novasamatech/sdk-statement@0.6.0(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/sdk-statement@0.6.0(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@polkadot-api/substrate-bindings': 0.20.1
       '@polkadot-api/utils': 0.4.0
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -4012,21 +4010,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/statement-store@0.8.7-2(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/statement-store@0.8.7(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      '@novasamatech/scale': 0.8.7-2
-      '@novasamatech/sdk-statement': 0.6.0(esbuild@0.25.12)(rxjs@7.8.2)
-      '@novasamatech/substrate-slot-sr25519-wasm': 0.8.7-2
+      '@novasamatech/scale': 0.8.7
+      '@novasamatech/sdk-statement': 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/substrate-slot-sr25519-wasm': 0.8.7
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot-api/substrate-client': 0.7.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
-      '@polkadot-labs/schnorrkel-wasm': 0.0.8
+      '@polkadot-labs/schnorrkel-wasm': 0.0.9
       '@scure/sr25519': 2.2.0
       nanoid: 5.1.11
       neverthrow: 8.2.0
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
       scale-ts: 1.6.1
     transitivePeerDependencies:
       - bufferutil
@@ -4035,25 +4033,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/storage-adapter@0.8.7-2':
+  '@novasamatech/storage-adapter@0.8.7':
     dependencies:
       nanoevents: 9.1.0
       neverthrow: 8.2.0
 
-  '@novasamatech/substrate-slot-sr25519-wasm@0.8.7-2': {}
+  '@novasamatech/substrate-slot-sr25519-wasm@0.8.7': {}
 
-  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2))':
+  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2))':
     dependencies:
       '@ipld/dag-pb': 4.1.5
       '@noble/hashes': 2.2.0
       '@polkadot-labs/hdkd-helpers': 0.0.29
       ipfs-unixfs: 12.0.2
       multiformats: 13.4.2
-      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.1.5(esbuild@0.27.7)(rxjs@7.8.2)
 
   '@parity/host-api-test-sdk@0.9.0(@playwright/test@1.60.0)':
     dependencies:
-      '@novasamatech/host-api': 0.8.6
+      '@novasamatech/host-api': 0.8.7
     optionalDependencies:
       '@playwright/test': 1.60.0
 
@@ -4086,6 +4084,41 @@ snapshots:
       read-pkg: 10.1.0
       rollup: 4.61.0
       rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.61.0)
+      rxjs: 7.8.2
+      tsc-prog: 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+      write-package: 7.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - esbuild
+      - supports-color
+      - utf-8-validate
+
+  '@polkadot-api/cli@0.21.4(esbuild@0.27.7)':
+    dependencies:
+      '@commander-js/extra-typings': 15.0.0(commander@15.0.0)
+      '@polkadot-api/codegen': 0.22.5
+      '@polkadot-api/ink-contracts': 0.6.3
+      '@polkadot-api/json-rpc-provider': 0.2.0
+      '@polkadot-api/known-chains': 0.11.5
+      '@polkadot-api/metadata-compatibility': 0.6.3
+      '@polkadot-api/observable-client': 0.18.7(rxjs@7.8.2)
+      '@polkadot-api/sm-provider': 0.3.5(@polkadot-api/smoldot@0.4.4)
+      '@polkadot-api/smoldot': 0.4.4
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot-api/substrate-client': 0.7.0
+      '@polkadot-api/utils': 0.4.0
+      '@polkadot-api/wasm-executor': 0.2.3
+      '@polkadot-api/ws-middleware': 0.3.4(rxjs@7.8.2)
+      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
+      '@types/node': 25.9.1
+      commander: 15.0.0
+      execa: 9.6.1
+      fs.promises.exists: 1.1.4
+      ora: 9.4.0
+      read-pkg: 10.1.0
+      rollup: 4.61.0
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.7)(rollup@4.61.0)
       rxjs: 7.8.2
       tsc-prog: 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -4292,7 +4325,7 @@ snapshots:
     dependencies:
       '@polkadot-labs/hdkd-helpers': 0.0.30
 
-  '@polkadot-labs/schnorrkel-wasm@0.0.8': {}
+  '@polkadot-labs/schnorrkel-wasm@0.0.9': {}
 
   '@polkadot/api-augment@16.5.6':
     dependencies:
@@ -5591,6 +5624,34 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2):
+    dependencies:
+      '@polkadot-api/cli': 0.21.4(esbuild@0.27.7)
+      '@polkadot-api/ink-contracts': 0.6.3
+      '@polkadot-api/json-rpc-provider': 0.2.0
+      '@polkadot-api/known-chains': 0.11.5
+      '@polkadot-api/logs-provider': 0.2.0
+      '@polkadot-api/metadata-builders': 0.14.3
+      '@polkadot-api/metadata-compatibility': 0.6.3
+      '@polkadot-api/observable-client': 0.18.7(rxjs@7.8.2)
+      '@polkadot-api/pjs-signer': 0.7.3
+      '@polkadot-api/polkadot-signer': 0.1.6
+      '@polkadot-api/signer': 0.3.3
+      '@polkadot-api/sm-provider': 0.3.5(@polkadot-api/smoldot@0.4.4)
+      '@polkadot-api/smoldot': 0.4.4
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot-api/substrate-client': 0.7.0
+      '@polkadot-api/utils': 0.4.0
+      '@polkadot-api/ws-middleware': 0.3.4(rxjs@7.8.2)
+      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
+      '@rx-state/core': 0.1.4(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - esbuild
+      - supports-color
+      - utf-8-validate
+
   postcss-load-config@6.0.1(postcss@8.5.15):
     dependencies:
       lilconfig: 3.1.3
@@ -5682,6 +5743,17 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       esbuild: 0.25.12
+      get-tsconfig: 4.14.0
+      rollup: 4.61.0
+      unplugin-utils: 0.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.61.0):
+    dependencies:
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      esbuild: 0.27.7
       get-tsconfig: 4.14.0
       rollup: 4.61.0
       unplugin-utils: 0.2.5

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -4,8 +4,8 @@ packages:
   - "scripts/bench-consumer"
 
 catalog:
-  "@novasamatech/host-api": ^0.8.7-2
-  "@novasamatech/host-api-wrapper": ^0.8.7-2
+  "@novasamatech/host-api": ^0.8.7
+  "@novasamatech/host-api-wrapper": ^0.8.7
   "@novasamatech/sdk-statement": ^0.6.0
   "@parity/host-api-test-sdk": ^0.9.0
   "@playwright/test": ^1.60.0


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                        
                                                            
  Stable `0.8.7` of the `@novasamatech/host-api` family is now published.                                                                                                                                                                           
  Bumps catalog + terminal pins from `^0.8.7-2` (prerelease) to `^0.8.7`
  (stable). Published consumers see a cleaner semver range; we get the                                                                                                                                                                              
  same code we've been testing against.                     
                                                                                                                                                                                                                                                    
  ## Delta vs 0.8.7-2                                       
                                                                                                                                                                                                                                                    
  - `host-papp` `MAX_SSO_REQUEST_SIZE`: 256 KiB → 500 KiB                                                                                                                                                                                           
  - `statement-store` `ExpiryTooLowError` / `AccountFullError` use
    `bigint` (internal)                                                                                                                                                                                                                             
  - New additive `statement-store` exports — not consumed by product-sdk
  - No session/secrets codec changes   