### PR TITLE
chore: bump triangle-js to 0.8.9

### DIFF
--- a/product-sdk/packages/terminal/package.json
+++ b/product-sdk/packages/terminal/package.json
@@ -35,9 +35,9 @@
         "@noble/ciphers": "^2.1.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.2.0",
-        "@novasamatech/host-papp": "^0.8.8",
-        "@novasamatech/statement-store": "^0.8.8",
-        "@novasamatech/storage-adapter": "^0.8.8",
+        "@novasamatech/host-papp": "^0.8.9",
+        "@novasamatech/statement-store": "^0.8.9",
+        "@novasamatech/storage-adapter": "^0.8.9",
         "@parity/product-sdk-logger": "workspace:*",
         "@polkadot-api/substrate-bindings": "^0.20.2",
         "@polkadot-api/utils": "^0.4.0",
@@ -50,7 +50,7 @@
         "scale-ts": "^1.6.1"
     },
     "devDependencies": {
-        "@novasamatech/substrate-slot-sr25519-wasm": "^0.8.8",
+        "@novasamatech/substrate-slot-sr25519-wasm": "^0.8.9",
         "@types/qrcode": "^1.5.5",
         "tsup": "catalog:",
         "typescript": "catalog:",

--- a/product-sdk/pending-changesets/bump-novasamatech-0-8-9.md
+++ b/product-sdk/pending-changesets/bump-novasamatech-0-8-9.md
@@ -1,0 +1,15 @@
+---
+"@parity/product-sdk-host": patch
+"@parity/product-sdk-signer": patch
+"@parity/product-sdk-statement-store": patch
+"@parity/product-sdk-terminal": patch
+---
+
+chore(deps): bump @novasamatech/* host SDKs to 0.8.9
+
+Update the upstream host-API SDKs to the 0.8.9 release:
+
+- catalog: `@novasamatech/host-api` and `@novasamatech/host-api-wrapper` `^0.8.8` → `^0.8.9`
+- terminal: `@novasamatech/host-papp`, `@novasamatech/statement-store`, `@novasamatech/storage-adapter`, and `@novasamatech/substrate-slot-sr25519-wasm` `^0.8.8` → `^0.8.9`
+
+`@novasamatech/sdk-statement` is unaffected (separate package, latest is 0.6.0).

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@novasamatech/host-api':
-      specifier: ^0.8.8
-      version: 0.8.8
+      specifier: ^0.8.9
+      version: 0.8.9
     '@novasamatech/host-api-wrapper':
-      specifier: ^0.8.8
-      version: 0.8.8
+      specifier: ^0.8.9
+      version: 0.8.9
     '@novasamatech/sdk-statement':
       specifier: ^0.6.0
       version: 0.6.0
@@ -73,10 +73,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -110,10 +110,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -147,10 +147,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-chain-client':
         specifier: workspace:*
         version: link:../../packages/chain-client
@@ -184,10 +184,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -212,10 +212,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -262,10 +262,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
@@ -290,10 +290,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-signer':
         specifier: workspace:*
         version: link:../../packages/signer
@@ -318,10 +318,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)
       '@parity/product-sdk-host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -349,10 +349,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-address':
         specifier: workspace:*
         version: link:../../packages/address
@@ -533,10 +533,10 @@ importers:
     dependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-logger':
         specifier: workspace:*
         version: link:../logger
@@ -701,10 +701,10 @@ importers:
     optionalDependencies:
       '@novasamatech/host-api':
         specifier: 'catalog:'
-        version: 0.8.8
+        version: 0.8.9
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
 
   packages/statement-store:
     dependencies:
@@ -729,7 +729,7 @@ importers:
     devDependencies:
       '@novasamatech/host-api-wrapper':
         specifier: 'catalog:'
-        version: 0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
+        version: 0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)
@@ -752,14 +752,14 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@novasamatech/host-papp':
-        specifier: ^0.8.8
-        version: 0.8.8(esbuild@0.27.7)
+        specifier: ^0.8.9
+        version: 0.8.9(esbuild@0.27.7)
       '@novasamatech/statement-store':
-        specifier: ^0.8.8
-        version: 0.8.8(esbuild@0.27.7)(rxjs@7.8.2)
+        specifier: ^0.8.9
+        version: 0.8.9(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/storage-adapter':
-        specifier: ^0.8.8
-        version: 0.8.8
+        specifier: ^0.8.9
+        version: 0.8.9
       '@parity/product-sdk-logger':
         specifier: workspace:*
         version: link:../logger
@@ -792,8 +792,8 @@ importers:
         version: 1.6.1
     devDependencies:
       '@novasamatech/substrate-slot-sr25519-wasm':
-        specifier: ^0.8.8
-        version: 0.8.8
+        specifier: ^0.8.9
+        version: 0.8.9
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.6
@@ -1425,29 +1425,29 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@novasamatech/host-api-wrapper@0.8.8':
-    resolution: {integrity: sha512-/ym2kK9pPubq3iyJettReNb6R4YnfJwDbcdz4Hlxz7uVKu3+XxjqjLgEGb6klPcC+N+0f6bmFB3JSUo6QXHTzw==}
+  '@novasamatech/host-api-wrapper@0.8.9':
+    resolution: {integrity: sha512-4ofzbg/9J78sGsvNX9nmei5dyE7nw7+LeYsXG6rURTBjy0LyPSmR8wCfMmxOGxUTTE7BnzIloNInC/3aksfktw==}
 
-  '@novasamatech/host-api@0.8.8':
-    resolution: {integrity: sha512-dTO5tQGJnyy6SOZaR1Z6+yzH2CmJp8wcZScVF1HHqqeMe1uVWcioyTH6jf9Rw46U01uLaa5unembuNmJIOC2ew==}
+  '@novasamatech/host-api@0.8.9':
+    resolution: {integrity: sha512-KPh81iVv3sQckq7/oyRpFF2uYBPXJD0+7cRuXO+lnWPAxQBXK1aNUQzSq+vJUHkcGRXJd0up/IlHJ4DMfQyUhQ==}
 
-  '@novasamatech/host-papp@0.8.8':
-    resolution: {integrity: sha512-WNHHP3rkUkAB/6Ddm4zc1wywrwVjRC/2eWWLDol7uz8WKbWZnB8tpmYGFmnWLZQttelpM7kIOp8Kg1Vd//wc/w==}
+  '@novasamatech/host-papp@0.8.9':
+    resolution: {integrity: sha512-Z1iENq/nn3e1P/4Mj0SS98yqO7tD8841G3xNGqO+O7tSnEjxDY4keS4uy4Rhx5hYIIRcUxe3xe1g/kUbJWVa+g==}
 
-  '@novasamatech/scale@0.8.8':
-    resolution: {integrity: sha512-cWg4RkrUoysc+q7zQnr2vC+JmcuRLZFft3ZITkq1U6d7wDAYGJjzTYGKLDxIe2HZ+mRhU7otFCz1aaFtBEu98w==}
+  '@novasamatech/scale@0.8.9':
+    resolution: {integrity: sha512-/Gt0KwfdkQZGyqd7e8YApx/QPMj/WDFrFYYOW5qxNWlbDpSUmYqNX+D1LECSokXw1vqE2m+ydBmNsAwyhJCLuQ==}
 
   '@novasamatech/sdk-statement@0.6.0':
     resolution: {integrity: sha512-NTqM+yS45iHgy87lVSWIpFozrTfCUWb7r4ZpsDtN1eFnfixXpDKpPXDWQsvPs+nh18r/jmoMgtlTjUltrS6mYQ==}
 
-  '@novasamatech/statement-store@0.8.8':
-    resolution: {integrity: sha512-2D71j3VzTIknlUlCfrnQG3l1lzxkZrASNh+w1dp0HClMrKhlcdSiZDGrPPRkVjcOi2zt3KSLH+i5+5EOuZ66Yw==}
+  '@novasamatech/statement-store@0.8.9':
+    resolution: {integrity: sha512-MCx9ah9vVoetU1+7BTU/85gUiUjirNqky4yy6ydKiYLgLAjMiRsGW02rjlngJ+4tnE0Xy3euuJcCI8FjOwMoSA==}
 
-  '@novasamatech/storage-adapter@0.8.8':
-    resolution: {integrity: sha512-q83gWxMUyooDZGDlriZ+NXFCk8MZHHCFJBiCXMMnAs6CzUAIlnFxyi8/PpUgXZUinEQCgpmKkEbx8hYMwKRdrw==}
+  '@novasamatech/storage-adapter@0.8.9':
+    resolution: {integrity: sha512-JXo6mfx0x9dZJzevKYD9MK6WxvlH5N9lBQegcSvWt3wpIniDriEUN8gmyJRkdbDdTZLwhmw1VM6mukM+RhJw1A==}
 
-  '@novasamatech/substrate-slot-sr25519-wasm@0.8.8':
-    resolution: {integrity: sha512-clW1YI19AXiR28/DT79IyoXL9MukJlkT2bOSfmuzwwVPZ3QYmkIZ7RUiz/74r7edy56W1rM8NK9F/s5bWAmwYQ==}
+  '@novasamatech/substrate-slot-sr25519-wasm@0.8.9':
+    resolution: {integrity: sha512-Y8tkYq7h9gGn0WwtxrdCjGBUdG+nVXEDzKDo+5WXe+MZI+kTc2zmhlaxXWe3f/gzqNktxKGEkJXyokB8b21buA==}
 
   '@parity/bulletin-sdk@0.3.0':
     resolution: {integrity: sha512-sxVwBzyH/egXze1muPXbaGwQuOkP8efVB4Lxunshixf18gJ6WT2tedgUy08QOfQ1848BDQS4wVpRRQfPfb09/g==}
@@ -3928,9 +3928,26 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@novasamatech/host-api-wrapper@0.8.8(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
+  '@novasamatech/host-api-wrapper@0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.25.12)(rxjs@7.8.2)':
     dependencies:
-      '@novasamatech/host-api': 0.8.8
+      '@novasamatech/host-api': 0.8.9
+      '@polkadot-api/json-rpc-provider-proxy': 0.4.0
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
+      neverthrow: 8.2.0
+      polkadot-api: 2.1.5(esbuild@0.25.12)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@polkadot/api'
+      - '@polkadot/util'
+      - bufferutil
+      - esbuild
+      - rxjs
+      - supports-color
+      - utf-8-validate
+
+  '@novasamatech/host-api-wrapper@0.8.9(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)':
+    dependencies:
+      '@novasamatech/host-api': 0.8.9
       '@polkadot-api/json-rpc-provider-proxy': 0.4.0
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
@@ -3945,23 +3962,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/host-api@0.8.8':
+  '@novasamatech/host-api@0.8.9':
     dependencies:
-      '@novasamatech/scale': 0.8.8
+      '@novasamatech/scale': 0.8.9
       nanoevents: 9.1.0
       nanoid: 5.1.11
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
-  '@novasamatech/host-papp@0.8.8(esbuild@0.27.7)':
+  '@novasamatech/host-papp@0.8.9(esbuild@0.27.7)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
-      '@novasamatech/host-api': 0.8.8
-      '@novasamatech/scale': 0.8.8
-      '@novasamatech/statement-store': 0.8.8(esbuild@0.27.7)(rxjs@7.8.2)
-      '@novasamatech/storage-adapter': 0.8.8
+      '@novasamatech/host-api': 0.8.9
+      '@novasamatech/scale': 0.8.9
+      '@novasamatech/statement-store': 0.8.9(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/storage-adapter': 0.8.9
       '@polkadot-api/utils': 0.4.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
       nanoevents: 9.1.0
@@ -3976,7 +3993,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/scale@0.8.8':
+  '@novasamatech/scale@0.8.9':
     dependencies:
       '@polkadot-api/utils': 0.4.0
       scale-ts: 1.6.1
@@ -3993,13 +4010,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/statement-store@0.8.8(esbuild@0.27.7)(rxjs@7.8.2)':
+  '@novasamatech/statement-store@0.8.9(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      '@novasamatech/scale': 0.8.8
+      '@novasamatech/scale': 0.8.9
       '@novasamatech/sdk-statement': 0.6.0(esbuild@0.27.7)(rxjs@7.8.2)
-      '@novasamatech/substrate-slot-sr25519-wasm': 0.8.8
+      '@novasamatech/substrate-slot-sr25519-wasm': 0.8.9
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot-api/substrate-client': 0.7.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
@@ -4016,12 +4033,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/storage-adapter@0.8.8':
+  '@novasamatech/storage-adapter@0.8.9':
     dependencies:
       nanoevents: 9.1.0
       neverthrow: 8.2.0
 
-  '@novasamatech/substrate-slot-sr25519-wasm@0.8.8': {}
+  '@novasamatech/substrate-slot-sr25519-wasm@0.8.9': {}
 
   '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2))':
     dependencies:
@@ -4034,13 +4051,48 @@ snapshots:
 
   '@parity/host-api-test-sdk@0.9.0(@playwright/test@1.60.0)':
     dependencies:
-      '@novasamatech/host-api': 0.8.8
+      '@novasamatech/host-api': 0.8.9
     optionalDependencies:
       '@playwright/test': 1.60.0
 
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@polkadot-api/cli@0.21.4(esbuild@0.25.12)':
+    dependencies:
+      '@commander-js/extra-typings': 15.0.0(commander@15.0.0)
+      '@polkadot-api/codegen': 0.22.5
+      '@polkadot-api/ink-contracts': 0.6.3
+      '@polkadot-api/json-rpc-provider': 0.2.0
+      '@polkadot-api/known-chains': 0.11.5
+      '@polkadot-api/metadata-compatibility': 0.6.3
+      '@polkadot-api/observable-client': 0.18.7(rxjs@7.8.2)
+      '@polkadot-api/sm-provider': 0.3.5(@polkadot-api/smoldot@0.4.4)
+      '@polkadot-api/smoldot': 0.4.4
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot-api/substrate-client': 0.7.0
+      '@polkadot-api/utils': 0.4.0
+      '@polkadot-api/wasm-executor': 0.2.3
+      '@polkadot-api/ws-middleware': 0.3.4(rxjs@7.8.2)
+      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
+      '@types/node': 25.9.1
+      commander: 15.0.0
+      execa: 9.6.1
+      fs.promises.exists: 1.1.4
+      ora: 9.4.0
+      read-pkg: 10.1.0
+      rollup: 4.61.0
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.61.0)
+      rxjs: 7.8.2
+      tsc-prog: 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+      write-package: 7.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - esbuild
+      - supports-color
+      - utf-8-validate
 
   '@polkadot-api/cli@0.21.4(esbuild@0.27.7)':
     dependencies:
@@ -5544,6 +5596,34 @@ snapshots:
 
   pngjs@5.0.0: {}
 
+  polkadot-api@2.1.5(esbuild@0.25.12)(rxjs@7.8.2):
+    dependencies:
+      '@polkadot-api/cli': 0.21.4(esbuild@0.25.12)
+      '@polkadot-api/ink-contracts': 0.6.3
+      '@polkadot-api/json-rpc-provider': 0.2.0
+      '@polkadot-api/known-chains': 0.11.5
+      '@polkadot-api/logs-provider': 0.2.0
+      '@polkadot-api/metadata-builders': 0.14.3
+      '@polkadot-api/metadata-compatibility': 0.6.3
+      '@polkadot-api/observable-client': 0.18.7(rxjs@7.8.2)
+      '@polkadot-api/pjs-signer': 0.7.3
+      '@polkadot-api/polkadot-signer': 0.1.6
+      '@polkadot-api/signer': 0.3.3
+      '@polkadot-api/sm-provider': 0.3.5(@polkadot-api/smoldot@0.4.4)
+      '@polkadot-api/smoldot': 0.4.4
+      '@polkadot-api/substrate-bindings': 0.20.3
+      '@polkadot-api/substrate-client': 0.7.0
+      '@polkadot-api/utils': 0.4.0
+      '@polkadot-api/ws-middleware': 0.3.4(rxjs@7.8.2)
+      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
+      '@rx-state/core': 0.1.4(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - esbuild
+      - supports-color
+      - utf-8-validate
+
   polkadot-api@2.1.5(esbuild@0.27.7)(rxjs@7.8.2):
     dependencies:
       '@polkadot-api/cli': 0.21.4(esbuild@0.27.7)
@@ -5657,6 +5737,17 @@ snapshots:
       signal-exit: 4.1.0
 
   reusify@1.1.0: {}
+
+  rollup-plugin-esbuild@6.2.1(esbuild@0.25.12)(rollup@4.61.0):
+    dependencies:
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      esbuild: 0.25.12
+      get-tsconfig: 4.14.0
+      rollup: 4.61.0
+      unplugin-utils: 0.2.5
+    transitivePeerDependencies:
+      - supports-color
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.61.0):
     dependencies:

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -4,8 +4,8 @@ packages:
   - "scripts/bench-consumer"
 
 catalog:
-  "@novasamatech/host-api": ^0.8.8
-  "@novasamatech/host-api-wrapper": ^0.8.8
+  "@novasamatech/host-api": ^0.8.9
+  "@novasamatech/host-api-wrapper": ^0.8.9
   "@novasamatech/sdk-statement": ^0.6.0
   "@parity/host-api-test-sdk": ^0.9.0
   "@playwright/test": ^1.60.0


### PR DESCRIPTION
Updates the upstream novasamatech host SDKs (triangle-js-sdks) from 0.8.8 to 0.8.9.

  ### Changes
  - **Catalog:** `host-api`, `host-api-wrapper` → `^0.8.9`
  - **`terminal`:** `host-papp`, `statement-store`, `storage-adapter`, `substrate-slot-sr25519-wasm` → `^0.8.9`

  Upstream 0.8.9 fixes a host-container bug where TruApi-routed transaction broadcasts were torn down before inclusion. `@novasamatech/sdk-statement` is unaffected. Patch changeset included.