### PR TITLE
docs(skills): document @parity/product-sdk-auth

### DIFF
--- a/product-sdk/skills/product-sdk-app-builder/SKILL.md
+++ b/product-sdk/skills/product-sdk-app-builder/SKILL.md
@@ -68,6 +68,7 @@ polkadot-api                        # Core runtime (peer dep of descriptors)
 | Submit transactions | `@parity/product-sdk-tx` | product-sdk-transactions |
 | Wallet connection (Talisman, Polkadot.js, Host API) | `@parity/product-sdk-signer` | product-sdk-transactions |
 | Key derivation | `@parity/product-sdk-keys` | product-sdk-transactions |
+| CLI sign-in (QR/mobile) + session signers | `@parity/product-sdk-auth` | product-sdk-transactions |
 | Decentralized storage | `@parity/product-sdk-cloud-storage` | product-sdk-cloud-storage |
 | Pub/sub messaging | `@parity/product-sdk-statement-store` | product-sdk-statement-store |
 | Address encoding | `@parity/product-sdk-address` | product-sdk-utilities |

--- a/product-sdk/skills/product-sdk-app-builder/references/package-selector.md
+++ b/product-sdk/skills/product-sdk-app-builder/references/package-selector.md
@@ -25,8 +25,11 @@ START
 │  ├─ Need testnet dev accounts only?
 │  │  YES → @parity/product-sdk-tx (includes createDevSigner)
 │  │
-│  └─ Need key derivation or session keys?
-│     YES → @parity/product-sdk-keys
+│  ├─ Need key derivation or session keys?
+│  │  YES → @parity/product-sdk-keys
+│  │
+│  └─ Building a CLI that signs as a product account via phone (QR) pairing?
+│     YES → @parity/product-sdk-auth (see product-sdk-transactions › CLI Sign-In)
 │
 ├─ Need to interact with smart contracts (PolkaVM/Solidity on Asset Hub)?
 │  YES → @parity/product-sdk-contracts
@@ -136,6 +139,7 @@ local-storage ← host, logger
 keys ← address, crypto, utils, local-storage
 tx ← keys, logger
 signer ← address, keys, logger
+auth ← address, keys, terminal, tx  (CLI QR/mobile sign-in + session signers)
 chain-client ← descriptors, host  (provides .raw for ContractRuntime creation)
 contracts ← tx, signer, keys, logger  (needs ContractRuntime from @parity/product-sdk-contracts)
 cloud-storage ← chain-client, descriptors, host, logger, tx

--- a/product-sdk/skills/product-sdk-transactions/SKILL.md
+++ b/product-sdk/skills/product-sdk-transactions/SKILL.md
@@ -3,9 +3,11 @@ name: product-sdk-transactions
 description: >
   Submit transactions, connect wallets, manage signers, and handle keys in product-sdk.
   Use when: submitting transactions, integrating Host API signing (Polkadot Desktop/Mobile),
-  managing multi-provider wallet accounts, deriving keys, or creating dev signers for testnet.
+  managing multi-provider wallet accounts, deriving keys, creating dev signers for testnet,
+  or wiring QR/mobile sign-in for CLIs.
   Covers @parity/product-sdk-tx (submit/watch), @parity/product-sdk-signer (wallet connection, account
-  management, multi-provider signing), and @parity/product-sdk-keys (key derivation, session keys).
+  management, multi-provider signing), @parity/product-sdk-keys (key derivation, session keys), and
+  @parity/product-sdk-auth (QR/mobile CLI sign-in + product-account session signers).
 ---
 
 # Product SDK Transactions, Signing, and Key Management
@@ -17,6 +19,7 @@ This skill covers three packages that work together for submitting on-chain tran
 | tx | `@parity/product-sdk-tx` | Submit, watch, retry transactions |
 | signer | `@parity/product-sdk-signer` | Manage signing accounts across providers |
 | keys | `@parity/product-sdk-keys` | Derive keys, accounts, and session keys |
+| auth | `@parity/product-sdk-auth` | QR/mobile CLI sign-in + product-account session signers |
 
 ## Quick Start: Submit a Transaction in 10 Lines
 
@@ -224,6 +227,111 @@ manager.destroy();
 See [`examples/tx-demo/src/main.ts`](../../examples/tx-demo/src/main.ts) for the
 full end-to-end pattern (imports, state, init flow).
 
+## CLI Sign-In and Session Signers (`@parity/product-sdk-auth`)
+
+For **command-line products**, `@parity/product-sdk-auth` is the shared sign-in
+layer: QR/mobile pairing, persisted sessions, a sign-out flow, and a
+product-account signer — all bound to a product via injected config (no per-CLI
+`config.ts`). It sits on top of `@parity/product-sdk-terminal` and derives the
+product account with the same *derivation scheme* the mobile wallet uses (via
+terminal's `deriveProductPublicKey`, the CLI counterpart of the keys package's
+`deriveProductAccountPublicKey` below).
+
+> The signer it returns signs as the **product account** (`/product/{productId}/{index}`),
+> NOT the wallet's selected account — so its address matches the funded /
+> allowance-granted account. This is the CLI analogue of `SignerManager.getProductAccount()`.
+
+### Getting a signer
+
+`resolveSigner` is the one call to reach for: it returns a dev signer when a
+`--suri` is supplied, otherwise the persisted QR session's product-account
+signer.
+
+```ts
+import { createAuthClient, resolveSigner } from "@parity/product-sdk-auth";
+import { submitAndWatch } from "@parity/product-sdk-tx";
+
+// 1. Bind an auth client to your product's config (inject per-product values).
+const authClient = createAuthClient({
+  dappId: "playground",              // scopes ~/.polkadot-apps/${dappId}_* + SSO pairing
+  productId: "playground.dot",       // derives the product account
+  derivationIndex: 0,                // 0 = default product account
+  peopleEndpoints: ["wss://<people-rpc>"],
+});
+
+// 2. Get a PolkadotSigner — dev SURI if provided, else the persisted QR session.
+//    `suri` accepts a dev name (//Alice) OR a full BIP-39 mnemonic with an
+//    optional //<path> derivation suffix. Throws SignerNotAvailableError if
+//    neither a suri nor a session is available (prompt the user to `login`).
+const resolved = await resolveSigner(authClient, { suri: process.env.SURI }); // suri optional
+try {
+  const result = await submitAndWatch(tx, resolved.signer);
+  // resolved.address / resolved.addresses (root/product/H160) / resolved.source ("dev" | "session")
+  // resolved.userSession is present only for QR/mobile sessions (undefined for dev signers).
+} finally {
+  resolved.destroy();                // REQUIRED: releases the session WebSocket
+}
+```
+
+### First-time login (QR flow)
+
+`connect()` + `waitForLogin()` only **authenticate and persist** the session —
+they do not return a signer. After a successful login, call `resolveSigner()`
+(or `authClient.getSessionSigner()`) to actually sign.
+
+```ts
+const conn = await authClient.connect();
+if (conn.kind === "existing") {
+  console.log("Already signed in as", conn.address);
+} else {
+  // Render the QR (terminal UI helpers live under the `/ui` subpath so headless
+  // consumers don't pull terminal-rendering deps).
+  console.log(conn.qrCode);
+  const address = await authClient.waitForLogin(conn.login, (s) => console.log(s.step));
+}
+// Session is now persisted — resolveSigner()/getSessionSigner() will find it.
+```
+
+```ts
+// Status formatters + QR renderer (separate entrypoint):
+import { renderLoginStatus, renderLogoutStatus, renderQrCode } from "@parity/product-sdk-auth/ui";
+```
+
+### Sign-out (logout)
+
+Mirror image of the login flow: find the paired session, disconnect it (notifies
+the mobile app), and clear the local `${dappId}_*` files.
+
+```ts
+const handle = await authClient.findSession();
+if (!handle) {
+  console.log("Not signed in.");
+} else {
+  await authClient.waitForLogout(handle, (s) => console.log(renderLogoutStatus(s)));
+  // LogoutStatus.step: "disconnecting" | "success" | "partial" (local cleared, remote unreachable) | "error"
+}
+```
+
+### Resource allocation (RFC-0010)
+
+A fresh session needs allowances before it can sign (statement store / Bulletin /
+smart-contract sponsoring). The mobile wallet prompts the user to approve. By
+default `requestAllocation` requests `DEFAULT_RESOURCES` — `BulletInAllowance`,
+`StatementStoreAllowance`, and `SmartContractAllowance` for the default (index 0)
+product account.
+
+```ts
+import { DEFAULT_RESOURCES, summarizeOutcomes } from "@parity/product-sdk-auth";
+
+// resolved.userSession is only set for QR/mobile sessions (not dev signers).
+const outcomes = await authClient.requestAllocation(resolved.userSession!); // DEFAULT_RESOURCES, onExisting "Ignore"
+const { granted, rejected, unavailable } = summarizeOutcomes(outcomes, DEFAULT_RESOURCES);
+```
+
+> **When to use which:** `SignerManager.getProductAccount()` is for **in-host / web**
+> products (Host API). `@parity/product-sdk-auth` is for **standalone CLIs** that pair
+> with a phone over QR. Both end at a `PolkadotSigner` you pass to `submitAndWatch`.
+
 ## KeyManager: Hierarchical Key Derivation
 
 ```ts
@@ -282,8 +390,13 @@ Mirrors the algorithm used by polkadot-desktop and polkadot-app-android-v2. sr25
 
 5. **Forgetting account mapping** - EVM contract interactions on Asset Hub require calling `ensureAccountMapped` first.
 
+6. **Not calling `resolved.destroy()`** (auth) - session signers own a WebSocket that keeps the Node event loop alive; the CLI won't exit cleanly until it's torn down. Call it in a `finally`.
+
+7. **Signing on a fresh session without allocations** (auth) - per the package's own note, RFC-0010 allowances are needed before a fresh session can sign (statement store / Bulletin / smart-contract). Run `authClient.requestAllocation(session)` once after first login and let the user approve it on the phone.
+
 ## Reference Files
 
 - [tx-api.md](references/tx-api.md) - Full `@parity/product-sdk-tx` API reference
 - [signer-api.md](references/signer-api.md) - Full `@parity/product-sdk-signer` API reference
 - [keys-api.md](references/keys-api.md) - Full `@parity/product-sdk-keys` API reference
+- [auth-api.md](references/auth-api.md) - Full `@parity/product-sdk-auth` API reference (CLI sign-in, session signers, logout, RFC-0010 allocations)

--- a/product-sdk/skills/product-sdk-transactions/references/auth-api.md
+++ b/product-sdk/skills/product-sdk-transactions/references/auth-api.md
@@ -1,0 +1,153 @@
+# `@parity/product-sdk-auth` API Reference
+
+QR/mobile sign-in + session signing for Polkadot product **CLIs**. The root
+entrypoint is runtime-agnostic (no terminal UI); terminal-rendering helpers live
+under the `./ui` subpath so headless consumers don't pull them in.
+
+Package version documented: **0.2.0**. Re-verify names/signatures against the
+shipped `dist/index.d.ts` before relying on them (`node -e "import('@parity/product-sdk-auth').then(m => console.log(Object.keys(m)))"`).
+
+## Root entrypoint (`@parity/product-sdk-auth`)
+
+### `createAuthClient(config: AuthConfig): AuthClient`
+
+Builds a product-bound auth client. All adapter creation, address derivation, and
+session-storage scoping read from `config`, so the same code serves any product.
+
+```ts
+interface AuthConfig {
+  dappId: string;          // scopes ~/.polkadot-apps/${dappId}_* + the SSO pairing
+  productId: string;       // derives the product account (/product/{productId}/{index})
+  derivationIndex: number; // 0 = default product account
+  peopleEndpoints: string[]; // People-parachain RPC endpoints
+}
+```
+
+### `AuthClient`
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `connect` | `() => Promise<ConnectResult>` | Resolve login state: existing session (address only) or a QR payload + login handle. |
+| `waitForLogin` | `(handle: LoginHandle, onStatus: (s: LoginStatus) => void) => Promise<string \| null>` | Await the running login; returns the SS58 product address or `null` on failure. |
+| `getSessionSigner` | `() => Promise<SessionHandle \| null>` | Build a signer from the persisted session. `null` if none. Owns a WebSocket — call `.destroy()`. |
+| `findSession` | `() => Promise<LogoutHandle \| null>` | Look up the paired session for sign-out. `null` if not signed in. |
+| `waitForLogout` | `(handle: LogoutHandle, onStatus: (s: LogoutStatus) => void) => Promise<void>` | Disconnect the session (notifies the phone) and clear local files. |
+| `requestAllocation` | `(session: UserSession, resources?: AllocatableResource[], onExisting?: OnExistingAllowancePolicy) => Promise<AllocationOutcome[]>` | RFC-0010 resource allocation. Defaults: `DEFAULT_RESOURCES`, `onExisting: "Ignore"`. |
+| `clearLocalAppStorage` | `(dir?: string) => Promise<void>` | Best-effort removal of this app's `${dappId}_*` files under `~/.polkadot-apps/`. |
+
+```ts
+type ConnectResult =
+  | { kind: "existing"; address: string; addresses: SessionAddresses }
+  | { kind: "qr"; qrCode: string; login: LoginHandle };
+
+type LoginStatus =
+  | { step: "waiting" }
+  | { step: "paired" }
+  | { step: "pending"; stage: string }
+  | { step: "success"; address: string; addresses: SessionAddresses }
+  | { step: "error"; message: string };
+
+type LogoutStatus =
+  | { step: "disconnecting"; address: string }
+  | { step: "success"; address: string }
+  | { step: "partial"; address: string; reason: string } // local cleared, remote unreachable
+  | { step: "error"; message: string };
+
+interface SessionAddresses {
+  rootAddress: string;             // SS58 of the mobile root account (input for lookupUsername)
+  productAddress: string;          // SS58 of the derived product account — signs on-chain
+  productH160: `0x${string}`;      // same product pubkey as a 20-byte EVM address (Revive/contracts)
+}
+
+interface SessionHandle {
+  address: string;
+  addresses: SessionAddresses;
+  signer: PolkadotSigner;
+  userSession: UserSession;
+  destroy(): void;                 // REQUIRED — tears down the adapter WebSocket
+}
+
+interface LoginHandle { adapter: TerminalAdapter; authPromise: /* sso.authenticate() */ }
+interface LogoutHandle { adapter: TerminalAdapter; address: string; session: UserSession }
+```
+
+### `resolveSigner(authClient: AuthClient, options?: SignerOptions): Promise<ResolvedSigner>`
+
+The blessed "give me a signer" call. Precedence:
+
+1. `options.suri` → dev signer. Accepts a well-known dev name (`//Alice` … `//Ferdie`)
+   OR a full BIP-39 mnemonic with an optional `//<path>` derivation suffix.
+2. Persisted QR session → session signer (via `authClient.getSessionSigner()`).
+3. Neither → throws `SignerNotAvailableError`.
+
+```ts
+interface SignerOptions { suri?: string }        // takes priority over the session
+type SignerSource = "dev" | "session";
+
+interface ResolvedSigner {
+  signer: PolkadotSigner;
+  address: string;
+  source: SignerSource;
+  userSession?: UserSession;       // QR/mobile only (undefined for dev signers)
+  addresses?: SessionAddresses;    // QR/mobile only
+  destroy(): void;                 // call in a finally — no-op for dev signers
+}
+```
+
+`class SignerNotAvailableError extends Error` — thrown when no signer can be resolved.
+`parseDevAccountName(suri: string): DevAccountName | null` — parse a `//Alice`-style dev SURI (exact-case, `//` prefix required).
+
+### Allocations (RFC-0010)
+
+```ts
+const DEFAULT_RESOURCES: AllocatableResource[]; // BulletInAllowance, StatementStoreAllowance, SmartContractAllowance(0)
+
+// Standalone twin of authClient.requestAllocation — for callers that already have a session + productId.
+function requestResourceAllocation(
+  session: UserSession,
+  productId: string,
+  resources?: AllocatableResource[],   // default DEFAULT_RESOURCES
+  onExisting?: OnExistingAllowancePolicy, // default "Ignore"
+): Promise<AllocationOutcome[]>;
+
+// Bucket outcomes by tag. Order-sensitive: outcomes[i] maps to resources[i].
+function summarizeOutcomes(
+  outcomes: AllocationOutcome[],
+  resources: AllocatableResource[],
+): { granted: AllocatableResource[]; rejected: AllocatableResource[]; unavailable: AllocatableResource[] };
+
+type AllocationOutcome;              // re-export of terminal's ApAllocationOutcome; .tag: "Allocated" | "Rejected" | …
+type AllocatableResource;            // re-export from terminal ({ tag, value })
+type ResourceTag = AllocatableResource["tag"];
+type OnExistingAllowancePolicy;      // re-export from terminal
+```
+
+### Session-signer primitives (re-exported from `@parity/product-sdk-terminal`)
+
+```ts
+createSessionSigner(session: UserSession, ref: ProductAccountRef): PolkadotSigner;
+deriveProductPublicKey(session: UserSession, ref: ProductAccountRef): Uint8Array; // CLI counterpart of keys' deriveProductAccountPublicKey
+sessionRootPublicKey(session: UserSession): Uint8Array;
+const INCOMPLETE_SESSION_MESSAGE: string;
+type ProductAccountRef;              // { productId, derivationIndex }
+```
+
+## `./ui` entrypoint (`@parity/product-sdk-auth/ui`)
+
+Terminal-rendering helpers, isolated so the root stays headless.
+
+```ts
+renderQrCode(payload): Promise<string>;        // re-exported from terminal
+renderLoginStatus(status: LoginStatus): string;
+renderLogoutStatus(status: LogoutStatus): string;
+```
+
+## Lifecycle notes
+
+- Every handle that owns an adapter (`SessionHandle`, `ResolvedSigner` with
+  `source: "session"`) holds a live WebSocket. **Always `destroy()` in a `finally`** —
+  otherwise the Node event loop stays alive and the CLI hangs on exit.
+- `connect()`/`waitForLogin()` only authenticate and persist the session; they do
+  not return a signer. Call `resolveSigner()`/`getSessionSigner()` afterward.
+- A freshly paired session has no allowances — run `requestAllocation()` once
+  (approved on the phone) before statement-store / Bulletin / contract writes.


### PR DESCRIPTION
### Description

- Adds skill docs for @parity/product-sdk-auth (published 0.2.0), the shared QR/mobile sign-in + session-signing package for product CLIs.
- No skill covered it before. The docs are reference for any future CLI product; verified against the shipped package source.
- Docs only - no code or package changes, so no changeset.

### Changes

Modified

**product-sdk/skills/product-sdk-app-builder/SKILL.md**
- Adds an `auth` row to the feature/package table.

**product-sdk/skills/product-sdk-app-builder/references/package-selector.md**
- Adds a decision-tree branch (building a CLI that signs via phone pairing).
- Adds a dependency-graph line for the package.

**product-sdk/skills/product-sdk-transactions/SKILL.md**
- Extends the frontmatter so the skill is found for sign-in queries.
- Adds an `auth` row to the package table.
- New "CLI Sign-In and Session Signers" section: get a signer, first-time QR login, logout, and RFC-0010 resource allocation.
- Two Common Mistakes: not calling `destroy()`, and the fresh-session allocation precondition.
- Links the new reference file.

New

**product-sdk/skills/product-sdk-transactions/references/auth-api.md**
- Full API reference for the package: `createAuthClient`, `resolveSigner`, the `AuthClient` methods (login/logout/allocation), the `/ui` helpers, and lifecycle notes.

### Verify

- Every symbol cited in the docs exists in the package source.
- `pnpm check` passes.
