### PR TITLE
chore(typecheck): add strict per-package typecheck + CI gate

### DIFF
--- a/.github/workflows/product-sdk-ci.yml
+++ b/.github/workflows/product-sdk-ci.yml
@@ -76,6 +76,13 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      # Strict typecheck of every package's src + tests. Runs after build so it
+      # sees each package's current `.d.ts` (workspace deps resolve to dist) and
+      # the generated descriptors. Catches errors vitest's transform and the
+      # per-package tsup build both skip (tests aren't emitted).
+      - name: Typecheck
+        run: pnpm typecheck
+
   test:
     name: "product-sdk: Test"
     runs-on: parity-default

--- a/product-sdk/package.json
+++ b/product-sdk/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test",
+    "typecheck": "pnpm -r typecheck",
     "test:e2e": "pnpm --filter \"@parity/product-sdk-*-demo\" test:e2e",
     "lint": "pnpm -r lint",
     "clean": "pnpm -r clean",

--- a/product-sdk/packages/address/package.json
+++ b/product-sdk/packages/address/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@noble/hashes": "^2.2.0",

--- a/product-sdk/packages/address/tsconfig.typecheck.json
+++ b/product-sdk/packages/address/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/auth/package.json
+++ b/product-sdk/packages/auth/package.json
@@ -22,7 +22,7 @@
         "build": "tsup",
         "test": "vitest run",
         "clean": "rm -rf dist",
-        "typecheck": "tsc --noEmit"
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-address": "workspace:*",

--- a/product-sdk/packages/auth/tsconfig.typecheck.json
+++ b/product-sdk/packages/auth/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/chain-client/package.json
+++ b/product-sdk/packages/chain-client/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-descriptors": "workspace:*",

--- a/product-sdk/packages/chain-client/tsconfig.typecheck.json
+++ b/product-sdk/packages/chain-client/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/cloud-storage/package.json
+++ b/product-sdk/packages/cloud-storage/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/bulletin-sdk": "^0.3.0",

--- a/product-sdk/packages/cloud-storage/tsconfig.typecheck.json
+++ b/product-sdk/packages/cloud-storage/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/contracts/package.json
+++ b/product-sdk/packages/contracts/package.json
@@ -31,7 +31,8 @@
     "scripts": {
         "build": "tsup",
         "clean": "rm -rf dist",
-        "test": "vitest run"
+        "test": "vitest run",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-address": "workspace:*",

--- a/product-sdk/packages/contracts/tsconfig.typecheck.json
+++ b/product-sdk/packages/contracts/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/crypto/package.json
+++ b/product-sdk/packages/crypto/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@noble/ciphers": "^1.2.1",

--- a/product-sdk/packages/crypto/tsconfig.typecheck.json
+++ b/product-sdk/packages/crypto/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/errors/package.json
+++ b/product-sdk/packages/errors/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "devDependencies": {
         "typescript": "^5.7.0",

--- a/product-sdk/packages/errors/tsconfig.typecheck.json
+++ b/product-sdk/packages/errors/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/host/package.json
+++ b/product-sdk/packages/host/package.json
@@ -21,7 +21,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-logger": "workspace:*",

--- a/product-sdk/packages/host/tsconfig.typecheck.json
+++ b/product-sdk/packages/host/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/keys/package.json
+++ b/product-sdk/packages/keys/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-address": "workspace:*",

--- a/product-sdk/packages/keys/tsconfig.typecheck.json
+++ b/product-sdk/packages/keys/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/local-storage/package.json
+++ b/product-sdk/packages/local-storage/package.json
@@ -21,7 +21,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-logger": "workspace:*",

--- a/product-sdk/packages/local-storage/tsconfig.typecheck.json
+++ b/product-sdk/packages/local-storage/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/logger/package.json
+++ b/product-sdk/packages/logger/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "devDependencies": {
         "@types/node": "^22.0.0",

--- a/product-sdk/packages/logger/tsconfig.typecheck.json
+++ b/product-sdk/packages/logger/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/result/package.json
+++ b/product-sdk/packages/result/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "devDependencies": {
         "typescript": "^5.7.0",

--- a/product-sdk/packages/result/tsconfig.typecheck.json
+++ b/product-sdk/packages/result/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/sdk/package.json
+++ b/product-sdk/packages/sdk/package.json
@@ -65,7 +65,8 @@
     "scripts": {
         "build": "NODE_OPTIONS=--max-old-space-size=8192 tsup",
         "test": "vitest run",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-address": "workspace:*",

--- a/product-sdk/packages/sdk/tsconfig.typecheck.json
+++ b/product-sdk/packages/sdk/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/signer/package.json
+++ b/product-sdk/packages/signer/package.json
@@ -21,7 +21,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-address": "workspace:*",

--- a/product-sdk/packages/signer/tsconfig.typecheck.json
+++ b/product-sdk/packages/signer/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/statement-store/package.json
+++ b/product-sdk/packages/statement-store/package.json
@@ -23,7 +23,8 @@
     "scripts": {
         "build": "tsup",
         "clean": "rm -rf dist",
-        "test": "vitest run"
+        "test": "vitest run",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@polkadot-api/substrate-client": "catalog:",

--- a/product-sdk/packages/statement-store/tsconfig.typecheck.json
+++ b/product-sdk/packages/statement-store/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/terminal/package.json
+++ b/product-sdk/packages/terminal/package.json
@@ -29,7 +29,8 @@
         "build": "tsup",
         "clean": "rm -rf dist",
         "pretest": "tsup",
-        "test": "vitest run"
+        "test": "vitest run",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@noble/ciphers": "^2.1.0",

--- a/product-sdk/packages/terminal/src/testing.interop.test.ts
+++ b/product-sdk/packages/terminal/src/testing.interop.test.ts
@@ -41,8 +41,12 @@ const statementStoreShim: StatementStoreAdapter = {
     subscribeStatements: () => () => {},
     submitStatement: () => okAsync(undefined),
 };
+// Must satisfy host-papp's IdentityAdapter (not exported from the package root,
+// so matched structurally). Neither method runs in these tests — `watchIdentity`
+// is present only to keep the shim complete when host-papp adds members.
 const identityShim = {
     readIdentities: () => errAsync(new Error("test shim")),
+    watchIdentity: neverCalled,
 };
 // `createPappAdapter` only reaches the lazy client if we don't supply a
 // `statementStore` / `identities` — we do supply shims for both, so none of

--- a/product-sdk/packages/terminal/tsconfig.typecheck.json
+++ b/product-sdk/packages/terminal/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/tx/package.json
+++ b/product-sdk/packages/tx/package.json
@@ -17,7 +17,8 @@
     "scripts": {
         "build": "tsup",
         "test": "vitest",
-        "clean": "rm -rf dist"
+        "clean": "rm -rf dist",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@parity/product-sdk-keys": "workspace:*",

--- a/product-sdk/packages/tx/tsconfig.typecheck.json
+++ b/product-sdk/packages/tx/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/product-sdk/packages/utils/package.json
+++ b/product-sdk/packages/utils/package.json
@@ -21,7 +21,8 @@
         "build": "tsup",
         "clean": "rm -rf dist",
         "test": "vitest run",
-        "test:watch": "vitest"
+        "test:watch": "vitest",
+        "typecheck": "tsc -p tsconfig.typecheck.json"
     },
     "dependencies": {
         "@noble/hashes": "^2.2.0",

--- a/product-sdk/packages/utils/tsconfig.typecheck.json
+++ b/product-sdk/packages/utils/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Add strict typecheck gate

### What
Adds a `pnpm typecheck` that strictly type-checks every package's source **and tests**, wired into CI.

### Why
Nothing in our local/CI flow actually caught TypeScript errors:
- `pnpm check` is biome (lint/format only)
- `pnpm -r test` runs vitest, which strips types via esbuild
- the `tsup` build doesn't typecheck, and some packages exclude `*.test.ts` from their build tsconfig

The only thing strict-typechecking test files was `docs:generate` (TypeDoc) — so type errors kept slipping through to the docs CI job instead of surfacing where we work.

### How
- A `tsconfig.typecheck.json` per package — extends the package's own config, `noEmit`, includes `src` + tests (no test-exclude). Build configs are untouched, so `dist` still omits tests.
- A `typecheck` script per package + a root `pnpm typecheck`.
- A CI step in the Build job, run **after** `pnpm build` (so workspace deps resolve to current `.d.ts` and generated descriptors exist).

### Bonus
The gate immediately caught a real latent bug on `main`: `terminal`'s test `identityShim` was missing `watchIdentity` (now required by host-papp's `IdentityAdapter`). Fixed here.

### Note for reviewers
Run `pnpm build` before `pnpm typecheck` locally — it needs current `.d.ts` + generated descriptors, otherwise you'll hit false failures.