### PR TITLE
fix(signer): degrade gracefully when resolving a product account signed out

### DIFF
--- a/product-sdk/packages/signer/src/errors.ts
+++ b/product-sdk/packages/signer/src/errors.ts
@@ -41,9 +41,17 @@ export class HostUnavailableError extends SignerError {
 
 /** The host rejected the account or signing request. */
 export class HostRejectedError extends SignerError {
-    constructor(message = "Host rejected the request") {
+    /**
+     * True when the rejection reflects an expected, non-transient state (e.g.
+     * the user is signed out / `NotConnected`) rather than a fault. Callers use
+     * this to degrade to read-only instead of erroring and retrying.
+     */
+    readonly nonTransient: boolean;
+
+    constructor(message = "Host rejected the request", nonTransient = false) {
         super(message);
         this.name = "HostRejectedError";
+        this.nonTransient = nonTransient;
     }
 }
 

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -346,7 +346,9 @@ export class HostProvider implements SignerProvider {
             const raw = cause instanceof Error ? cause.cause : cause;
             const nonTransient = isNonTransientHostError(raw);
             if (nonTransient) {
-                log.debug("product account unavailable (signed out)", { error: message });
+                log.debug("product account unavailable (expected, non-transient)", {
+                    error: message,
+                });
             } else {
                 log.error("failed to get product account", { error: message });
             }
@@ -563,7 +565,7 @@ export class HostProvider implements SignerProvider {
                 const error = accountResult.error;
                 if (error instanceof HostRejectedError && error.nonTransient) {
                     log.warn(
-                        "product account unavailable (signed out); resolving with empty accounts",
+                        "product account unavailable (signed out or unregistered); resolving with empty accounts",
                         { dotNsIdentifier: this.productAccount.dotNsIdentifier },
                     );
                     signerAccounts = [];
@@ -703,7 +705,14 @@ export class HostProvider implements SignerProvider {
  * degrades to read-only (empty accounts) instead of erroring and retrying —
  * it's the user not being signed in, which no amount of retrying will fix.
  */
-const NON_TRANSIENT_HOST_TAGS: ReadonlySet<string> = new Set(["NotConnected"]);
+const NON_TRANSIENT_HOST_TAGS: ReadonlySet<string> = new Set([
+    // User is signed out.
+    "NotConnected",
+    // The product's dotNS identifier isn't registered/valid for this user —
+    // the same condition the `dappName` branch already soft-degrades for.
+    // Retrying can't fix either; both resolve to read-only.
+    "DomainNotValid",
+]);
 
 /**
  * Does a host error represent a non-transient, expected condition (e.g. the
@@ -1450,6 +1459,16 @@ if (import.meta.vitest) {
             expect(isNonTransientHostError({ tag: "NotConnected" })).toBe(true);
         });
 
+        test("matches DomainNotValid (unregistered dotNS identifier)", () => {
+            expect(isNonTransientHostError({ tag: "DomainNotValid" })).toBe(true);
+            expect(
+                isNonTransientHostError({
+                    tag: "Domain",
+                    value: { tag: "V1", value: { tag: "DomainNotValid" } },
+                }),
+            ).toBe(true);
+        });
+
         test("matches NotConnected nested inside a versioned envelope", () => {
             expect(isNonTransientHostError({ tag: "v1", value: { tag: "NotConnected" } })).toBe(
                 true,
@@ -1464,6 +1483,9 @@ if (import.meta.vitest) {
 
         test("does not match transient / other errors", () => {
             expect(isNonTransientHostError({ tag: "PermissionDenied" })).toBe(false);
+            // Deliberate: `Rejected` (user declined the prompt) is NOT non-transient
+            // — a re-prompt can succeed, so it should still surface/retry.
+            expect(isNonTransientHostError({ tag: "Rejected" })).toBe(false);
             expect(isNonTransientHostError({ tag: "v1", value: { reason: "flaky" } })).toBe(false);
             expect(isNonTransientHostError({ reason: "boom" })).toBe(false);
             expect(isNonTransientHostError("NotConnected")).toBe(false); // bare string, not tagged

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -490,11 +490,12 @@ export class HostProvider implements SignerProvider {
         try {
             provider = await this.loadAccountsProvider();
         } catch (cause) {
-            log.warn("host accounts provider unavailable", { cause });
+            const detail = cause instanceof Error ? cause.message : String(cause);
+            log.warn("host accounts provider unavailable", { error: detail });
             return err(
                 new HostUnavailableError(
                     cause instanceof Error
-                        ? `host accounts provider failed: ${cause.message}`
+                        ? `host accounts provider failed: ${detail}`
                         : "host accounts provider is unavailable",
                 ),
             );
@@ -629,7 +630,9 @@ export class HostProvider implements SignerProvider {
                 });
                 log.debug("ChainSubmit permission result", { granted });
             } catch (cause) {
-                log.warn("failed to request ChainSubmit permission", { cause });
+                log.warn("failed to request ChainSubmit permission", {
+                    error: cause instanceof Error ? cause.message : String(cause),
+                });
             }
         }
 
@@ -678,7 +681,9 @@ export class HostProvider implements SignerProvider {
                     },
                 );
             } catch (cause) {
-                log.debug("getUserId threw; product account name stays null", { cause });
+                log.debug("getUserId threw; product account name stays null", {
+                    error: cause instanceof Error ? cause.message : String(cause),
+                });
                 return null;
             }
         };

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -307,8 +307,11 @@ export class HostProvider implements SignerProvider {
                 .match(
                     (account) => account,
                     (error) => {
+                        // Preserve the raw tagged error as `cause` so the catch
+                        // can classify it (e.g. NotConnected → signed-out).
                         throw new Error(
                             `Host rejected product account request: ${formatError(error)}`,
+                            { cause: error },
                         );
                     },
                 )) as RawAccount;
@@ -334,12 +337,20 @@ export class HostProvider implements SignerProvider {
                 },
             });
         } catch (cause) {
-            log.error("failed to get product account", { cause });
-            return err(
-                new HostRejectedError(
-                    cause instanceof Error ? cause.message : "Failed to get product account",
-                ),
-            );
+            const message =
+                cause instanceof Error ? cause.message : "Failed to get product account";
+            // A signed-out (NotConnected) failure is an expected state, not a
+            // fault: log it at debug with a readable message rather than dumping
+            // a raw Error at error level (whose props are non-enumerable and
+            // serialize to `{}`). Genuine faults still log at error.
+            const raw = cause instanceof Error ? cause.cause : cause;
+            const nonTransient = isNonTransientHostError(raw);
+            if (nonTransient) {
+                log.debug("product account unavailable (signed out)", { error: message });
+            } else {
+                log.error("failed to get product account", { error: message });
+            }
+            return err(new HostRejectedError(message, nonTransient));
         }
     }
 
@@ -543,8 +554,25 @@ export class HostProvider implements SignerProvider {
                 this.productAccount.derivationIndex ?? 0,
                 this.productAccount.requestName ?? true,
             );
-            if (!accountResult.ok) return accountResult;
-            signerAccounts = [accountResult.value];
+            if (!accountResult.ok) {
+                // Signed-out / non-transient: soft-degrade to read-only, matching
+                // the `dappName` branch. Returning `ok([])` (not the error) also
+                // means `connect()`'s retry loop doesn't burn attempts on a state
+                // no retry can fix. Genuine transient faults still surface as an
+                // error and get retried.
+                const error = accountResult.error;
+                if (error instanceof HostRejectedError && error.nonTransient) {
+                    log.warn(
+                        "product account unavailable (signed out); resolving with empty accounts",
+                        { dotNsIdentifier: this.productAccount.dotNsIdentifier },
+                    );
+                    signerAccounts = [];
+                } else {
+                    return accountResult;
+                }
+            } else {
+                signerAccounts = [accountResult.value];
+            }
         } else if (this.dappName) {
             // `.dot` is appended if missing so `"my-app"` and `"my-app.dot"`
             // resolve to the same identifier on the host side.
@@ -667,6 +695,32 @@ export class HostProvider implements SignerProvider {
         const account = accountResult.value;
         return ok({ ...account, name: account.name ?? primaryUsername });
     }
+}
+
+/**
+ * Tags that represent an expected signed-out / not-yet-connected state rather
+ * than a fault. When a product-account fetch fails with one of these, the SDK
+ * degrades to read-only (empty accounts) instead of erroring and retrying —
+ * it's the user not being signed in, which no amount of retrying will fix.
+ */
+const NON_TRANSIENT_HOST_TAGS: ReadonlySet<string> = new Set(["NotConnected"]);
+
+/**
+ * Does a host error represent a non-transient, expected condition (e.g. the
+ * user is signed out)? Walks the tagged-enum chain the same way
+ * {@link formatError} does — the identifying tag can sit at the outer level or
+ * nested inside a `{ tag: "v1"|"Domain", value: … }` versioned envelope — so a
+ * match anywhere in the chain counts.
+ */
+function isNonTransientHostError(error: unknown): boolean {
+    let node: unknown = error;
+    // Bounded walk: envelopes are shallow (Domain → V1 → domain error).
+    for (let depth = 0; node && typeof node === "object" && depth < 8; depth++) {
+        const tag = (node as { tag?: unknown }).tag;
+        if (typeof tag === "string" && NON_TRANSIENT_HOST_TAGS.has(tag)) return true;
+        node = (node as { value?: unknown }).value;
+    }
+    return false;
 }
 
 /**
@@ -894,6 +948,46 @@ if (import.meta.vitest) {
             }
             // `.dot` appended automatically.
             expect(mockProvider.getProductAccount).toHaveBeenCalledWith("my-cli.dot", 0);
+        });
+
+        test("connect with productAccount soft-degrades to [] when signed out (NotConnected)", async () => {
+            const mockProvider = createMockProvider({
+                shouldReject: true,
+                error: { tag: "NotConnected" },
+            });
+            const provider = new HostProvider({
+                maxRetries: 3,
+                productAccount: { dotNsIdentifier: "my-cli.dot" },
+                loadAccountsProvider: loadProvider(mockProvider),
+                requestChainSubmitPermissionFn: grantPermission(),
+            });
+            const result = await provider.connect();
+
+            // Resolves read-only rather than erroring.
+            expect(result.ok).toBe(true);
+            if (result.ok) expect(result.value).toEqual([]);
+            // And does NOT retry a signed-out state — one attempt only.
+            expect(mockProvider.getProductAccount).toHaveBeenCalledTimes(1);
+        });
+
+        test("connect with productAccount surfaces + retries a transient failure", async () => {
+            const mockProvider = createMockProvider({
+                shouldReject: true,
+                error: { tag: "SomethingTransient", value: { reason: "flaky" } },
+            });
+            const provider = new HostProvider({
+                maxRetries: 3,
+                retryDelay: 0,
+                productAccount: { dotNsIdentifier: "my-cli.dot" },
+                loadAccountsProvider: loadProvider(mockProvider),
+                requestChainSubmitPermissionFn: grantPermission(),
+            });
+            const result = await provider.connect();
+
+            // Transient failure is NOT swallowed — it errors...
+            expect(result.ok).toBe(false);
+            // ...and was retried the full maxRetries times.
+            expect(mockProvider.getProductAccount).toHaveBeenCalledTimes(3);
         });
 
         test("connect with dappName already ending in .dot doesn't double-append", async () => {
@@ -1322,6 +1416,32 @@ if (import.meta.vitest) {
 
         test("formats a primitive inner value alongside the tag", () => {
             expect(formatError({ tag: "v1", value: "code-42" })).toBe("v1 (code-42)");
+        });
+    });
+
+    describe("isNonTransientHostError", () => {
+        test("matches NotConnected at the outer tag", () => {
+            expect(isNonTransientHostError({ tag: "NotConnected" })).toBe(true);
+        });
+
+        test("matches NotConnected nested inside a versioned envelope", () => {
+            expect(isNonTransientHostError({ tag: "v1", value: { tag: "NotConnected" } })).toBe(
+                true,
+            );
+            expect(
+                isNonTransientHostError({
+                    tag: "Domain",
+                    value: { tag: "V1", value: { tag: "NotConnected" } },
+                }),
+            ).toBe(true);
+        });
+
+        test("does not match transient / other errors", () => {
+            expect(isNonTransientHostError({ tag: "PermissionDenied" })).toBe(false);
+            expect(isNonTransientHostError({ tag: "v1", value: { reason: "flaky" } })).toBe(false);
+            expect(isNonTransientHostError({ reason: "boom" })).toBe(false);
+            expect(isNonTransientHostError("NotConnected")).toBe(false); // bare string, not tagged
+            expect(isNonTransientHostError(undefined)).toBe(false);
         });
     });
 }

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -951,9 +951,16 @@ if (import.meta.vitest) {
         });
 
         test("connect with productAccount soft-degrades to [] when signed out (NotConnected)", async () => {
+            // The real signed-out error truapi 0.4 puts on the err channel is the
+            // full CallErrorValue envelope: Domain → V1 → NotConnected. Verified
+            // against truapi's own `client.test.ts` (getAccount error fixture:
+            // `{ tag: "Domain", value: { tag: "V1", value: { tag: "NotConnected" } } }`).
             const mockProvider = createMockProvider({
                 shouldReject: true,
-                error: { tag: "NotConnected" },
+                error: {
+                    tag: "Domain",
+                    value: { tag: "V1", value: { tag: "NotConnected", value: undefined } },
+                },
             });
             const provider = new HostProvider({
                 maxRetries: 3,
@@ -967,6 +974,25 @@ if (import.meta.vitest) {
             expect(result.ok).toBe(true);
             if (result.ok) expect(result.value).toEqual([]);
             // And does NOT retry a signed-out state — one attempt only.
+            expect(mockProvider.getProductAccount).toHaveBeenCalledTimes(1);
+        });
+
+        test("connect with productAccount soft-degrades on a bare NotConnected tag too", async () => {
+            // Defensive: some host builds / versions may surface the tag unwrapped.
+            const mockProvider = createMockProvider({
+                shouldReject: true,
+                error: { tag: "NotConnected" },
+            });
+            const provider = new HostProvider({
+                maxRetries: 3,
+                productAccount: { dotNsIdentifier: "my-cli.dot" },
+                loadAccountsProvider: loadProvider(mockProvider),
+                requestChainSubmitPermissionFn: grantPermission(),
+            });
+            const result = await provider.connect();
+
+            expect(result.ok).toBe(true);
+            if (result.ok) expect(result.value).toEqual([]);
             expect(mockProvider.getProductAccount).toHaveBeenCalledTimes(1);
         });
 

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -401,12 +401,10 @@ export class HostProvider implements SignerProvider {
 
             return ok(alias);
         } catch (cause) {
-            log.error("failed to get product account alias", { cause });
-            return err(
-                new HostRejectedError(
-                    cause instanceof Error ? cause.message : "Failed to get product account alias",
-                ),
-            );
+            const message =
+                cause instanceof Error ? cause.message : "Failed to get product account alias";
+            log.error("failed to get product account alias", { error: message });
+            return err(new HostRejectedError(message));
         }
     }
 
@@ -438,12 +436,9 @@ export class HostProvider implements SignerProvider {
 
             return ok(result);
         } catch (cause) {
-            log.error("failed to get user id", { cause });
-            return err(
-                new HostRejectedError(
-                    cause instanceof Error ? cause.message : "Failed to get user id",
-                ),
-            );
+            const message = cause instanceof Error ? cause.message : "Failed to get user id";
+            log.error("failed to get user id", { error: message });
+            return err(new HostRejectedError(message));
         }
     }
 
@@ -479,12 +474,10 @@ export class HostProvider implements SignerProvider {
 
             return ok(proof);
         } catch (cause) {
-            log.error("failed to create Ring VRF proof", { cause });
-            return err(
-                new HostRejectedError(
-                    cause instanceof Error ? cause.message : "Failed to create Ring VRF proof",
-                ),
-            );
+            const message =
+                cause instanceof Error ? cause.message : "Failed to create Ring VRF proof";
+            log.error("failed to create Ring VRF proof", { error: message });
+            return err(new HostRejectedError(message));
         }
     }
 

--- a/product-sdk/pending-changesets/signer-signed-out-degrade.md
+++ b/product-sdk/pending-changesets/signer-signed-out-degrade.md
@@ -1,0 +1,20 @@
+---
+"@parity/product-sdk-signer": minor
+"@parity/product-sdk": minor
+---
+
+**Degrade gracefully when resolving a product account while signed out (#253).**
+
+When `HostProvider` is configured with `productAccount` and `connect()` runs
+without an active user session, the signed-out (`NotConnected`) state was
+treated as a fault: logged at `error` level with an opaque `{ cause }` payload
+(which serialized to `{}`), and retried up to 3× by `connect()`. It now
+soft-degrades to an empty accounts list (read-only), mirroring the `dappName`
+branch — signed-out and unregistered-identifier (`DomainNotValid`) failures log
+at `debug`/`warn` and skip retries, while genuine transient faults still error
+and retry.
+
+All host-RPC error logs in `host.ts` now serialize a readable message
+(`{ error: <message> }`) instead of the opaque `{ cause }`, so structured log
+sinks show the actual reason. `HostRejectedError` gains a `nonTransient` flag
+carrying the classification.


### PR DESCRIPTION
## Fix opaque, retried error when resolving a product account while signed out

Closes #253

### Problem
When `HostProvider` is configured with `productAccount` and `connect()` runs without an active user session, the SDK treated the signed-out state as a fault. Three symptoms:

1. **Error-level logging for a normal state** — `NotConnected` (signed out) logged at `error`, even though it's expected. The `dappName` branch already degrades gracefully; the `productAccount` branch didn't.
2. **Unreadable messages** — `log.error("failed to get product account", { cause })` serialized to `{}` because `Error` properties are non-enumerable.
3. **Wasteful retries** — `connect()` retried the non-transient `NotConnected` failure 3×, repeating the same message per load.

### Fix
- **Classify the failure.** A new `isNonTransientHostError` helper walks the tagged-enum / versioned-envelope chain (the same structure `formatError` handles) looking for `NotConnected`. Signed-out failures log at `debug`; the `productAccount` branch soft-degrades to `warn` + empty accounts (read-only), matching `dappName`. Genuine faults still log at `error`.
- **Readable messages.** Logs now carry the `formatError`-derived string instead of a raw `Error`. The original tagged error is preserved via `Error.cause` so classification still works at the catch site.
- **No wasted retries.** Non-transient failures resolve to `ok([])` inside `tryConnect`, so they never reach the retry loop as an error — no `withRetry` change needed. Transient failures still error and retry.