### PR TITLE
docs(skills): correct statement-store config surface

### DIFF
--- a/product-sdk/skills/product-sdk-statement-store/SKILL.md
+++ b/product-sdk/skills/product-sdk-statement-store/SKILL.md
@@ -42,7 +42,6 @@ import { StatementStoreClient } from "@parity/product-sdk-statement-store";
 
 const client = new StatementStoreClient({
   appName: "my-app",
-  endpoint: "wss://paseo-bulletin-next-rpc.polkadot.io",
 });
 
 await client.connect({
@@ -67,9 +66,8 @@ client.destroy();
 ```ts
 const client = new StatementStoreClient({
   appName: "my-app",               // required: hashed as topic1
-  endpoint: "wss://...",           // optional: fallback WebSocket URL
-  pollIntervalMs: 10_000,          // optional: polling interval
-  defaultTtlSeconds: 30,           // optional: statement TTL
+  defaultTtlSeconds: 30,           // optional: statement TTL (default 30)
+  // transport: customTransport,   // optional: BYOD transport for tests
 });
 ```
 

--- a/product-sdk/skills/product-sdk-statement-store/references/statement-store-api.md
+++ b/product-sdk/skills/product-sdk-statement-store/references/statement-store-api.md
@@ -101,10 +101,7 @@ type ConnectionCredentials =
 ```ts
 interface StatementStoreConfig {
   appName: string;
-  endpoint?: string;
-  pollIntervalMs?: number;
   defaultTtlSeconds?: number;
-  enablePolling?: boolean;
   transport?: StatementTransport;
 }
 ```


### PR DESCRIPTION
  ## Summary                                                

  Fixes a docs/source drift in the statement-store skill reported via DevEx audit (#220). The skill described three `StatementStoreConfig` fields that don't exist on the shipped package — `endpoint`, `pollIntervalMs`, `enablePolling` — which   
  broke `tsc` for anyone copying the example.
                                                                                                                                                                                                                                                    
  These fields used to exist in the package source but were removed in #21 (refactor for container-only SDK). The skill was never updated alongside that refactor.                                                                                  
  
  ## What changed                                                                                                                                                                                                                                   
                                                            
  - `SKILL.md`: removed phantom `endpoint:` / `pollIntervalMs:` from the two `new StatementStoreClient(...)` examples.                                                                                                                              
  - `references/statement-store-api.md`: replaced the `StatementStoreConfig` block with the actual interface (`appName`, `defaultTtlSeconds?`, `transport?`).
                                                                                                                                                                                                                                                    
  ## No package changes                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                    
  The shipped `dist/index.d.ts` was the source of truth and is unchanged. Anyone hitting this issue got a tsc error, which is the right failure mode.