### PR TITLE
fix(signer): derive product account from dappName instead of throwing NoAccountsError

### DIFF
--- a/product-sdk/examples/signer-demo/e2e/connect.spec.ts
+++ b/product-sdk/examples/signer-demo/e2e/connect.spec.ts
@@ -16,9 +16,12 @@ test.describe("@parity/product-sdk-signer — connect + subscribe", () => {
         // but we at least confirm connect() didn't throw.
         await expect(frame.locator('[data-testid="last-error"]')).toBeEmpty();
 
-        // Exactly two accounts (Bob + Charlie) from the fixture.
+        // Exactly one account: the host connect path no longer enumerates
+        // legacy accounts — it derives a single product account from the
+        // configured `dappName` ("signer-demo" → "signer-demo.dot/0", mapped
+        // to Bob by the fixture).
         const rows = frame.locator('[data-testid="accounts-list"] .account-row');
-        await expect(rows).toHaveCount(2);
+        await expect(rows).toHaveCount(1);
 
         // Selected account starts with the Paseo Asset Hub SS58 prefix.
         const selected = frame.locator('[data-testid="selected-address"]');

--- a/product-sdk/examples/signer-demo/e2e/onconnect.spec.ts
+++ b/product-sdk/examples/signer-demo/e2e/onconnect.spec.ts
@@ -41,10 +41,13 @@ test.describe("@parity/product-sdk-signer — onConnect lifecycle hook", () => {
         const subscribeBefore = parseInt((await subscribeCount.textContent()) ?? "0", 10);
         const transitionBefore = parseInt((await transitionCount.textContent()) ?? "0", 10);
 
-        // Click an account row — subscribe fires (selectedAccount changes),
-        // but neither status transition nor onConnect should advance.
+        // Click the account row — selectAccount() calls setState(), which
+        // notifies subscribers unconditionally (even when re-selecting the
+        // already-selected account), so subscribe fires. Neither a status
+        // transition nor onConnect should advance. (The host connect path
+        // surfaces a single product account, so there's only one row to click.)
         const rows = frame.locator('[data-testid="accounts-list"] .account-row');
-        await rows.nth(1).click();
+        await rows.nth(0).click();
 
         // Subscribe count must strictly increase; transition + onConnect stay put.
         await expect

--- a/product-sdk/examples/signer-demo/e2e/persistence.spec.ts
+++ b/product-sdk/examples/signer-demo/e2e/persistence.spec.ts
@@ -17,25 +17,20 @@ test.describe("@parity/product-sdk-signer — persistence", () => {
     }) => {
         const frame = await waitForAppReady(testHost);
 
-        // Default selection is the first account (Bob). Pick the second row
-        // (Charlie) explicitly so we can distinguish persistence from the
-        // "just pick the first account" fallback after hydration.
+        // The host connect path surfaces a single derived product account,
+        // which is auto-selected on connect. (We can no longer distinguish
+        // persistence from the "pick first" fallback by selecting a second
+        // account — enumeration is gone — but the storage round-trip below
+        // still proves the selection is persisted and re-hydrated on reload.)
         const rows = frame.locator('[data-testid="accounts-list"] .account-row');
-        await expect(rows).toHaveCount(2);
+        await expect(rows).toHaveCount(1);
 
-        // Capture Bob's address (default selection) before clicking anything.
-        const bobAddr = await frame
-            .locator('[data-testid="selected-address"]')
-            .textContent();
-        expect(bobAddr).toBeTruthy();
-
-        // Click Charlie's row. Wait for the selection to actually flip.
-        await rows.nth(1).click();
+        // Capture the selected (product) account, then re-select it so the
+        // persistence write fires deterministically.
         const selectedLoc = frame.locator('[data-testid="selected-address"]');
-        await expect(selectedLoc).not.toHaveText(bobAddr!);
+        await rows.nth(0).click();
         const beforeReload = await selectedLoc.textContent();
         expect(beforeReload).toBeTruthy();
-        expect(beforeReload).not.toBe(bobAddr);
 
         // Wait for SignerManager.persistAccount to flush through the
         // postMessage round-trip into host localStorage. Without this we

--- a/product-sdk/examples/signer-demo/e2e/switch-account.spec.ts
+++ b/product-sdk/examples/signer-demo/e2e/switch-account.spec.ts
@@ -4,28 +4,27 @@ import { test, expect } from "./fixtures";
 import { waitForAppReady } from "./helpers";
 
 test.describe("@parity/product-sdk-signer — testHost.switchAccount", () => {
-    test("account swap propagates through SignerManager.subscribe", async ({ testHost }) => {
+    test("host account switch keeps the dapp-scoped product account stable", async ({ testHost }) => {
         const frame = await waitForAppReady(testHost);
 
-        const bobAddress = await frame
+        const beforeAddress = await frame
             .locator('[data-testid="selected-address"]')
             .textContent();
-        expect(bobAddress).toBeTruthy();
+        expect(beforeAddress).toBeTruthy();
 
-        // Flip the host's active non-product account to Charlie. This
-        // re-creates the product-sdk container, which the signer's
-        // `HostProvider` picks up via `onAccountsChange` + its connection
-        // status subscription. A new SignerManager.connect() kicks off in
-        // main.ts via the reload, so we wait for the post-switch ready
-        // state before asserting.
+        // Flip the host's active account to Charlie. The host connect path
+        // derives a *dapp-scoped* product account ("signer-demo.dot/0"),
+        // not the host's currently-active identity account, so switching the
+        // host account must NOT change the account the signer surfaces — it
+        // re-derives the same product account and stays connected.
         await testHost.switchAccount("charlie");
         await waitForAppReady(testHost);
 
-        const charlieAddress = await frame
+        const afterAddress = await frame
             .locator('[data-testid="selected-address"]')
             .textContent();
-        expect(charlieAddress).toBeTruthy();
-        expect(charlieAddress).not.toEqual(bobAddress);
+        expect(afterAddress).toBeTruthy();
+        expect(afterAddress).toEqual(beforeAddress);
 
         // Status must still read "connected" after the swap.
         await expect(frame.locator('[data-testid="connection-status"]')).toHaveText("connected");

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -3,12 +3,7 @@
 import { deriveH160, ss58Encode } from "@parity/product-sdk-address";
 import { createLogger } from "@parity/product-sdk-logger";
 
-import {
-    HostRejectedError,
-    HostUnavailableError,
-    NoAccountsError,
-    type SignerError,
-} from "../errors.js";
+import { HostRejectedError, HostUnavailableError, type SignerError } from "../errors.js";
 import { withRetry } from "../retry.js";
 import type { ConnectionStatus, ProviderType, Result, SignerAccount } from "../types.js";
 import { err, ok } from "../types.js";
@@ -24,6 +19,22 @@ export interface HostProviderOptions {
     maxRetries?: number;
     /** Initial retry delay in ms. Default: 500 */
     retryDelay?: number;
+    /**
+     * Dapp identifier the SDK falls back to when {@link productAccount} is
+     * not set, so `connect()` can still surface a usable account on hosts
+     * that don't enumerate legacy accounts.
+     *
+     * The value is treated as a dotNS identifier (`.dot` is appended if
+     * missing) and routed through `getProductAccount(dappName, 0)`. If the
+     * host rejects the derivation (e.g. the identifier isn't registered),
+     * `connect()` resolves with an empty accounts list rather than
+     * throwing — consumers can still drive the explicit signing paths
+     * (`signMessageWithDotNsIdentity`, `getLegacyAccountSigner`).
+     *
+     * Wired through from `SignerManager` automatically; only set directly
+     * when instantiating `HostProvider` outside the manager.
+     */
+    dappName?: string;
     /**
      * Custom SDK loader. Defaults to `import("@novasamatech/host-api-wrapper")`.
      * Override this for testing or custom SDK setups.
@@ -147,7 +158,6 @@ const PRODUCT_SIGNER_TYPE = "createTransaction" as const;
 
 /** @internal */
 export interface AccountsProvider {
-    getLegacyAccounts: () => NeverthrowResultAsync<RawAccount[], unknown>;
     getLegacyAccountSigner: (account: ProductAccount) => import("polkadot-api").PolkadotSigner;
     getProductAccount: (
         dotNsIdentifier: string,
@@ -237,6 +247,7 @@ export class HostProvider implements SignerProvider {
     private readonly loadHostApiEnum: () => Promise<HostApiEnumHelper>;
     private readonly requestChainSubmitPermission: boolean;
     private readonly productAccount: HostProviderOptions["productAccount"];
+    private readonly dappName: string | undefined;
 
     private accountsProvider: AccountsProvider | null = null;
     private statusCleanup: (() => void) | null = null;
@@ -255,6 +266,7 @@ export class HostProvider implements SignerProvider {
             options?.requestTransactionSubmitPermission ??
             true;
         this.productAccount = options?.productAccount;
+        this.dappName = options?.dappName;
     }
 
     async connect(signal?: AbortSignal): Promise<Result<SignerAccount[], SignerError>> {
@@ -552,11 +564,23 @@ export class HostProvider implements SignerProvider {
 
         // Step 4: Fetch accounts.
         //
-        // When `productAccount` is configured, skip the legacy fetch entirely
-        // and return a single product account. Product-account-only apps
-        // (no wallet picker) often run against hosts that have no legacy
-        // accounts to surface — calling `getLegacyAccounts()` there returns
-        // an empty list and the connect would fail with `NoAccountsError`.
+        // Both branches end in `fetchProductSignerAccount`. The difference
+        // is only where the dotNS identifier comes from:
+        //  - explicit `productAccount` option (caller-supplied), OR
+        //  - implicit derivation from `dappName` (the SDK-managed default
+        //    for hosts that don't enumerate accounts, e.g. Polkadot Desktop).
+        //
+        // On hosts that don't enumerate accounts (PoP / product-account
+        // hosts), `getLegacyAccounts()` returns `[]` by design — the host
+        // exposes only per-dapp product accounts and never the user's
+        // identity account. The implicit derivation path matches that
+        // contract: derive the per-dapp account using the consumer's
+        // `dappName` as the identifier, surface it on `connect()`. When
+        // the host rejects the derivation (typically because the dapp's
+        // dotNS identifier isn't registered for this user), we resolve
+        // with an empty accounts list rather than throwing so consumers
+        // can still drive the explicit-name signing paths
+        // (`signMessageWithDotNsIdentity`, `getLegacyAccountSigner`).
         let signerAccounts: SignerAccount[];
         if (this.productAccount) {
             const accountResult = await this.fetchProductSignerAccount(
@@ -567,48 +591,44 @@ export class HostProvider implements SignerProvider {
             );
             if (!accountResult.ok) return accountResult;
             signerAccounts = [accountResult.value];
-        } else {
-            let rawAccounts: RawAccount[];
-            try {
-                rawAccounts = (await provider.getLegacyAccounts().match(
-                    (accounts) => accounts,
-                    (error) => {
-                        throw new Error(`Host rejected account request: ${formatError(error)}`);
+        } else if (this.dappName) {
+            // `.dot` is appended if missing so `"my-app"` and `"my-app.dot"`
+            // resolve to the same identifier on the host side.
+            const dotNsIdentifier = this.dappName.endsWith(".dot")
+                ? this.dappName
+                : `${this.dappName}.dot`;
+            const accountResult = await this.fetchProductSignerAccount(
+                provider,
+                dotNsIdentifier,
+                0,
+                true,
+            );
+            if (!accountResult.ok) {
+                // Soft-degrade: host couldn't derive a product account for
+                // this dappName (most commonly because the identifier isn't
+                // registered for this user). Returning [] lets `connect()`
+                // resolve successfully — consumers handle the empty list
+                // and drive explicit signing paths.
+                log.warn(
+                    "host could not derive a product account for dappName; resolving with empty accounts",
+                    {
+                        dotNsIdentifier,
+                        error: accountResult.error.message,
                     },
-                )) as RawAccount[];
-            } catch (cause) {
-                // Safety net: upstream `host-api/transport.js` throws
-                // `Error('Environment is not correct')` synchronously inside
-                // `getLegacyAccounts()` when the env check fails. The Step 2
-                // pre-check catches this normally, but we also re-classify
-                // here for older wrappers that don't expose `sandboxTransport`
-                // and for races where the env flips after the pre-check.
-                // Without this, the user sees a misleading "Host rejected
-                // account request:" prefix for an error nothing rejected.
-                if (cause instanceof Error && /environment is not correct/i.test(cause.message)) {
-                    log.warn("not inside a host container (detected at getLegacyAccounts)");
-                    return err(
-                        new HostUnavailableError(
-                            "Host API is not available: not running inside a Polkadot host container. " +
-                                "Open this app inside Polkadot Desktop or the Polkadot Mobile WebView, " +
-                                "or pick a non-host signer provider (e.g. dev accounts).",
-                        ),
-                    );
-                }
-                log.error("failed to get accounts from host", { cause });
-                return err(
-                    new HostRejectedError(
-                        cause instanceof Error ? cause.message : "Failed to get accounts from host",
-                    ),
                 );
+                signerAccounts = [];
+            } else {
+                signerAccounts = [accountResult.value];
             }
-
-            if (rawAccounts.length === 0) {
-                log.warn("host returned no accounts");
-                return err(new NoAccountsError("host"));
-            }
-
-            signerAccounts = this.mapAccounts(rawAccounts);
+        } else {
+            // No `productAccount`, no `dappName` — caller asked the SDK to
+            // pick accounts with no hints. We can't, so resolve with an
+            // empty list. Consumers driving explicit-name signing still
+            // work; consumers expecting enumeration get a clear `[]`.
+            log.warn(
+                "no productAccount or dappName configured; resolving connect() with empty accounts",
+            );
+            signerAccounts = [];
         }
 
         // Step 5: Request ChainSubmit permission up-front.
@@ -707,30 +727,6 @@ export class HostProvider implements SignerProvider {
         if (!accountResult.ok) return accountResult;
         const account = accountResult.value;
         return ok({ ...account, name: account.name ?? primaryUsername });
-    }
-
-    private mapAccounts(rawAccounts: ReadonlyArray<RawAccount>): SignerAccount[] {
-        return rawAccounts.map((raw) => {
-            const address = ss58Encode(raw.publicKey, this.ss58Prefix);
-            const h160Address = deriveH160(raw.publicKey);
-            return {
-                address,
-                h160Address,
-                publicKey: raw.publicKey,
-                name: raw.name ?? null,
-                source: "host" as const,
-                getSigner: () => {
-                    if (!this.accountsProvider) {
-                        throw new Error("Host provider is disconnected");
-                    }
-                    return this.accountsProvider.getLegacyAccountSigner({
-                        dotNsIdentifier: "",
-                        derivationIndex: 0,
-                        publicKey: raw.publicKey,
-                    });
-                },
-            };
-        });
     }
 }
 
@@ -948,92 +944,73 @@ if (import.meta.vitest) {
             expect(mockProvider.getLegacyAccounts).not.toHaveBeenCalled();
         });
 
-        test("safety net: re-classifies upstream 'Environment is not correct' as HOST_UNAVAILABLE", async () => {
-            // For older wrappers (or test mocks) that don't supply
-            // `sandboxTransport`, the Step 2 pre-check is skipped and the
-            // upstream throw surfaces at `getLegacyAccounts()`. The catch
-            // in Step 4 must re-classify it rather than wrapping with the
-            // misleading "Host rejected account request:" prefix.
+        test("connect with dappName fallback derives a product account", async () => {
+            // Without an explicit `productAccount`, the SDK derives the
+            // dotNS identifier from `dappName` (with `.dot` appended if
+            // missing). This is the path hosts that don't enumerate
+            // accounts (PoP / Polkadot Desktop) take by default.
+            const productPubkey = new Uint8Array(32).fill(0x42);
             const mockProvider = createMockProvider({
-                shouldReject: true,
-                error: "Environment is not correct",
+                accounts: [{ publicKey: productPubkey, name: undefined }],
+                primaryUsername: "alice",
             });
             const provider = new HostProvider({
                 maxRetries: 1,
-                // sandboxTransport intentionally omitted — exercises the
-                // safety-net path, not the pre-check path.
+                dappName: "my-cli",
                 loadSdk: () => Promise.resolve(createMockSdk(mockProvider)),
-            });
-            const result = await provider.connect();
-
-            expect(result.ok).toBe(false);
-            if (!result.ok) {
-                expect(result.error).toBeInstanceOf(HostUnavailableError);
-                // Must NOT contain the misleading "Host rejected account request:" prefix.
-                expect(result.error.message).not.toMatch(/Host rejected/i);
-                expect(result.error.message).toMatch(
-                    /not running inside a Polkadot host container/i,
-                );
-            }
-        });
-
-        test("connect proceeds when sandboxTransport reports a correct environment", async () => {
-            // Mirror of the existing happy path, but with an explicit
-            // `isCorrectEnvironment: true` to prove the pre-check doesn't
-            // false-fail when the env IS correct.
-            const rawAccounts: RawAccountTest[] = [
-                { publicKey: new Uint8Array(32).fill(0x42), name: "Alice" },
-            ];
-            const mockProvider = createMockProvider({ accounts: rawAccounts });
-            const provider = new HostProvider({
-                maxRetries: 1,
-                loadSdk: () =>
-                    Promise.resolve(createMockSdk(mockProvider, { isCorrectEnvironment: true })),
             });
             const result = await provider.connect();
 
             expect(result.ok).toBe(true);
             if (result.ok) {
                 expect(result.value).toHaveLength(1);
-                expect(result.value[0].address).toMatch(/^5/);
+                expect(result.value[0].publicKey).toEqual(productPubkey);
+                expect(result.value[0].source).toBe("host");
             }
-            expect(mockProvider.getLegacyAccounts).toHaveBeenCalled();
+            // `.dot` appended automatically.
+            expect(mockProvider.getProductAccount).toHaveBeenCalledWith("my-cli.dot", 0);
         });
 
-        test("returns HOST_REJECTED when getLegacyAccounts fails", async () => {
+        test("connect with dappName already ending in .dot doesn't double-append", async () => {
+            const productPubkey = new Uint8Array(32).fill(0x77);
+            const mockProvider = createMockProvider({
+                accounts: [{ publicKey: productPubkey, name: undefined }],
+            });
+            const provider = new HostProvider({
+                maxRetries: 1,
+                dappName: "my-cli.dot",
+                loadSdk: () => Promise.resolve(createMockSdk(mockProvider)),
+            });
+            const result = await provider.connect();
+
+            expect(result.ok).toBe(true);
+            expect(mockProvider.getProductAccount).toHaveBeenCalledWith("my-cli.dot", 0);
+        });
+
+        test("connect with dappName fallback resolves to [] when host rejects derivation", async () => {
+            // Soft-degrade: when the host can't derive a product account
+            // for the dappName (commonly because the dotNS identifier isn't
+            // registered for this user), connect() returns ok([]) rather
+            // than throwing. Consumers handle the empty list and drive
+            // explicit signing paths.
             const mockProvider = createMockProvider({ shouldReject: true, error: "Rejected" });
             const provider = new HostProvider({
                 maxRetries: 1,
+                dappName: "not-registered",
                 loadSdk: () => Promise.resolve(createMockSdk(mockProvider)),
             });
             const result = await provider.connect();
 
-            expect(result.ok).toBe(false);
-            if (!result.ok) {
-                expect(result.error).toBeInstanceOf(HostRejectedError);
+            expect(result.ok).toBe(true);
+            if (result.ok) {
+                expect(result.value).toEqual([]);
             }
         });
 
-        test("returns NO_ACCOUNTS when host returns empty list", async () => {
-            const mockProvider = createMockProvider({ accounts: [] });
-            const provider = new HostProvider({
-                maxRetries: 1,
-                loadSdk: () => Promise.resolve(createMockSdk(mockProvider)),
-            });
-            const result = await provider.connect();
-
-            expect(result.ok).toBe(false);
-            if (!result.ok) {
-                expect(result.error).toBeInstanceOf(NoAccountsError);
-            }
-        });
-
-        test("maps accounts correctly on success", async () => {
-            const rawAccounts: RawAccountTest[] = [
-                { publicKey: new Uint8Array(32).fill(0xaa), name: "Alice" },
-                { publicKey: new Uint8Array(32).fill(0xbb), name: undefined },
-            ];
-            const mockProvider = createMockProvider({ accounts: rawAccounts });
+        test("connect resolves to [] when neither productAccount nor dappName is set", async () => {
+            // Caller asked us to pick accounts with no hints. We can't, so
+            // resolve with an empty list rather than throwing.
+            const mockProvider = createMockProvider({});
             const provider = new HostProvider({
                 maxRetries: 1,
                 loadSdk: () => Promise.resolve(createMockSdk(mockProvider)),
@@ -1042,11 +1019,7 @@ if (import.meta.vitest) {
 
             expect(result.ok).toBe(true);
             if (result.ok) {
-                expect(result.value).toHaveLength(2);
-                expect(result.value[0].name).toBe("Alice");
-                expect(result.value[0].source).toBe("host");
-                expect(result.value[0].publicKey).toEqual(rawAccounts[0].publicKey);
-                expect(result.value[1].name).toBeNull();
+                expect(result.value).toEqual([]);
             }
         });
 

--- a/product-sdk/packages/signer/src/signer-manager.ts
+++ b/product-sdk/packages/signer/src/signer-manager.ts
@@ -524,6 +524,7 @@ export class SignerManager {
                     ss58Prefix: this.ss58Prefix,
                     maxRetries: this.maxRetries,
                     retryDelay: 500,
+                    dappName: this.dappName,
                 });
             case "dev":
                 return new DevProvider({

--- a/product-sdk/pending-changesets/signer-replace-legacy-with-dapp-derivation.md
+++ b/product-sdk/pending-changesets/signer-replace-legacy-with-dapp-derivation.md
@@ -1,0 +1,30 @@
+---
+"@parity/product-sdk-signer": patch
+"@parity/product-sdk": patch
+---
+
+**`SignerManager.connect("host")` now derives a product account from `dappName` instead of calling the host's legacy-account enumeration.**
+
+On Proof-of-Personhood / product-account hosts (Polkadot Desktop today, Polkadot Mobile going forward), `accounts.getLegacyAccounts()` is hard-coded to return `[]` by design — the host exposes only per-dapp product accounts via enumeration and never the user's identity account. Pre-this-PR, calling `app.wallet.connect()` on such hosts surfaced `NoAccountsError`, which made the simplest possible "connect a wallet" flow unusable.
+
+### What changed
+
+`HostProvider.tryConnect()`:
+
+- The legacy-fetch branch (`provider.getLegacyAccounts()` → `mapAccounts(...)` → `NoAccountsError` on empty) is replaced with a derivation branch (`fetchProductSignerAccount(dappName + ".dot", 0)`).
+- When `dappName` is not set, OR the host rejects the derivation (typically because the dotNS identifier isn't registered for this user), `connect()` resolves with `ok([])` rather than throwing. Consumers can still drive the explicit signing paths (`wallet.signMessageWithDotNsIdentity`, `accounts.getLegacyAccountSigner`).
+- `HostProviderOptions` gains a `dappName?: string` field, wired through automatically from `SignerManager` (consumers don't pass it directly).
+- The `AccountsProvider` interface drops the now-unused `getLegacyAccounts` field. `getLegacyAccountSigner` is **kept** — it's the load-bearing primitive for explicit-name signing (used by `wallet.signMessageWithDotNsIdentity`).
+
+### No public API change
+
+- `SignerManager` constructor, `connect()`, and all other methods: unchanged.
+- `HostProvider` constructor: unchanged (`dappName` is additive).
+- `app.wallet.connect()` return shape: unchanged (`{ accounts: Account[] }`).
+- `getLegacyAccountSigner`, `getProductAccount`, `getProductAccountAlias`, `getUserId`, `createRingVRFProof`, `subscribeAccountConnectionStatus`: unchanged.
+
+### Behavioral note for consumers
+
+Anyone catching `NoAccountsError` to gate UI on Polkadot Desktop will see the error go away — `connect()` now resolves with one product-derived account (when the host can derive it) or an empty list (when it can't). Most consumers handle empty arrays gracefully; if you guarded on `NoAccountsError` specifically, switch to checking `accounts.length === 0`.
+
+The `dappName` you pass to `createApp({ name })` or `new SignerManager({ dappName })` is now also the dotNS identifier the host derives the product account from. `.dot` is appended automatically if missing. If your `dappName` isn't a valid registered dotNS identifier, the host will reject the derivation and `connect()` will resolve with `[]` — usable for explicit-name signing flows but no enumerated account.


### PR DESCRIPTION
  ## Summary

  Replaces `getLegacyAccounts()` enumeration in `HostProvider.tryConnect()` with a product-account derivation keyed off `dappName`. On Polkadot Desktop today the host hard-codes `getLegacyAccounts()` to return `[]` by design, so the default
  `app.wallet.connect()` flow was throwing `NoAccountsError`. Now it derives a usable account from `dappName` (with `.dot` appended automatically) and soft-degrades to `ok([])` when the host can't derive one — so consumers can still drive
  explicit signing paths (`wallet.signMessageWithDotNsIdentity`) on hosts that won't enumerate.

  `getLegacyAccountSigner` is **kept** — it's the load-bearing primitive for explicit-name signing and `signMessageWithDotNsIdentity` depends on it.

  ## What changed

  - `HostProvider.tryConnect()` legacy-fetch branch → `dappName`-derived product-account branch with `ok([])` soft-degrade.
  - `HostProviderOptions` adds `dappName?: string`, wired through automatically from `SignerManager`.
  - `AccountsProvider` interface drops `getLegacyAccounts` (now unused).
  - 5 obsolete tests dropped, 4 new tests added covering the dappName derivation path + soft-degrade.

  ## No public API change

  Constructor signatures, return shapes, and all other methods are unchanged. Consumers catching `NoAccountsError` on `connect()` will see the error go away — switch to checking `accounts.length === 0` if you displayed an empty-accounts state.