### PR TITLE
chore: release papi 2.1.6 catalog bump (#223)

### DIFF
--- a/product-sdk/.changeset/bump-papi-2.1.6.md
+++ b/product-sdk/.changeset/bump-papi-2.1.6.md
@@ -1,0 +1,24 @@
+---
+"@parity/product-sdk": patch
+"@parity/product-sdk-chain-client": patch
+"@parity/product-sdk-cloud-storage": patch
+"@parity/product-sdk-contracts": patch
+"@parity/product-sdk-descriptors": patch
+"@parity/product-sdk-host": patch
+"@parity/product-sdk-keys": patch
+"@parity/product-sdk-signer": patch
+"@parity/product-sdk-statement-store": patch
+"@parity/product-sdk-terminal": patch
+"@parity/product-sdk-tx": patch
+---
+
+chore(deps): bump polkadot-api to 2.1.6
+
+Updates the `polkadot-api` catalog entry `^2.1.5` → `^2.1.6` (2.1.6 carries the
+double-notification fix). Every published package resolves `polkadot-api`
+through `catalog:`, so each one's published `dependencies` range moves to
+`^2.1.6`. There is no source change in any package — these are patch bumps to
+ship the new floor via the published `catalog:` resolution.
+
+Releases the catalog bump from #223, which was merged to `main` without a
+changeset.


### PR DESCRIPTION
## What

Adds the changeset that #223 (`chore: bump papi to 2.1.6`) was merged to `main` without.

#223 moved the `polkadot-api` catalog entry `^2.1.5` → `^2.1.6` in `pnpm-workspace.yaml`, but shipped no changeset — so the bump is on `main` yet no package version reflects it and it was never published. Per [RELEASES.md](../blob/main/product-sdk/RELEASES.md#when-does-a-pr-need-a-changeset), a catalog change that flows through `catalog:` references in published packages needs a changeset.

## Scope

`polkadot-api` is a `dependencies` entry (via `catalog:`) of **11 published packages**, so each one's published dependency range moves to `^2.1.6`. Following the repo's standard for catalog/dep bumps with no source change (e.g. `bump-novasamatech-0-8-9.md`, `bump-novasama-host-api-0.8.6.md`), every consumer is **patch**:

`@parity/product-sdk`, `-chain-client`, `-cloud-storage`, `-contracts`, `-descriptors`, `-host`, `-keys`, `-signer`, `-statement-store`, `-terminal`, `-tx`.

No source change in any package — patch bumps to ship the new floor via published `catalog:` resolution.

## Effect

Merging this triggers the release workflow, which opens/updates the **Version Packages** PR with the patch bumps.