### PR TITLE
refactor(host): remove PJS bridge from account signer factories

### DIFF
--- a/product-sdk/examples/contracts-demo/src/main.ts
+++ b/product-sdk/examples/contracts-demo/src/main.ts
@@ -22,15 +22,14 @@
  *   4. ContractManager.fromClient(cdm, chain.raw.assetHub) wraps the contract.
  *   5. contract.getReportCount.query(shopKey) → dry-run via RPC — no signing.
  *   6. contract.storeDailyReport.tx(shopKey, date, cid, count) uses
- *      productAccount.getSigner() — which routes through
- *      `getProductAccountSigner(..., "createTransaction")` and preserves
- *      arbitrary signed extensions (e.g. AsPgas on Paseo Next).
+ *      productAccount.getSigner() — which routes through the host's
+ *      `createTransaction` path and preserves arbitrary signed extensions
+ *      (e.g. AsPgas on Paseo Next).
  *
- * Why not the legacy-account path: `manager.connect()` + `selectAccount`
- * + `manager.getSigner()` builds the signer via `getLegacyAccountSigner`,
- * which has no signerType switch upstream and always routes through PJS.
- * PJS throws on unknown signed extensions like AsPgas. Product-account
- * signing avoids that path entirely.
+ * This demo signs with an app-scoped product account. The legacy-account
+ * path (`manager.connect()` + `selectAccount` + `manager.getSigner()`)
+ * works too — both go through the host's create-transaction path and
+ * preserve unknown signed extensions.
  */
 
 import type { SignerAccount } from "@parity/product-sdk-signer";
@@ -235,11 +234,10 @@ $btnStoreReport.addEventListener("click", async () => {
 async function init() {
     log("Booting contracts-demo…");
 
-    // Step 1: establish the host session. We don't use the returned legacy
-    // accounts — they sign via the PJS bridge, which throws on unknown
-    // signed extensions (e.g. AsPgas on Paseo Next). The product-account
-    // request below uses `getProductAccountSigner` with `"createTransaction"`
-    // and avoids that path.
+    // Step 1: establish the host session. This demo signs with an app-scoped
+    // product account via `getProductAccountSigner` (the host's
+    // create-transaction path, which preserves unknown signed extensions like
+    // AsPgas on Paseo Next).
     log("Connecting signer…");
     const connectRes = await manager.connect();
     if (!connectRes.ok) {

--- a/product-sdk/examples/tx-demo/src/main.ts
+++ b/product-sdk/examples/tx-demo/src/main.ts
@@ -14,14 +14,13 @@
  *      Bob's funded keypair via `productAccounts`.
  *   3. getChainAPI("paseo") routes RPC through the host's chainConnection.
  *   4. submitAndWatch uses productAccount.getSigner() — which routes
- *      through `getProductAccountSigner(..., "createTransaction")` and
- *      preserves arbitrary signed extensions (e.g. AsPgas on Paseo Next).
+ *      through the host's `createTransaction` path and preserves arbitrary
+ *      signed extensions (e.g. AsPgas on Paseo Next).
  *
- * Why not the legacy-account path: `manager.connect()` + `selectAccount`
- * + `manager.getSigner()` builds the signer via `getLegacyAccountSigner`,
- * which has no signerType switch upstream and always routes through PJS.
- * PJS throws on unknown signed extensions like AsPgas. Product-account
- * signing avoids that path entirely.
+ * This demo signs with an app-scoped product account. The legacy-account
+ * path (`manager.connect()` + `selectAccount` + `manager.getSigner()`)
+ * works too — both go through the host's create-transaction path and
+ * preserve unknown signed extensions.
  */
 
 import type { SignerAccount } from "@parity/product-sdk-signer";
@@ -252,11 +251,10 @@ $btnSubmitBadTx.addEventListener("click", async () => {
 async function init() {
     log("Booting tx-demo…");
 
-    // Step 1: establish the host session. We don't use the returned legacy
-    // accounts — they sign via the PJS bridge, which throws on unknown
-    // signed extensions (e.g. AsPgas on Paseo Next). The product-account
-    // request below uses `getProductAccountSigner` with `"createTransaction"`
-    // and avoids that path.
+    // Step 1: establish the host session. This demo signs with an app-scoped
+    // product account via `getProductAccountSigner` (the host's
+    // create-transaction path, which preserves unknown signed extensions like
+    // AsPgas on Paseo Next).
     log("Connecting signer…");
     const connectRes = await manager.connect();
     if (!connectRes.ok) {

--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -138,6 +138,10 @@ export interface AccountsProvider {
  * Derive the host's extrinsic-extension version from SCALE-encoded metadata:
  * v4 → 0, otherwise the latest supported version. `unifyMetadata` normalizes
  * v14/v15 so `.extrinsic.version` is an array.
+ *
+ * Indirected through {@link deps} so the SCALE decode (which needs a real
+ * metadata blob) can be stubbed in unit tests while the rest of the `signTx`
+ * flow — genesis extraction, extension mapping, the host call — is exercised.
  */
 function deriveTxExtVersion(metadata: Uint8Array): number {
     const versions = unifyMetadata(decAnyMetadata(metadata)).extrinsic.version;
@@ -147,6 +151,9 @@ function deriveTxExtVersion(metadata: Uint8Array): number {
     const latestVersion = versions.reduce((acc, v) => Math.max(acc, v), 0);
     return latestVersion === 4 ? 0 : latestVersion;
 }
+
+/** Internal seam so `import.meta.vitest` can stub the metadata decode. @internal */
+const deps = { deriveTxExtVersion };
 
 /**
  * Map a PAPI `signTx` call's signed extensions onto the host's
@@ -233,7 +240,7 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
                             genesisHash: toHex(checkGenesis.additionalSigned),
                             callData: toHex(callData),
                             extensions: toHostExtensions(signedExtensions),
-                            txExtVersion: deriveTxExtVersion(metadata),
+                            txExtVersion: deps.deriveTxExtVersion(metadata),
                         }),
                         "createTransaction failed",
                     );
@@ -272,7 +279,7 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
                             genesisHash: toHex(checkGenesis.additionalSigned),
                             callData: toHex(callData),
                             extensions: toHostExtensions(signedExtensions),
-                            txExtVersion: deriveTxExtVersion(metadata),
+                            txExtVersion: deps.deriveTxExtVersion(metadata),
                         }),
                         "createTransactionWithLegacyAccount failed",
                     );
@@ -440,5 +447,98 @@ if (import.meta.vitest) {
         await expect(signer.signTx(new Uint8Array([1]), {}, new Uint8Array(), 0)).rejects.toThrow(
             "Can't find genesis hash on transaction",
         );
+    });
+
+    // Signed extensions PAPI hands to `signTx`. `CheckGenesis.additionalSigned`
+    // carries the genesis hash the signer pulls out; the rest are mapped to the
+    // host's `{ id, extra, additionalSigned }` wire shape.
+    const sampleExtensions = {
+        CheckGenesis: {
+            identifier: "CheckGenesis",
+            value: new Uint8Array([]),
+            additionalSigned: new Uint8Array([0x01, 0x02]),
+        },
+        CheckNonce: {
+            identifier: "CheckNonce",
+            value: new Uint8Array([0x05]),
+            additionalSigned: new Uint8Array([]),
+        },
+    };
+    const expectedHostExtensions = [
+        {
+            id: "CheckGenesis",
+            extra: toHex(new Uint8Array([])),
+            additionalSigned: toHex(new Uint8Array([0x01, 0x02])),
+        },
+        {
+            id: "CheckNonce",
+            extra: toHex(new Uint8Array([0x05])),
+            additionalSigned: toHex(new Uint8Array([])),
+        },
+    ];
+
+    test("the product signer's signTx builds createTransaction from genesis + extensions", async () => {
+        // Stub the metadata decode (needs a real SCALE blob) so the rest of the
+        // signTx flow — genesis extraction, extension mapping, the host call,
+        // response decode — is exercised against a fixed txExtVersion.
+        vi.spyOn(deps, "deriveTxExtVersion").mockReturnValue(0);
+        const calls: Array<[string, unknown]> = [];
+        const client = makeFakeClient({ onCall: (m, a) => calls.push([m, a]) });
+        const provider = adaptAccountsProvider(client);
+        const signer = provider.getProductAccountSigner({
+            dotNsIdentifier: "app.dot",
+            derivationIndex: 0,
+            publicKey: new Uint8Array(32).fill(0xaa),
+        });
+
+        const signed = await signer.signTx(
+            new Uint8Array([0xca, 0x11]),
+            sampleExtensions,
+            new Uint8Array([0x6d]),
+            0,
+        );
+
+        expect(calls.at(-1)).toEqual([
+            "createTransaction",
+            {
+                signer: { dotNsIdentifier: "app.dot", derivationIndex: 0 },
+                genesisHash: toHex(new Uint8Array([0x01, 0x02])),
+                callData: toHex(new Uint8Array([0xca, 0x11])),
+                extensions: expectedHostExtensions,
+                txExtVersion: 0,
+            },
+        ]);
+        expect(signed).toEqual(fromHex("0xdead"));
+        vi.restoreAllMocks();
+    });
+
+    test("the legacy signer's signTx builds createTransactionWithLegacyAccount (signer = hex pubkey)", async () => {
+        vi.spyOn(deps, "deriveTxExtVersion").mockReturnValue(0);
+        const calls: Array<[string, unknown]> = [];
+        const client = makeFakeClient({ onCall: (m, a) => calls.push([m, a]) });
+        const provider = adaptAccountsProvider(client);
+        const publicKey = new Uint8Array(32).fill(0xbb);
+        const signer = provider.getLegacyAccountSigner({ publicKey });
+
+        const signed = await signer.signTx(
+            new Uint8Array([0xca, 0x11]),
+            sampleExtensions,
+            new Uint8Array([0x6d]),
+            0,
+        );
+
+        expect(calls.at(-1)).toEqual([
+            "createTransactionWithLegacyAccount",
+            {
+                // createTransactionWithLegacyAccount identifies the signer by raw hex pubkey.
+                signer: toHex(publicKey),
+                genesisHash: toHex(new Uint8Array([0x01, 0x02])),
+                callData: toHex(new Uint8Array([0xca, 0x11])),
+                extensions: expectedHostExtensions,
+                txExtVersion: 0,
+            },
+        ]);
+        expect(signed).toEqual(fromHex("0xfeed"));
+        vi.restoreAllMocks();
     });
 }

--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -10,13 +10,13 @@
  * status, and PAPI `PolkadotSigner` factories for both product and legacy
  * accounts.
  *
- * **Provenance.** The provider mirrors `@novasamatech/host-api-wrapper`'s
- * `createAccountsProvider` (`dist/accounts.js`); the lookup/proof methods are
- * re-pointed onto `truApi.account.*` and the signer factories onto
- * `truApi.signing.*`. truapi exposes the signing primitives but not the
- * `PolkadotSigner` adapter, so the `signTx`/`signBytes` construction
- * (metadata-driven `txExtVersion` derivation, signed-extension mapping) is
- * carried over from the upstream module.
+ * The signer factories build a PAPI `PolkadotSigner` directly over
+ * `truApi.signing.createTransaction` (product) /
+ * `createTransactionWithLegacyAccount` (legacy) — `signTx` derives the
+ * metadata-driven `txExtVersion` and maps the signed extensions to the host's
+ * wire shape; `signBytes` calls `signing.signRaw(WithLegacyAccount)`. No PJS
+ * bridge is involved, so opaque signed extensions (e.g. Paseo Next's `AsPgas`)
+ * survive end-to-end.
  *
  * @module
  */
@@ -24,10 +24,8 @@
 import { decAnyMetadata, unifyMetadata } from "@polkadot-api/substrate-bindings";
 import type { ResultAsync } from "neverthrow";
 import { AccountId, type PolkadotSigner } from "polkadot-api";
-import { getPolkadotSignerFromPjs, type SignerPayloadJSON } from "polkadot-api/pjs-signer";
 
 import type {
-    HexString,
     HostAccountConnectionStatusSubscribeItem,
     HostAccountCreateProofError,
     HostAccountGetAliasResponse as WireAlias,
@@ -35,7 +33,6 @@ import type {
     HostGetUserIdError,
     HostRequestLoginError,
     HostRequestLoginResponse,
-    HostSignPayloadData,
     LegacyAccount as WireLegacyAccount,
     ProductAccount as WireProductAccount,
     ProductAccountId,
@@ -121,15 +118,11 @@ export interface AccountsProvider {
         message: Uint8Array,
     ): ResultAsync<Uint8Array, HostAccountCreateProofError>;
     /**
-     * Build a `PolkadotSigner` for a product account. `signerType` defaults to
-     * `"createTransaction"` (the host decodes metadata and forwards opaque
-     * signed-extension bytes); `"signPayload"` routes via the PJS bridge and is
-     * retained for backward compatibility.
+     * Build a `PolkadotSigner` for a product account. Signing routes through the
+     * host's `createTransaction` path: the host decodes the metadata and forwards
+     * the opaque signed-extension bytes, so unknown extensions survive end-to-end.
      */
-    getProductAccountSigner(
-        account: ProductAccount,
-        signerType?: "signPayload" | "createTransaction",
-    ): PolkadotSigner;
+    getProductAccountSigner(account: ProductAccount): PolkadotSigner;
     /**
      * Build a `PolkadotSigner` for one of the user's existing wallet accounts.
      * `name` is accepted for callsite ergonomics but unused — the signer is
@@ -141,74 +134,41 @@ export interface AccountsProvider {
     ): HostSubscription;
 }
 
-/** Ensure a `0x` prefix on a hex string (PJS payload fields arrive with or without it). */
-function asHex(value: string): HexString {
-    return (value.startsWith("0x") ? value : `0x${value}`) as HexString;
+/**
+ * Derive the host's extrinsic-extension version from SCALE-encoded metadata:
+ * v4 → 0, otherwise the latest supported version. `unifyMetadata` normalizes
+ * v14/v15 so `.extrinsic.version` is an array.
+ */
+function deriveTxExtVersion(metadata: Uint8Array): number {
+    const versions = unifyMetadata(decAnyMetadata(metadata)).extrinsic.version;
+    if (versions.length === 0) {
+        throw new Error("No extrinsic version found in metadata");
+    }
+    const latestVersion = versions.reduce((acc, v) => Math.max(acc, v), 0);
+    return latestVersion === 4 ? 0 : latestVersion;
 }
 
-/** Map a PJS `SignerPayloadJSON` onto the host's {@link HostSignPayloadData}. */
-function buildSigningPayloadFields(payload: SignerPayloadJSON): HostSignPayloadData {
-    return {
-        blockHash: asHex(payload.blockHash),
-        blockNumber: asHex(payload.blockNumber),
-        era: asHex(payload.era),
-        genesisHash: asHex(payload.genesisHash),
-        method: asHex(payload.method),
-        nonce: asHex(payload.nonce),
-        specVersion: asHex(payload.specVersion),
-        transactionVersion: asHex(payload.transactionVersion),
-        tip: asHex(payload.tip),
-        metadataHash: payload.metadataHash ? asHex(payload.metadataHash) : undefined,
-        // PJS types assetId as `number | object`; the host expects the encoded
-        // hex form, which is what PAPI produces at runtime. Passed through as
-        // the wrapper did.
-        assetId:
-            payload.assetId !== undefined ? (payload.assetId as unknown as HexString) : undefined,
-        mode: payload.mode,
-        withSignedTransaction: payload.withSignedTransaction,
-        signedExtensions: payload.signedExtensions,
-        version: payload.version,
-    };
+/**
+ * Map a PAPI `signTx` call's signed extensions onto the host's
+ * `TxPayloadExtension` wire shape (hex-encoded `extra` / `additionalSigned`).
+ */
+function toHostExtensions(
+    signedExtensions: Record<
+        string,
+        { identifier: string; value: Uint8Array; additionalSigned: Uint8Array }
+    >,
+) {
+    return Object.values(signedExtensions).map((ext) => ({
+        id: ext.identifier,
+        extra: toHex(ext.value),
+        additionalSigned: toHex(ext.additionalSigned),
+    }));
 }
 
 /** Build an {@link AccountsProvider} over a TruAPI client's `account` / `signing` domains. */
 function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
     const account = client.account;
     const signing = client.signing;
-
-    /** Build the product-account signer's PJS-bridge signing callbacks (deprecated `signPayload` mode). */
-    function productPjsSigner(productAccountId: {
-        dotNsIdentifier: string;
-        derivationIndex: number;
-    }) {
-        return getPolkadotSignerFromPjs(
-            // Address slot is unused for product signing but PJS requires a string.
-            "",
-            async (payload) => {
-                const response = await unwrapHostResult(
-                    signing.signPayload({
-                        account: productAccountId,
-                        payload: buildSigningPayloadFields(payload),
-                    }),
-                    "signPayload failed",
-                );
-                return {
-                    signature: response.signature,
-                    signedTransaction: response.signedTransaction,
-                };
-            },
-            async (raw) => {
-                const response = await unwrapHostResult(
-                    signing.signRaw({
-                        account: productAccountId,
-                        payload: { tag: "Bytes", value: { bytes: asHex(raw.data) } },
-                    }),
-                    "signRaw failed",
-                );
-                return { id: 0, signature: response.signature };
-            },
-        );
-    }
 
     return {
         getUserId() {
@@ -253,29 +213,15 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
                 })
                 .map((response) => fromHex(response.proof));
         },
-        getProductAccountSigner(account_, signerType = "createTransaction") {
+        getProductAccountSigner(account_) {
             const productAccountId = {
                 dotNsIdentifier: account_.dotNsIdentifier,
                 derivationIndex: account_.derivationIndex,
             };
 
-            if (signerType === "signPayload") {
-                return productPjsSigner(productAccountId);
-            }
-
             return {
                 publicKey: account_.publicKey,
                 async signTx(callData, signedExtensions, metadata) {
-                    // The host needs the extrinsic-extension version: v4 → 0,
-                    // otherwise the latest supported version. unifyMetadata
-                    // normalizes v14/v15 so `.extrinsic.version` is an array.
-                    const versions = unifyMetadata(decAnyMetadata(metadata)).extrinsic.version;
-                    if (versions.length === 0) {
-                        throw new Error("No extrinsic version found in metadata");
-                    }
-                    const latestVersion = versions.reduce((acc, v) => Math.max(acc, v), 0);
-                    const txExtVersion = latestVersion === 4 ? 0 : latestVersion;
-
                     const checkGenesis = signedExtensions.CheckGenesis;
                     if (!checkGenesis) {
                         throw new Error("Can't find genesis hash on transaction");
@@ -286,12 +232,8 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
                             signer: productAccountId,
                             genesisHash: toHex(checkGenesis.additionalSigned),
                             callData: toHex(callData),
-                            extensions: Object.values(signedExtensions).map((ext) => ({
-                                id: ext.identifier,
-                                extra: toHex(ext.value),
-                                additionalSigned: toHex(ext.additionalSigned),
-                            })),
-                            txExtVersion,
+                            extensions: toHostExtensions(signedExtensions),
+                            txExtVersion: deriveTxExtVersion(metadata),
                         }),
                         "createTransaction failed",
                     );
@@ -310,36 +252,43 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
             };
         },
         getLegacyAccountSigner(account_) {
-            // The pjs `address` is propagated verbatim into the wire `signer`
-            // field, so it must be an SS58 address the wallet can match — not a
-            // raw hex public key.
+            // `createTransactionWithLegacyAccount` identifies the signer by its
+            // raw account id (hex public key); `signRawWithLegacyAccount` takes an
+            // SS58 address the wallet can match. Compute both up front.
+            const signerHex = toHex(account_.publicKey);
             const ss58Address = AccountId().dec(account_.publicKey);
-            return getPolkadotSignerFromPjs(
-                ss58Address,
-                async (payload) => {
+
+            return {
+                publicKey: account_.publicKey,
+                async signTx(callData, signedExtensions, metadata) {
+                    const checkGenesis = signedExtensions.CheckGenesis;
+                    if (!checkGenesis) {
+                        throw new Error("Can't find genesis hash on transaction");
+                    }
+
                     const response = await unwrapHostResult(
-                        signing.signPayloadWithLegacyAccount({
-                            signer: payload.address,
-                            payload: buildSigningPayloadFields(payload),
+                        signing.createTransactionWithLegacyAccount({
+                            signer: signerHex,
+                            genesisHash: toHex(checkGenesis.additionalSigned),
+                            callData: toHex(callData),
+                            extensions: toHostExtensions(signedExtensions),
+                            txExtVersion: deriveTxExtVersion(metadata),
                         }),
-                        "signPayloadWithLegacyAccount failed",
+                        "createTransactionWithLegacyAccount failed",
                     );
-                    return {
-                        signature: response.signature,
-                        signedTransaction: response.signedTransaction,
-                    };
+                    return fromHex(response.transaction);
                 },
-                async (raw) => {
+                async signBytes(data) {
                     const response = await unwrapHostResult(
                         signing.signRawWithLegacyAccount({
-                            signer: raw.address,
-                            payload: { tag: "Bytes", value: { bytes: asHex(raw.data) } },
+                            signer: ss58Address,
+                            payload: { tag: "Bytes", value: { bytes: toHex(data) } },
                         }),
                         "signRawWithLegacyAccount failed",
                     );
-                    return { id: 0, signature: response.signature };
+                    return fromHex(response.signature);
                 },
-            );
+            };
         },
         subscribeAccountConnectionStatus(callback) {
             return subscribeWithInterrupt(account.connectionStatusSubscribe(), callback);
@@ -391,7 +340,13 @@ if (import.meta.vitest) {
             },
             signing: {
                 createTransaction: method("createTransaction", { transaction: "0xdead" }),
+                createTransactionWithLegacyAccount: method("createTransactionWithLegacyAccount", {
+                    transaction: "0xfeed",
+                }),
                 signRaw: method("signRaw", { signature: "0xbeef" }),
+                signRawWithLegacyAccount: method("signRawWithLegacyAccount", {
+                    signature: "0xcafe",
+                }),
             },
         } as unknown as TrUApiClient;
     }
@@ -457,5 +412,33 @@ if (import.meta.vitest) {
             },
         ]);
         expect(signature).toEqual(fromHex("0xbeef"));
+    });
+
+    test("the legacy signer signs bytes via signing.signRawWithLegacyAccount (by SS58 address)", async () => {
+        const calls: Array<[string, unknown]> = [];
+        const client = makeFakeClient({ onCall: (m, a) => calls.push([m, a]) });
+        const provider = adaptAccountsProvider(client);
+        const publicKey = new Uint8Array(32).fill(0xbb);
+        const signer = provider.getLegacyAccountSigner({ publicKey });
+        const signature = await signer.signBytes(new Uint8Array([7, 7]));
+        // signRawWithLegacyAccount identifies the signer by SS58 address, not raw pubkey.
+        expect(calls.at(-1)).toEqual([
+            "signRawWithLegacyAccount",
+            {
+                signer: AccountId().dec(publicKey),
+                payload: { tag: "Bytes", value: { bytes: toHex(new Uint8Array([7, 7])) } },
+            },
+        ]);
+        expect(signature).toEqual(fromHex("0xcafe"));
+    });
+
+    test("the legacy signer's signTx throws without a CheckGenesis extension", async () => {
+        const provider = adaptAccountsProvider(makeFakeClient());
+        const signer = provider.getLegacyAccountSigner({
+            publicKey: new Uint8Array(32).fill(0xbb),
+        });
+        await expect(signer.signTx(new Uint8Array([1]), {}, new Uint8Array(), 0)).rejects.toThrow(
+            "Can't find genesis hash on transaction",
+        );
     });
 }

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -72,7 +72,7 @@ export interface HostProviderOptions {
      * `dotNsIdentifier`, skipping the legacy fetch entirely. For apps
      * that sign exclusively with a per-dapp derived account.
      *
-     * Signing is pinned to `createTransaction` (see PR #96).
+     * Signing goes through the host's `createTransaction` path (see PR #96).
      */
     productAccount?: {
         /** App identifier (e.g., `"playground.dot"`). */
@@ -146,18 +146,6 @@ interface NeverthrowResultAsync<T, E> {
     match: <A, B = A>(ok: (t: T) => A, err: (e: E) => B) => Promise<A | B>;
 }
 
-/**
- * Pin product-account signing to the host's `createTransaction` path.
- *
- * The `createTransaction` path forwards opaque signed-extension bytes to the
- * host for metadata-driven decoding, so unknown extensions (e.g. `AsPgas` on
- * Paseo Next) survive end-to-end. The alternate `"signPayload"` path wraps via
- * PJS and throws `"PJS does not support this signed-extension: AsPgas"` on
- * those chains. Pinning it here keeps the routing legible at the call site;
- * the legacy-account signer doesn't expose this switch.
- */
-const PRODUCT_SIGNER_TYPE = "createTransaction" as const;
-
 /** @internal */
 export interface AccountsProvider {
     getLegacyAccounts: () => NeverthrowResultAsync<RawAccount[], unknown>;
@@ -168,10 +156,7 @@ export interface AccountsProvider {
         dotNsIdentifier: string,
         derivationIndex?: number,
     ) => NeverthrowResultAsync<RawAccount, unknown>;
-    getProductAccountSigner: (
-        account: ProductAccount,
-        signerType?: "signPayload" | "createTransaction",
-    ) => import("polkadot-api").PolkadotSigner;
+    getProductAccountSigner: (account: ProductAccount) => import("polkadot-api").PolkadotSigner;
     getProductAccountAlias: (
         dotNsIdentifier: string,
         derivationIndex?: number,
@@ -332,10 +317,7 @@ export class HostProvider implements SignerProvider {
                     if (!this.accountsProvider) {
                         throw new Error("Host provider is disconnected");
                     }
-                    return this.accountsProvider.getProductAccountSigner(
-                        productAccount,
-                        PRODUCT_SIGNER_TYPE,
-                    );
+                    return this.accountsProvider.getProductAccountSigner(productAccount);
                 },
             });
         } catch (cause) {
@@ -354,17 +336,15 @@ export class HostProvider implements SignerProvider {
      * Convenience method for when you already have the product account details.
      * Requires a prior successful `connect()` call.
      *
-     * Routing is pinned to `signerType: "createTransaction"` via
-     * {@link PRODUCT_SIGNER_TYPE} so unknown signed extensions (e.g. `AsPgas`
-     * on Paseo Next) are forwarded to the host as opaque bytes for
-     * metadata-driven decoding, rather than going through the PJS bridge
-     * that throws on unknown extensions.
+     * Signing routes through the host's `createTransaction` path, so unknown
+     * signed extensions (e.g. `AsPgas` on Paseo Next) are forwarded to the host
+     * as opaque bytes for metadata-driven decoding.
      */
     getProductAccountSigner(account: ProductAccount): import("polkadot-api").PolkadotSigner {
         if (!this.accountsProvider) {
             throw new Error("Host provider is not connected");
         }
-        return this.accountsProvider.getProductAccountSigner(account, PRODUCT_SIGNER_TYPE);
+        return this.accountsProvider.getProductAccountSigner(account);
     }
 
     /**
@@ -958,11 +938,11 @@ if (import.meta.vitest) {
             }
         });
 
-        test("getProductAccountSigner pins signerType to 'createTransaction'", async () => {
-            // Regression guard: the alternate "signPayload" route goes through
-            // PJS and throws on unknown signed extensions (e.g. AsPgas on
-            // Paseo Next). If a future refactor drops the explicit pin, this
-            // would silently regress.
+        test("getProductAccountSigner delegates to the host accounts provider", async () => {
+            // The host accounts provider's getProductAccountSigner has a single
+            // signing path (the host's `createTransaction`, which forwards opaque
+            // signed extensions like AsPgas on Paseo Next). There is no PJS
+            // fallback to select, so it's called with just the account.
             const rawAccounts: RawAccountTest[] = [
                 { publicKey: new Uint8Array(32).fill(0xaa), name: "Alice" },
             ];
@@ -982,7 +962,6 @@ if (import.meta.vitest) {
             });
             expect(mockProvider.getProductAccountSigner).toHaveBeenLastCalledWith(
                 expect.anything(),
-                "createTransaction",
             );
 
             // Path 2: getSigner() returned from HostProvider.getProductAccount(...)
@@ -992,7 +971,6 @@ if (import.meta.vitest) {
                 productAccountResult.value.getSigner();
                 expect(mockProvider.getProductAccountSigner).toHaveBeenLastCalledWith(
                     expect.anything(),
-                    "createTransaction",
                 );
             }
         });
@@ -1042,7 +1020,6 @@ if (import.meta.vitest) {
                         dotNsIdentifier: "myapp.dot",
                         derivationIndex: 0,
                     }),
-                    "createTransaction",
                 );
             }
             expect(mockProvider.getProductAccount).toHaveBeenCalledWith("myapp.dot", 0);

--- a/product-sdk/pending-changesets/remove-pjs-from-host-accounts.md
+++ b/product-sdk/pending-changesets/remove-pjs-from-host-accounts.md
@@ -1,0 +1,9 @@
+---
+"@parity/product-sdk-host": minor
+"@parity/product-sdk-signer": minor
+"@parity/product-sdk": minor
+---
+
+Remove the last PolkadotJS (`polkadot-api/pjs-signer`) dependency from the host account signer factories. `getLegacyAccountSigner` now builds a PAPI `PolkadotSigner` directly over `truApi.signing.createTransactionWithLegacyAccount` / `signRawWithLegacyAccount`, mirroring the product-account `createTransaction` path, so opaque signed extensions (e.g. Paseo Next's `AsPgas`) survive end-to-end for legacy accounts too.
+
+`getProductAccountSigner` drops its `signerType` parameter — the deprecated `"signPayload"` (PJS-bridge) mode is gone; product-account signing always uses the host's `createTransaction` path. The signer's `HostProvider` no longer passes a signer type.


### PR DESCRIPTION
## Summary

Removes the last PolkadotJS (`polkadot-api/pjs-signer`) dependency from `@parity/product-sdk-host`'s account signer factories. truapi exposes `createTransactionWithLegacyAccount`, so the legacy-account signer can build a PAPI `PolkadotSigner` directly — the same way the product-account path already did.

Follow-up to the truapi migration (#186).

## Changes

- **`host/src/accounts.ts`**
  - `getLegacyAccountSigner` is rebuilt over `signing.createTransactionWithLegacyAccount` (`signTx`) and `signRawWithLegacyAccount` (`signBytes`) — no PJS bridge. So opaque signed extensions (e.g. Paseo Next's `AsPgas`) now survive end-to-end for legacy accounts too, not just product accounts.
  - `getProductAccountSigner` drops its `signerType` parameter; the deprecated `"signPayload"` (PJS) mode is gone.
  - Removed the dead helpers (`getPolkadotSignerFromPjs` import, `buildSigningPayloadFields`, `asHex`, `productPjsSigner`).
- **`signer/src/providers/host.ts`** — removed `PRODUCT_SIGNER_TYPE` and the `signerType` argument; the `HostProvider` just calls `getProductAccountSigner(account)`.
- **`tx-demo` / `contracts-demo`** — refreshed comments that claimed the legacy path "routes through PJS".

## Breaking change

`getProductAccountSigner` no longer takes a `signerType` argument. Product-account signing always uses the host's `createTransaction` path (this was already the only path the signer used).

closes: https://github.com/paritytech/product-sdk/issues/228