### PR TITLE
feat(contracts): export QUERY_FALLBACK_ORIGIN read origin

### DIFF
--- a/product-sdk/.changeset/export-query-fallback-origin.md
+++ b/product-sdk/.changeset/export-query-fallback-origin.md
@@ -1,0 +1,20 @@
+---
+"@parity/product-sdk-contracts": minor
+"@parity/product-sdk": minor
+---
+
+**Export `QUERY_FALLBACK_ORIGIN` — pallet-revive's keyless account used as the read-only query origin.**
+
+Other products (e.g. the playground CLI) pass an explicit `defaultOrigin` /
+`registryOrigin` for read-only registry dry-runs and were re-deriving
+pallet-revive's account (`PalletId(*b"py/reviv").into_account_truncating()` =
+`5EYCAe5ijiYfhaAUBd6H9WGRTsvwFFc7GnhQkiHvBYxdvpbV`) by mirroring the byte
+derivation. The SDK already computes this internally as its read-only fallback
+origin; it is now exported so consumers can import it instead of duplicating
+the derivation:
+
+```ts
+import { QUERY_FALLBACK_ORIGIN } from "@parity/product-sdk-contracts";
+```
+
+No behaviour change — only a new export.

--- a/product-sdk/packages/contracts/src/index.ts
+++ b/product-sdk/packages/contracts/src/index.ts
@@ -22,6 +22,10 @@ export {
     createContractRuntimeFromClient,
     ensureContractAccountMapped,
 } from "./runtime.js";
+// pallet-revive's keyless account, used as the read-only query origin when no
+// wallet is connected. Exported so other products can reuse the same origin
+// instead of re-deriving it.
+export { QUERY_FALLBACK_ORIGIN } from "./wrap.js";
 export type {
     ContractRuntime,
     ContractRuntimeOptions,

--- a/product-sdk/packages/contracts/src/wrap.ts
+++ b/product-sdk/packages/contracts/src/wrap.ts
@@ -61,9 +61,14 @@ function extractOverrides<T>(
 }
 
 /**
- * pallet-revive's own account, used as fallback origin for read-only queries
- * when no wallet is connected. The runtime API requires an origin, so we pass
- * this account when there is no connected one.
+ * pallet-revive's own account, used as the fallback origin for read-only
+ * queries when no wallet is connected. The runtime API requires an origin, so
+ * we pass this account when there is no connected one.
+ *
+ * Exported so other products can reuse the exact same read origin instead of
+ * re-deriving it: pass it as an explicit `defaultOrigin` / `registryOrigin`,
+ * or compare against it. Its SS58 (substrate generic, prefix 42) value is
+ * `5EYCAe5ijiYfhaAUBd6H9WGRTsvwFFc7GnhQkiHvBYxdvpbV`.
  *
  * This mirrors `Pallet::<T>::account_id()` in pallet-revive, which is
  * `PalletId(*b"py/reviv").into_account_truncating()`. The 32-byte AccountId is
@@ -72,7 +77,7 @@ function extractOverrides<T>(
  */
 const REVIVE_PALLET_ACCOUNT = new Uint8Array(32);
 REVIVE_PALLET_ACCOUNT.set(new TextEncoder().encode("modlpy/reviv"));
-const QUERY_FALLBACK_ORIGIN = ss58Address(REVIVE_PALLET_ACCOUNT) as SS58String;
+export const QUERY_FALLBACK_ORIGIN = ss58Address(REVIVE_PALLET_ACCOUNT) as SS58String;
 
 function resolveOrigin(
     defaults: ContractDefaults,
@@ -685,6 +690,14 @@ if (import.meta.vitest) {
 
         test("returns undefined when nothing available", () => {
             expect(resolveOrigin({})).toBeUndefined();
+        });
+
+        test("query fallback derives pallet-revive's keyless account", () => {
+            // Frozen public value: other products import QUERY_FALLBACK_ORIGIN
+            // to reuse this exact read origin. A regression here breaks them.
+            expect(QUERY_FALLBACK_ORIGIN).toBe("5EYCAe5ijiYfhaAUBd6H9WGRTsvwFFc7GnhQkiHvBYxdvpbV");
+            const defaults: ContractDefaults = {};
+            expect(resolveOrigin(defaults, undefined, true)).toBe(QUERY_FALLBACK_ORIGIN);
         });
     });
 


### PR DESCRIPTION
## What

Export `QUERY_FALLBACK_ORIGIN` — pallet-revive's keyless account, the origin the SDK already uses internally for read-only query dry-runs when no wallet is connected — from `@parity/product-sdk-contracts` (and, via the umbrella's `export *`, from `@parity/product-sdk/contracts`).

```ts
import { QUERY_FALLBACK_ORIGIN } from "@parity/product-sdk-contracts";
// 5EYCAe5ijiYfhaAUBd6H9WGRTsvwFFc7GnhQkiHvBYxdvpbV
```

## Why

Other products pass an explicit `defaultOrigin` / `registryOrigin` for read-only registry dry-runs, so the SDK's internal fallback never reaches them. Until now `QUERY_FALLBACK_ORIGIN` wasn't exported, so consumers re-derived `PalletId(*b"py/reviv").into_account_truncating()` by hand.

paritytech/playground-cli#275 mirrors that 3-line byte derivation in its own `registry.ts`, and its follow-up explicitly asks product-sdk to export the constant so consumers can import it instead of duplicating the derivation. This PR does that — the playground CLI (and anything else) can now drop the mirrored code.

## How

- `wrap.ts` — add `export` to the existing `QUERY_FALLBACK_ORIGIN` const; expand its doc to note it's public and document the frozen SS58 value.
- `index.ts` — re-export it from the package entry point. It flows through the umbrella automatically via `export * from "@parity/product-sdk-contracts"`.
- Add a value-freezing test in the `resolveOrigin` block: consumers now depend on the exact SS58, so a regression away from `5EYCAe5ijiYfhaAUBd6H9WGRTsvwFFc7GnhQkiHvBYxdvpbV` fails loudly.
- `minor` changeset for `@parity/product-sdk-contracts` + umbrella `@parity/product-sdk` (per the repo's umbrella-bump policy). No behaviour change — only a new export.

## Test

- `pnpm --filter @parity/product-sdk-contracts test` — 144/144 pass (incl. the new freeze test).
- `pnpm --filter @parity/product-sdk-contracts build` / `pnpm --filter @parity/product-sdk build` — export present in `dist/index.{js,d.ts}`; test block dead-code-eliminated from the bundle; umbrella forwards it.
- `pnpm check` — clean.
- `pnpm changeset status` — bumps contracts + umbrella at minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)