### PR TITLE
fix: review comments

### DIFF
--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -270,6 +270,9 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
                     // otherwise the latest supported version. unifyMetadata
                     // normalizes v14/v15 so `.extrinsic.version` is an array.
                     const versions = unifyMetadata(decAnyMetadata(metadata)).extrinsic.version;
+                    if (versions.length === 0) {
+                        throw new Error("No extrinsic version found in metadata");
+                    }
                     const latestVersion = versions.reduce((acc, v) => Math.max(acc, v), 0);
                     const txExtVersion = latestVersion === 4 ? 0 : latestVersion;
 

--- a/product-sdk/packages/host/src/papi-provider.ts
+++ b/product-sdk/packages/host/src/papi-provider.ts
@@ -48,10 +48,13 @@ import type {
     StorageQueryType,
     TrUApiClient,
 } from "@parity/truapi";
+import { createLogger } from "@parity/product-sdk-logger";
 
 import { subscribeWithInterrupt } from "./transport.js";
 import { formatHostError } from "./truapi.js";
 import type { HostSubscription } from "./types.js";
+
+const log = createLogger("host:papi");
 
 /** JSON-RPC internal-error code used for every host-side failure (matches the upstream). */
 const JSON_RPC_INTERNAL_ERROR = -32603;
@@ -225,12 +228,11 @@ export function createHostPapiProvider(
                 case "chainHead_v1_follow": {
                     const [withRuntime] = params as [boolean];
                     const syntheticSubId = getNextSubId();
-                    // Hold the handle in a ref so the Stop branch can release the
-                    // host subscription BEFORE forwarding the event: the consumer's
-                    // substrate-client refollows synchronously inside the handler,
-                    // and the transport dedupes by (method, payload-hash) — unless
-                    // this dead subscription is gone first, the refollow shares it
-                    // and never reaches the host, so events stop flowing.
+                    // The Stop branch unsubscribes its own host subscription, but the
+                    // handle is this call's return value — the ref breaks that
+                    // chicken-and-egg. (Releasing before forwarding the Stop is just
+                    // cleanup; the consumer's synchronous refollow gets a fresh wire
+                    // subscription either way.)
                     const ref: { handle?: HostSubscription } = {};
                     ref.handle = subscribeWithInterrupt(
                         chain.followHeadSubscribe({ request: { genesisHash, withRuntime } }),
@@ -422,7 +424,20 @@ export function createHostPapiProvider(
 
         return {
             send(message) {
-                handleMessage(message);
+                // A synchronous throw inside a handler (e.g. a malformed positional
+                // param) must not leave the JSON-RPC request unsettled — the caller
+                // would hang. Surface it as an error response for the request id.
+                try {
+                    handleMessage(message);
+                } catch (error) {
+                    // Handlers must settle the request themselves; reaching here means a
+                    // synchronous throw before any response was sent. (A handler that
+                    // sends then throws would double-respond — none do today.)
+                    log.warn("send: handler threw before settling the request", {
+                        error: formatHostError(error),
+                    });
+                    sendJsonRpcError(message.id, JSON_RPC_INTERNAL_ERROR, formatHostError(error));
+                }
             },
             disconnect() {
                 for (const handle of activeFollows.values()) {

--- a/product-sdk/packages/statement-store/src/transport.ts
+++ b/product-sdk/packages/statement-store/src/transport.ts
@@ -46,6 +46,18 @@ class HostTransport implements StatementTransport {
                 onStatements(page.statements.map(hostSignedStatementToSdk));
             });
 
+            // Host-side teardown (transport close → `error`, host interrupt →
+            // `complete`) is delivered only through `onInterrupt`; surface it so the
+            // consumer learns the stream ended instead of silently waiting forever.
+            sub.onInterrupt((reason) => {
+                const msg =
+                    reason instanceof Error
+                        ? reason.message
+                        : "Host ended the statement subscription";
+                log.warn("Host subscription interrupted", { error: msg });
+                onError(new StatementSubscriptionError(msg));
+            });
+
             log.info("Host subscription active");
 
             return {


### PR DESCRIPTION
## Summary
Small, contained fixes surfaced by a review pass of the migration (3 files, +37/−7). Stacked on vf/truapi-migration; validated (host + statement-store build, 120 unit tests, biome clean) and adversarially reviewed (verdict: ship).

## Changes
- statement-store: surface host subscription interrupts as `onError`. The host subscription's `onInterrupt` was never registered, so a host-side teardown (transport close / interrupt) never reached the consumer - a silent dead stream.
- host (papi-provider): settle the JSON-RPC request on a synchronous handler throw. A malformed positional param threw out of `send()` before the error boundary, leaving the request unsettled (caller hangs). Now returns a JSON-RPC error + logs.
- host (accounts): reject empty `extrinsic.version` instead of silently signing as Extrinsic V4.
- host (papi-provider): correct a stale code comment - @parity/truapi mints a fresh requestId per subscription and does not dedupe by (method, payload-hash).

## Notes
- These are improvements on the migrated code, not migration regressions (the same behaviors exist in the novasama baseline). Flag for reviewers: the statement-store change is observable behavior product-sdk didn't have before - fine to land here, or split into resilience work if we want #186 kept strictly drop-in.
- Covered by the migration's existing pending changeset (host + statement-store minor); no new changeset.

Refs #186