### PR TITLE
feat: verify DotNS identity signatures

### DIFF
--- a/product-sdk/packages/contracts/src/index.ts
+++ b/product-sdk/packages/contracts/src/index.ts
@@ -22,6 +22,11 @@ export {
     createContractRuntimeFromClient,
     ensureContractAccountMapped,
 } from "./runtime.js";
+export {
+    SYSTEM_PRECOMPILE_ADDRESS,
+    verifySr25519Signature,
+} from "./precompiles.js";
+export type { VerifySr25519SignatureArgs } from "./precompiles.js";
 export type {
     ContractRuntime,
     ContractRuntimeOptions,

--- a/product-sdk/packages/contracts/src/precompiles.ts
+++ b/product-sdk/packages/contracts/src/precompiles.ts
@@ -49,10 +49,30 @@ export async function verifySr25519Signature(
     runtime: ContractRuntime,
     args: VerifySr25519SignatureArgs,
 ): Promise<boolean> {
-    const signature = normalizeSignature(args.signature);
+    if (args.signature.length !== 64) {
+        throw new Error(`Expected 64-byte sr25519 signature, got ${args.signature.length} bytes`);
+    }
+    const signature = Array.from(args.signature, (byte) => {
+        if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
+            throw new Error(`Expected sr25519 signature bytes in range 0..255, got ${byte}`);
+        }
+        return byte;
+    });
+
     const message =
         typeof args.message === "string" ? new TextEncoder().encode(args.message) : args.message;
-    const publicKey = normalizeBytes32(args.publicKey, "publicKey");
+    let publicKey: HexString;
+    if (args.publicKey instanceof Uint8Array) {
+        if (args.publicKey.length !== 32) {
+            throw new Error(`Expected 32-byte publicKey, got ${args.publicKey.length} bytes`);
+        }
+        publicKey = bytesToHex(args.publicKey);
+    } else {
+        if (!/^0x[0-9a-fA-F]{64}$/.test(args.publicKey)) {
+            throw new Error("Expected 32-byte publicKey as 0x-prefixed hex");
+        }
+        publicKey = args.publicKey.toLowerCase() as HexString;
+    }
 
     const system = createContract(runtime, SYSTEM_PRECOMPILE_ADDRESS, SYSTEM_PRECOMPILE_ABI);
     const result = await system.sr25519Verify.query(signature, bytesToHex(message), publicKey, {
@@ -62,41 +82,17 @@ export async function verifySr25519Signature(
 
     if (!result.success) {
         throw new ContractError(
-            `sr25519Verify precompile call failed: ${stringifyUnknown(result.value)}`,
+            `sr25519Verify precompile call failed: ${
+                typeof result.value === "string"
+                    ? result.value
+                    : JSON.stringify(result.value, (_, v) =>
+                          typeof v === "bigint" ? v.toString() : v,
+                      )
+            }`,
         );
     }
 
     return Boolean(result.value);
-}
-
-function normalizeSignature(signature: Uint8Array | readonly number[]): number[] {
-    if (signature.length !== 64) {
-        throw new Error(`Expected 64-byte sr25519 signature, got ${signature.length} bytes`);
-    }
-    return Array.from(signature, (byte) => {
-        if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
-            throw new Error(`Expected sr25519 signature bytes in range 0..255, got ${byte}`);
-        }
-        return byte;
-    });
-}
-
-function normalizeBytes32(value: Uint8Array | HexString, name: string): HexString {
-    if (value instanceof Uint8Array) {
-        if (value.length !== 32) {
-            throw new Error(`Expected 32-byte ${name}, got ${value.length} bytes`);
-        }
-        return bytesToHex(value);
-    }
-    if (!/^0x[0-9a-fA-F]{64}$/.test(value)) {
-        throw new Error(`Expected 32-byte ${name} as 0x-prefixed hex`);
-    }
-    return value.toLowerCase() as HexString;
-}
-
-function stringifyUnknown(value: unknown): string {
-    if (typeof value === "string") return value;
-    return JSON.stringify(value, (_, v) => (typeof v === "bigint" ? v.toString() : v));
 }
 
 if (import.meta.vitest) {

--- a/product-sdk/packages/contracts/src/precompiles.ts
+++ b/product-sdk/packages/contracts/src/precompiles.ts
@@ -1,0 +1,168 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+import type { HexString, SS58String } from "polkadot-api";
+import { bytesToHex, hexToBytes } from "viem";
+import { ContractError } from "./errors.js";
+import { createContract } from "./manager.js";
+import type { AbiEntry } from "./types.js";
+import type { ContractDryRunAt, ContractRuntime } from "./runtime.js";
+
+/** pallet-revive system precompile address. */
+export const SYSTEM_PRECOMPILE_ADDRESS = "0x0000000000000000000000000000000000000900" as HexString;
+
+const SYSTEM_PRECOMPILE_ABI = [
+    {
+        type: "function",
+        name: "sr25519Verify",
+        inputs: [
+            { name: "signature", type: "uint8[64]" },
+            { name: "message", type: "bytes" },
+            { name: "publicKey", type: "bytes32" },
+        ],
+        outputs: [{ name: "", type: "bool" }],
+        stateMutability: "view",
+    },
+] satisfies AbiEntry[];
+
+export interface VerifySr25519SignatureArgs {
+    /** 64-byte sr25519 signature. */
+    signature: Uint8Array | readonly number[];
+    /** Message bytes that were signed. Strings are UTF-8 encoded. */
+    message: Uint8Array | string;
+    /** 32-byte sr25519 public key. */
+    publicKey: Uint8Array | HexString;
+    /** Optional dry-run origin. Defaults to the contracts query fallback origin. */
+    origin?: SS58String;
+    /** Optional block target for the dry-run. */
+    at?: ContractDryRunAt;
+}
+
+/**
+ * Verify an sr25519 signature through pallet-revive's system precompile.
+ *
+ * This calls `sr25519Verify(uint8[64],bytes,bytes32)` on
+ * `0x0000000000000000000000000000000000000900` using a read-only
+ * `ReviveApi.call` dry-run. A cryptographically invalid signature returns
+ * `false`; runtime/precompile call failures are surfaced as errors.
+ */
+export async function verifySr25519Signature(
+    runtime: ContractRuntime,
+    args: VerifySr25519SignatureArgs,
+): Promise<boolean> {
+    const signature = normalizeSignature(args.signature);
+    const message =
+        typeof args.message === "string" ? new TextEncoder().encode(args.message) : args.message;
+    const publicKey = normalizeBytes32(args.publicKey, "publicKey");
+
+    const system = createContract(runtime, SYSTEM_PRECOMPILE_ADDRESS, SYSTEM_PRECOMPILE_ABI);
+    const result = await system.sr25519Verify.query(signature, bytesToHex(message), publicKey, {
+        origin: args.origin,
+        at: args.at,
+    });
+
+    if (!result.success) {
+        throw new ContractError(
+            `sr25519Verify precompile call failed: ${stringifyUnknown(result.value)}`,
+        );
+    }
+
+    return Boolean(result.value);
+}
+
+function normalizeSignature(signature: Uint8Array | readonly number[]): number[] {
+    if (signature.length !== 64) {
+        throw new Error(`Expected 64-byte sr25519 signature, got ${signature.length} bytes`);
+    }
+    return Array.from(signature, (byte) => {
+        if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
+            throw new Error(`Expected sr25519 signature bytes in range 0..255, got ${byte}`);
+        }
+        return byte;
+    });
+}
+
+function normalizeBytes32(value: Uint8Array | HexString, name: string): HexString {
+    if (value instanceof Uint8Array) {
+        if (value.length !== 32) {
+            throw new Error(`Expected 32-byte ${name}, got ${value.length} bytes`);
+        }
+        return bytesToHex(value);
+    }
+    if (!/^0x[0-9a-fA-F]{64}$/.test(value)) {
+        throw new Error(`Expected 32-byte ${name} as 0x-prefixed hex`);
+    }
+    return value.toLowerCase() as HexString;
+}
+
+function stringifyUnknown(value: unknown): string {
+    if (typeof value === "string") return value;
+    return JSON.stringify(value, (_, v) => (typeof v === "bigint" ? v.toString() : v));
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test, vi } = import.meta.vitest;
+
+    const dryRunBase = {
+        weight_consumed: { ref_time: 1n, proof_size: 1n },
+        weight_required: { ref_time: 1n, proof_size: 1n },
+        storage_deposit: { type: "Refund" as const, value: 0n },
+        max_storage_deposit: { type: "Refund" as const, value: 0n },
+        gas_consumed: 1n,
+    };
+
+    async function makeRuntime(value: boolean): Promise<ContractRuntime> {
+        const { encodeFunctionResult } = await import("viem");
+        const data = hexToBytes(
+            encodeFunctionResult({
+                abi: SYSTEM_PRECOMPILE_ABI,
+                functionName: "sr25519Verify",
+                result: value,
+            }),
+        );
+
+        return {
+            api: {} as ContractRuntime["api"],
+            dryRunCall: vi.fn(async () => ({
+                ...dryRunBase,
+                result: { success: true as const, value: { flags: 0, data } },
+            })),
+        };
+    }
+
+    describe("verifySr25519Signature", () => {
+        test("calls the system precompile and returns the decoded boolean", async () => {
+            const runtime = await makeRuntime(true);
+            const ok = await verifySr25519Signature(runtime, {
+                signature: new Uint8Array(64).fill(1),
+                message: "hello",
+                publicKey: new Uint8Array(32).fill(2),
+                at: "finalized",
+            });
+
+            expect(ok).toBe(true);
+            expect(runtime.dryRunCall).toHaveBeenCalledTimes(1);
+            expect(runtime.dryRunCall).toHaveBeenCalledWith(
+                expect.any(String),
+                SYSTEM_PRECOMPILE_ADDRESS,
+                0n,
+                undefined,
+                undefined,
+                expect.any(Uint8Array),
+                { at: "finalized" },
+            );
+        });
+
+        test("rejects invalid fixed byte lengths before calling the chain", async () => {
+            const runtime = await makeRuntime(false);
+            await expect(
+                verifySr25519Signature(runtime, {
+                    signature: new Uint8Array(63),
+                    message: new Uint8Array(),
+                    publicKey: new Uint8Array(32),
+                }),
+            ).rejects.toThrow(/64-byte sr25519 signature/);
+
+            expect(runtime.dryRunCall).not.toHaveBeenCalled();
+        });
+    });
+}

--- a/product-sdk/packages/sdk/src/core/createApp.ts
+++ b/product-sdk/packages/sdk/src/core/createApp.ts
@@ -30,7 +30,11 @@ import {
     isConnected,
     destroyAll,
 } from "@parity/product-sdk-chain-client";
-import { accountIdHexToBytes, resolvePeopleUsernameOwner } from "../identity/dotns.js";
+import {
+    accountIdHexToBytes,
+    resolvePeopleUsernameOwner,
+    verifyDotNsIdentitySignature,
+} from "../identity/dotns.js";
 
 const log = createLogger("app");
 
@@ -314,6 +318,8 @@ function createWalletApi(signerManager: SignerManager): WalletApi {
                 );
             }
         },
+
+        verifyDotNsIdentitySignature,
 
         onAccountChange(callback: (account: Account | null) => void): () => void {
             accountChangeSubscribers.add(callback);

--- a/product-sdk/packages/sdk/src/core/types.ts
+++ b/product-sdk/packages/sdk/src/core/types.ts
@@ -7,7 +7,7 @@
 import type { LogLevel } from "@parity/product-sdk-logger";
 import type { CloudStorageEnvironment } from "@parity/product-sdk-cloud-storage";
 import type { ChainClient } from "@parity/product-sdk-chain-client";
-import type { PeopleUsernameChain } from "../identity/dotns.js";
+import type { PeopleUsernameChain, VerifyDotNsIdentitySignatureArgs } from "../identity/dotns.js";
 import type { ChainDefinition, TypedApi, PolkadotClient } from "polkadot-api";
 
 export type { LogLevel };
@@ -58,6 +58,11 @@ export interface WalletApi {
     signMessageWithDotNsIdentity(
         args: SignMessageWithDotNsIdentityArgs,
     ): Promise<DotNsIdentitySignature>;
+    /**
+     * Verify a DotNS / People username identity signature through the
+     * pallet-revive sr25519 system precompile.
+     */
+    verifyDotNsIdentitySignature(args: VerifyDotNsIdentitySignatureArgs): Promise<boolean>;
     /** Subscribe to account changes */
     onAccountChange(callback: (account: Account | null) => void): () => void;
     /** Get product-scoped account (container mode only) */
@@ -198,6 +203,8 @@ export interface DotNsIdentitySignature {
     /** Signature bytes returned by the host wallet. */
     signature: Uint8Array;
 }
+
+export type { VerifyDotNsIdentitySignatureArgs };
 
 // Re-export ChainDefinition from polkadot-api for convenience
 export type { ChainDefinition, TypedApi, PolkadotClient } from "polkadot-api";

--- a/product-sdk/packages/sdk/src/identity/dotns.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns.ts
@@ -8,6 +8,11 @@
 
 import { accountIdBytes } from "@parity/product-sdk-address";
 import { createChainClient } from "@parity/product-sdk-chain-client";
+import {
+    createContractRuntimeFromClient,
+    verifySr25519Signature,
+    type ContractDryRunAt,
+} from "@parity/product-sdk-contracts";
 import { bytesToHex, hexToBytes } from "@parity/product-sdk-crypto";
 import { createLogger } from "@parity/product-sdk-logger";
 import type {
@@ -47,6 +52,29 @@ export type PeopleUsernameChain = ChainDefinition & {
 };
 
 type GetPeopleUsernameOwner = (username: Uint8Array) => Promise<SS58String | undefined>;
+
+/** Arguments for verifying a DotNS / People username identity signature. */
+export interface VerifyDotNsIdentitySignatureArgs {
+    /** PAPI descriptor for the People / Individuality chain containing `Resources.UsernameOwnerOf`. */
+    peopleChain: PeopleUsernameChain;
+    /** PAPI descriptor for the pallet-revive chain exposing the system precompile. */
+    reviveChain: ChainDefinition;
+    /** People / People Lite username to resolve before verifying. */
+    username: string;
+    /** Message that was signed. Strings are UTF-8 encoded before verification. */
+    message: string | Uint8Array;
+    /** Signature bytes returned by the host wallet. */
+    signature: Uint8Array;
+    /**
+     * Optional expected owner AccountId32. When supplied, verification returns
+     * false if the username no longer resolves to this account.
+     */
+    accountId?: `0x${string}`;
+    /** Optional dry-run origin. Defaults to the contracts query fallback origin. */
+    origin?: SS58String;
+    /** Optional block target for the precompile dry-run. */
+    at?: ContractDryRunAt;
+}
 
 /**
  * Check if a string is a valid DotNS name
@@ -152,6 +180,39 @@ export async function resolvePeopleUsernameOwner<TPeopleChain extends PeopleUser
     if (!owner) return null;
 
     return accountIdBytesToHex(accountIdBytes(owner));
+}
+
+/**
+ * Verify that a signature was produced by the current owner of a DotNS /
+ * People username.
+ *
+ * The username owner is resolved from `Resources.UsernameOwnerOf` on the
+ * provided People / Individuality chain. The sr25519 signature check itself is
+ * delegated to pallet-revive's `sr25519Verify` system precompile on the
+ * provided Revive-capable chain.
+ */
+export async function verifyDotNsIdentitySignature(
+    args: VerifyDotNsIdentitySignatureArgs,
+): Promise<boolean> {
+    const resolvedAccountId = await resolvePeopleUsernameOwner(args.username, args.peopleChain);
+    if (!resolvedAccountId) return false;
+
+    if (
+        args.accountId !== undefined &&
+        assertHex(args.accountId).toLowerCase() !== resolvedAccountId.toLowerCase()
+    ) {
+        return false;
+    }
+
+    const client = await createChainClient({ chains: { revive: args.reviveChain } });
+    const runtime = createContractRuntimeFromClient(client.raw.revive, args.reviveChain);
+    return verifySr25519Signature(runtime, {
+        signature: args.signature,
+        message: args.message,
+        publicKey: accountIdHexToBytes(resolvedAccountId),
+        origin: args.origin,
+        at: args.at,
+    });
 }
 
 function assertHex(value: string): `0x${string}` {

--- a/product-sdk/packages/sdk/src/identity/index.ts
+++ b/product-sdk/packages/sdk/src/identity/index.ts
@@ -16,8 +16,9 @@ export {
     isDotNsAvailable,
     accountIdHexToBytes,
     resolvePeopleUsernameOwner,
+    verifyDotNsIdentitySignature,
 } from "./dotns.js";
-export type { PeopleUsernameChain } from "./dotns.js";
+export type { PeopleUsernameChain, VerifyDotNsIdentitySignatureArgs } from "./dotns.js";
 
 // Context alias utilities
 export {

--- a/product-sdk/packages/sdk/src/index.ts
+++ b/product-sdk/packages/sdk/src/index.ts
@@ -38,6 +38,7 @@ export type {
     Account,
     DotNsIdentitySignature,
     SignMessageWithDotNsIdentityArgs,
+    VerifyDotNsIdentitySignatureArgs,
     ChainClient,
     ChainDefinition,
     TypedApi,

--- a/product-sdk/packages/sdk/src/react/useWallet.ts
+++ b/product-sdk/packages/sdk/src/react/useWallet.ts
@@ -10,6 +10,7 @@ import type {
     Account,
     DotNsIdentitySignature,
     SignMessageWithDotNsIdentityArgs,
+    VerifyDotNsIdentitySignatureArgs,
 } from "../core/types.js";
 
 /** Wallet hook state */
@@ -40,6 +41,8 @@ export interface UseWalletActions {
     signMessageWithDotNsIdentity: (
         args: SignMessageWithDotNsIdentityArgs,
     ) => Promise<DotNsIdentitySignature>;
+    /** Verify a DotNS / People username identity signature. */
+    verifyDotNsIdentitySignature: (args: VerifyDotNsIdentitySignatureArgs) => Promise<boolean>;
 }
 
 /** Return type of useWallet */
@@ -137,6 +140,13 @@ export function useWallet(): UseWalletReturn {
         [app],
     );
 
+    const verifyDotNsIdentitySignature = useCallback(
+        async (args: VerifyDotNsIdentitySignatureArgs) => {
+            return app.wallet.verifyDotNsIdentitySignature(args);
+        },
+        [app],
+    );
+
     // Subscribe to account changes
     useEffect(() => {
         const unsubscribe = app.wallet.onAccountChange((account) => {
@@ -152,5 +162,6 @@ export function useWallet(): UseWalletReturn {
         selectAccount,
         signMessage,
         signMessageWithDotNsIdentity,
+        verifyDotNsIdentitySignature,
     };
 }


### PR DESCRIPTION
## Summary
- add a low-level sr25519 signature verification helper that calls pallet-revive's system precompile at 0x0000000000000000000000000000000000000900
- add DotNS identity signature verification that resolves the current username owner and verifies the signature against that AccountId32
- expose the verifier through app.wallet, @parity/product-sdk/identity, and the React wallet hook
