### PR TITLE
feat(signer,sdk): sign DotNS identity via explicit legacy signer

### DIFF
--- a/product-sdk/packages/sdk/src/core/createApp.ts
+++ b/product-sdk/packages/sdk/src/core/createApp.ts
@@ -315,21 +315,32 @@ function createWalletApi(signerManager: SignerManager): WalletApi {
             }
 
             const owner = accountIdHexToBytes(accountId);
-            const account = signerManager
+
+            // Prefer an account that's already connected (no extra host prompt).
+            // Otherwise sign with the owner as an explicitly-named legacy signer.
+            //
+            // The owning account is frequently NOT enumerable: Proof-of-Personhood
+            // / product-account hosts expose only a per-dapp derived account via
+            // the connected-accounts list, never the user's identity account that
+            // actually owns the DotNS / People username. Such hosts can still sign
+            // with that account when it's named explicitly (typically behind a
+            // user-approval prompt), so we route through the legacy-signer path
+            // instead of failing. This is what makes DotNS identity signing work
+            // on those hosts at all.
+            const connected = signerManager
                 .getState()
                 .accounts.find((candidate) => bytesEqual(candidate.publicKey, owner));
-            if (!account) {
-                throw new Error(
-                    `DotNS username "${username}" resolves to ${accountId}, but no connected wallet account matches that AccountId.`,
-                );
-            }
 
             try {
-                return {
-                    username,
-                    accountId,
-                    signature: await account.getSigner().signBytes(message),
-                };
+                let signature: Uint8Array;
+                if (connected) {
+                    signature = await connected.getSigner().signBytes(message);
+                } else {
+                    const result = await signerManager.signRawWithLegacyAccount(owner, message);
+                    if (!result.ok) throw new Error(result.error.message);
+                    signature = result.value;
+                }
+                return { username, accountId, signature };
             } catch (cause) {
                 throw new Error(
                     `Failed to sign with DotNS username "${username}": ${

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -498,6 +498,43 @@ export class HostProvider implements SignerProvider {
         }
     }
 
+    /**
+     * Sign a raw message with a specific account identified by its public key,
+     * via the host's legacy-account signing path.
+     *
+     * Unlike `connect()`, this does NOT require the account to be returned by
+     * `getLegacyAccounts()` — it signs through `host_sign_raw_with_legacy_account`
+     * using the SS58 address derived from `publicKey`, which the host resolves
+     * itself. Hosts that withhold the user's identity account from *enumeration*
+     * (e.g. Proof-of-Personhood / product-account hosts that only expose a
+     * per-dapp derived account) may still honour an explicitly-named signer,
+     * typically behind a user-approval prompt.
+     *
+     * This is what makes DotNS-identity signing work on such hosts: the owning
+     * account resolved from the name is never enumerable, but it can still be
+     * named explicitly here. See {@link SignerManager.signRawWithLegacyAccount}.
+     *
+     * Requires a prior successful `connect()` call.
+     */
+    async signRawWithLegacyAccount(
+        publicKey: Uint8Array,
+        data: Uint8Array,
+    ): Promise<Result<Uint8Array, SignerError>> {
+        if (!this.accountsProvider) {
+            return err(new HostUnavailableError("Host provider is not connected"));
+        }
+
+        try {
+            const signature = await this.legacySignerFor(publicKey).signBytes(data);
+            return ok(signature);
+        } catch (cause) {
+            log.error("failed to sign with legacy account", { cause });
+            return err(
+                new HostRejectedError(`Host rejected legacy-account signing: ${formatError(cause)}`),
+            );
+        }
+    }
+
     // ── Private ──────────────────────────────────────────────────────
 
     private async tryConnect(): Promise<Result<SignerAccount[], SignerError>> {
@@ -709,6 +746,25 @@ export class HostProvider implements SignerProvider {
         return ok({ ...account, name: account.name ?? primaryUsername });
     }
 
+    /**
+     * Build a `PolkadotSigner` for the account with the given public key via the
+     * host's legacy-account signing path. The host resolves the SS58 address
+     * from `publicKey`; `dotNsIdentifier` / `derivationIndex` are unused for
+     * legacy accounts (the host-api shape just reuses the product-account
+     * struct). Shared by `mapAccounts` (enumerated accounts) and
+     * `signRawWithLegacyAccount` (an explicitly-named, non-enumerated account).
+     */
+    private legacySignerFor(publicKey: Uint8Array): import("polkadot-api").PolkadotSigner {
+        if (!this.accountsProvider) {
+            throw new Error("Host provider is disconnected");
+        }
+        return this.accountsProvider.getLegacyAccountSigner({
+            dotNsIdentifier: "",
+            derivationIndex: 0,
+            publicKey,
+        });
+    }
+
     private mapAccounts(rawAccounts: ReadonlyArray<RawAccount>): SignerAccount[] {
         return rawAccounts.map((raw) => {
             const address = ss58Encode(raw.publicKey, this.ss58Prefix);
@@ -719,16 +775,7 @@ export class HostProvider implements SignerProvider {
                 publicKey: raw.publicKey,
                 name: raw.name ?? null,
                 source: "host" as const,
-                getSigner: () => {
-                    if (!this.accountsProvider) {
-                        throw new Error("Host provider is disconnected");
-                    }
-                    return this.accountsProvider.getLegacyAccountSigner({
-                        dotNsIdentifier: "",
-                        derivationIndex: 0,
-                        publicKey: raw.publicKey,
-                    });
-                },
+                getSigner: () => this.legacySignerFor(raw.publicKey),
             };
         });
     }

--- a/product-sdk/packages/signer/src/signer-manager.ts
+++ b/product-sdk/packages/signer/src/signer-manager.ts
@@ -436,6 +436,33 @@ export class SignerManager {
     }
 
     /**
+     * Sign a raw message with a specific account named by its public key, via
+     * the host's legacy-account signing path. Only available when connected via
+     * the host provider — returns HOST_UNAVAILABLE otherwise.
+     *
+     * Unlike the connect-time account list, the named account does NOT need to
+     * be enumerable via `getLegacyAccounts()`. This is the building block for
+     * signing with a DotNS / People identity account that the host exposes for
+     * signing but not for enumeration.
+     */
+    async signRawWithLegacyAccount(
+        publicKey: Uint8Array,
+        data: Uint8Array,
+    ): Promise<Result<Uint8Array, SignerError>> {
+        if (this.isDestroyed) return err(new DestroyedError());
+
+        const host = this.getHostProvider();
+        if (!host) {
+            return err(
+                new HostUnavailableError(
+                    "Signing with a legacy account requires a host provider connection",
+                ),
+            );
+        }
+        return host.signRawWithLegacyAccount(publicKey, data);
+    }
+
+    /**
      * Destroy the manager and release all resources.
      *
      * **Terminal** — clears all subscribers, cancels in-flight work, and


### PR DESCRIPTION
Stacks on #212 (`feat/dotns-identity-signing`) — merge that first; this targets its branch.

## Problem

`signMessageWithDotNsIdentity` resolves the username → owner `AccountId`, then signs by finding that account in the **connected-accounts list**. On Proof-of-Personhood / product-account hosts (e.g. Polkadot Desktop) the host exposes only a per-dapp **product account** and never *enumerates* the user's identity account — so the owner is never found and signing fails with:

> DotNS username "…" resolves to …, but no connected wallet account matches that AccountId.

That makes DotNS-identity signing unusable on exactly the hosts the product targets.

## Fix

Probing Polkadot Desktop confirmed these hosts will still sign with an account when it is **named explicitly** via `host_sign_raw_with_legacy_account`, even though they withhold it from `getLegacyAccounts()` enumeration. So:

- **`HostProvider.signRawWithLegacyAccount(publicKey, data)`** — signs with an account named by public key, via a shared `legacySignerFor(publicKey)` helper now also used by `mapAccounts` (dedupes the legacy-account construction).
- **`SignerManager.signRawWithLegacyAccount(publicKey, data)`** — thin delegation, mirrors `getUserId` / `createRingVRFProof`.
- **`signMessageWithDotNsIdentity`** now prefers an already-connected account (no extra prompt) and otherwise signs via the explicit legacy signer, instead of throwing when the owner isn't enumerable.

## Validation

- Probed inside Polkadot Desktop: the identity account that owns the People username is withheld from `getLegacyAccounts()` enumeration but signs when named explicitly — the case this PR unblocks.
- `tsc --noEmit` clean for `signer` + `sdk`; existing signer suite passes (102/102).
- Dedicated unit tests for the new path are a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)