### PR TITLE
feat(cloud-storage): Bulletin allowance status read-back

### DIFF
--- a/product-sdk/.changeset/bulletin-allowance-status.md
+++ b/product-sdk/.changeset/bulletin-allowance-status.md
@@ -1,0 +1,15 @@
+---
+"@parity/product-sdk-cloud-storage": minor
+"@parity/product-sdk": minor
+---
+
+Bulletin allowance status read-back: `getBulletinAllowanceStatus`.
+
+New `getBulletinAllowanceStatus(api, slotAddress)` returns
+`Result<BulletinAllowanceStatus, CloudStorageAuthorizationError>`, composing
+the existing `checkAuthorization` quota read with a `System.Number`
+current-block read. `BulletinAllowanceStatus extends AuthorizationStatus` with
+the two derived fields every consumer re-computes by hand:
+`remainingBlocks` (`max(0, expiration - currentBlock)`) and `usable`
+(`authorized && currentBlock < expiration` — the chain's only hard gate).
+Errors from either on-chain read propagate on the `err` channel.

--- a/product-sdk/packages/cloud-storage/src/authorization.ts
+++ b/product-sdk/packages/cloud-storage/src/authorization.ts
@@ -156,7 +156,11 @@ export async function getBulletinAllowanceStatus(
     const result: BulletinAllowanceStatus = {
         ...status,
         remainingBlocks: Math.max(0, status.expiration - currentBlock),
-        usable: status.authorized && currentBlock < status.expiration,
+        usable:
+            status.authorized &&
+            currentBlock < status.expiration &&
+            status.remainingTransactions > 0 &&
+            status.remainingBytes > 0n,
     };
 
     log.debug("getBulletinAllowanceStatus", {
@@ -552,6 +556,46 @@ if (import.meta.vitest) {
             const status = unwrapOk(await getBulletinAllowanceStatus(api, "5GrwvaEF..."));
 
             expect(status.remainingBlocks).toBe(0);
+            expect(status.usable).toBe(false);
+        });
+
+        test("not usable when unexpired but transaction quota is exhausted", async () => {
+            const exhaustedTx = {
+                extent: {
+                    transactions: 10,
+                    transactions_allowance: 10, // remainingTransactions === 0
+                    bytes: 250_000n,
+                    bytes_permanent: 0n,
+                    bytes_allowance: 1_000_000n,
+                },
+                expiration: 1_000,
+            };
+            const api = createMockApiWithBlock(exhaustedTx, 400);
+            const status = unwrapOk(await getBulletinAllowanceStatus(api, "5GrwvaEF..."));
+
+            expect(status.authorized).toBe(true);
+            expect(status.remainingBlocks).toBe(600); // not expired
+            expect(status.remainingTransactions).toBe(0);
+            expect(status.usable).toBe(false);
+        });
+
+        test("not usable when unexpired but byte quota is exhausted", async () => {
+            const exhaustedBytes = {
+                extent: {
+                    transactions: 3,
+                    transactions_allowance: 10,
+                    bytes: 1_000_000n,
+                    bytes_permanent: 0n,
+                    bytes_allowance: 1_000_000n, // remainingBytes === 0n
+                },
+                expiration: 1_000,
+            };
+            const api = createMockApiWithBlock(exhaustedBytes, 400);
+            const status = unwrapOk(await getBulletinAllowanceStatus(api, "5GrwvaEF..."));
+
+            expect(status.authorized).toBe(true);
+            expect(status.remainingBlocks).toBe(600); // not expired
+            expect(status.remainingBytes).toBe(0n);
             expect(status.usable).toBe(false);
         });
 

--- a/product-sdk/packages/cloud-storage/src/authorization.ts
+++ b/product-sdk/packages/cloud-storage/src/authorization.ts
@@ -7,7 +7,7 @@ import type { PolkadotSigner } from "polkadot-api";
 import { Enum } from "polkadot-api";
 
 import { CloudStorageAuthorizationError, ProductCloudStorageError } from "./errors.js";
-import type { AuthorizationStatus, CloudStorageApi } from "./types.js";
+import type { AuthorizationStatus, BulletinAllowanceStatus, CloudStorageApi } from "./types.js";
 
 const log = createLogger("cloudStorage");
 
@@ -97,6 +97,76 @@ export async function checkAuthorization(
     });
 
     return ok(status);
+}
+
+/**
+ * Read an account's Bulletin authorization AND evaluate its liveness against
+ * the current chain height.
+ *
+ * One extra `System.Number` read on top of {@link checkAuthorization}: the
+ * result carries the raw quota plus the derived `remainingBlocks` and
+ * `usable` fields, so callers don't have to fetch the current block and
+ * compare against `expiration` themselves. Typical use is a slot account's
+ * pre-flight "can I store to Bulletin right now?" check.
+ *
+ * @param api         - Typed Cloud Storage API instance.
+ * @param slotAddress - SS58-encoded account address to check (usually the
+ *   product's allowance slot account).
+ * @returns A {@link Result}: `ok(BulletinAllowanceStatus)`, or
+ *   `err(CloudStorageAuthorizationError)` if either on-chain read fails.
+ *
+ * @example
+ * ```ts
+ * import { getBulletinAllowanceStatus } from "@parity/product-sdk-cloud-storage";
+ *
+ * const r = await getBulletinAllowanceStatus(api, slotAddress);
+ * if (!r.ok) return console.error("allowance check failed:", r.error.message);
+ * if (!r.value.usable) {
+ *     console.error("Bulletin allowance expired — re-request the allocation");
+ * }
+ * ```
+ *
+ * @see {@link checkAuthorization} for the raw quota read without the block comparison.
+ */
+export async function getBulletinAllowanceStatus(
+    api: CloudStorageApi,
+    slotAddress: string,
+): Promise<Result<BulletinAllowanceStatus, CloudStorageAuthorizationError>> {
+    let statusResult: Result<AuthorizationStatus, CloudStorageAuthorizationError>;
+    let currentBlock: number;
+    try {
+        // The two reads are independent — run them in parallel.
+        // checkAuthorization never rejects (its failures come back as err),
+        // so a rejection here can only be the block read. Same single-cast
+        // pattern as checkAuthorization — CloudStorageApi is upstream-typed
+        // as TypedApi<any>, so member access is loose by design.
+        [statusResult, currentBlock] = await Promise.all([
+            checkAuthorization(api, slotAddress),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (api as any).query.System.Number.getValue().then(Number),
+        ]);
+    } catch (error) {
+        // Same no-log policy as checkAuthorization: the error carries the
+        // address and cause; the caller decides whether to report it.
+        return err(new CloudStorageAuthorizationError(slotAddress, error));
+    }
+    if (!statusResult.ok) return statusResult;
+    const status = statusResult.value;
+
+    const result: BulletinAllowanceStatus = {
+        ...status,
+        remainingBlocks: Math.max(0, status.expiration - currentBlock),
+        usable: status.authorized && currentBlock < status.expiration,
+    };
+
+    log.debug("getBulletinAllowanceStatus", {
+        address: slotAddress,
+        currentBlock,
+        remainingBlocks: result.remainingBlocks,
+        usable: result.usable,
+    });
+
+    return ok(result);
 }
 
 /**
@@ -424,6 +494,129 @@ if (import.meta.vitest) {
             const arg = getValue.mock.calls[0][0];
             expect(arg.type).toBe("Account");
             expect(arg.value).toBe("5GrwvaEF...");
+        });
+    });
+
+    describe("getBulletinAllowanceStatus", () => {
+        function createMockApiWithBlock(authResult: unknown, currentBlock: unknown) {
+            return {
+                query: {
+                    TransactionStorage: {
+                        Authorizations: {
+                            getValue: vi.fn().mockResolvedValue(authResult),
+                        },
+                    },
+                    System: {
+                        Number: {
+                            getValue: vi.fn().mockResolvedValue(currentBlock),
+                        },
+                    },
+                },
+            } as unknown as CloudStorageApi;
+        }
+
+        const activeAuth = {
+            extent: {
+                transactions: 3,
+                transactions_allowance: 10,
+                bytes: 250_000n,
+                bytes_permanent: 0n,
+                bytes_allowance: 1_000_000n,
+            },
+            expiration: 1_000,
+        };
+
+        test("usable authorization: derives remainingBlocks from the current height", async () => {
+            const api = createMockApiWithBlock(activeAuth, 400);
+            const status = unwrapOk(await getBulletinAllowanceStatus(api, "5GrwvaEF..."));
+
+            expect(status.authorized).toBe(true);
+            expect(status.remainingTransactions).toBe(7);
+            expect(status.remainingBytes).toBe(750_000n);
+            expect(status.expiration).toBe(1_000);
+            expect(status.remainingBlocks).toBe(600);
+            expect(status.usable).toBe(true);
+        });
+
+        test("expired authorization: remainingBlocks clamps to 0 and usable is false", async () => {
+            const api = createMockApiWithBlock(activeAuth, 1_500);
+            const status = unwrapOk(await getBulletinAllowanceStatus(api, "5GrwvaEF..."));
+
+            expect(status.authorized).toBe(true); // the entry still exists on-chain
+            expect(status.remainingBlocks).toBe(0);
+            expect(status.usable).toBe(false);
+        });
+
+        test("authorization expiring at exactly the current block is not usable", async () => {
+            const api = createMockApiWithBlock(activeAuth, 1_000);
+            const status = unwrapOk(await getBulletinAllowanceStatus(api, "5GrwvaEF..."));
+
+            expect(status.remainingBlocks).toBe(0);
+            expect(status.usable).toBe(false);
+        });
+
+        test("no authorization entry: not authorized, not usable", async () => {
+            const api = createMockApiWithBlock(undefined, 400);
+            const status = unwrapOk(await getBulletinAllowanceStatus(api, "5GrwvaEF..."));
+
+            expect(status.authorized).toBe(false);
+            expect(status.remainingBlocks).toBe(0);
+            expect(status.usable).toBe(false);
+        });
+
+        test("coerces a bigint block number from PAPI", async () => {
+            const api = createMockApiWithBlock(activeAuth, 400n);
+            const status = unwrapOk(await getBulletinAllowanceStatus(api, "5GrwvaEF..."));
+
+            expect(status.remainingBlocks).toBe(600);
+            expect(status.usable).toBe(true);
+        });
+
+        test("propagates err from the inner checkAuthorization", async () => {
+            const api = {
+                query: {
+                    TransactionStorage: {
+                        Authorizations: {
+                            getValue: vi.fn().mockRejectedValue(new Error("RPC connection lost")),
+                        },
+                    },
+                    System: {
+                        Number: { getValue: vi.fn().mockResolvedValue(400) },
+                    },
+                },
+            } as unknown as CloudStorageApi;
+
+            const result = await getBulletinAllowanceStatus(api, "5GrwvaEF...");
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error).toBeInstanceOf(CloudStorageAuthorizationError);
+                expect((result.error.cause as Error).message).toBe("RPC connection lost");
+            }
+        });
+
+        test("returns err(CloudStorageAuthorizationError) when the block read fails", async () => {
+            const api = {
+                query: {
+                    TransactionStorage: {
+                        Authorizations: {
+                            getValue: vi.fn().mockResolvedValue(activeAuth),
+                        },
+                    },
+                    System: {
+                        Number: {
+                            getValue: vi.fn().mockRejectedValue(new Error("DisjointError")),
+                        },
+                    },
+                },
+            } as unknown as CloudStorageApi;
+
+            const result = await getBulletinAllowanceStatus(api, "5GrwvaEF...");
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error).toBeInstanceOf(CloudStorageAuthorizationError);
+                expect(result.error.address).toBe("5GrwvaEF...");
+                expect((result.error.cause as Error).message).toBe("DisjointError");
+            }
         });
     });
 

--- a/product-sdk/packages/cloud-storage/src/index.ts
+++ b/product-sdk/packages/cloud-storage/src/index.ts
@@ -19,7 +19,11 @@ export { CloudStorageClient } from "./client.js";
 export type { CreateCloudStorageClientOptions } from "./client.js";
 export { CloudStorageNetworks } from "./networks.js";
 export type { CloudStorageEnvironment, CloudStorageNetwork } from "./networks.js";
-export { authorizeAccount, checkAuthorization } from "./authorization.js";
+export {
+    authorizeAccount,
+    checkAuthorization,
+    getBulletinAllowanceStatus,
+} from "./authorization.js";
 export type { AuthorizeAccountOptions } from "./authorization.js";
 export { createLazySigner } from "./lazy-signer.js";
 export { executeQuery, queryBytes, queryJson } from "./query.js";
@@ -51,6 +55,7 @@ export {
 // Types
 export type {
     AuthorizationStatus,
+    BulletinAllowanceStatus,
     CloudStorageApi,
     Environment,
     QueryOptions,

--- a/product-sdk/packages/cloud-storage/src/types.ts
+++ b/product-sdk/packages/cloud-storage/src/types.ts
@@ -38,7 +38,13 @@ export interface AuthorizationStatus {
 export interface BulletinAllowanceStatus extends AuthorizationStatus {
     /** Blocks until expiry; 0 if expired or not authorized. */
     remainingBlocks: number;
-    /** `authorized && currentBlock < expiration` — the chain's only hard gate. */
+    /**
+     * Usable *right now*: `authorized`, not expired (`currentBlock < expiration`),
+     * and with quota left (`remainingTransactions > 0 && remainingBytes > 0n`).
+     * Expiry is not the only hard gate — the chain also rejects a store once the
+     * transaction or byte quota is exhausted. Callers must still size-check
+     * `remainingBytes` against their actual payload.
+     */
     usable: boolean;
 }
 

--- a/product-sdk/packages/cloud-storage/src/types.ts
+++ b/product-sdk/packages/cloud-storage/src/types.ts
@@ -27,6 +27,22 @@ export interface AuthorizationStatus {
 }
 
 /**
+ * {@link AuthorizationStatus} plus block-relative liveness, evaluated against
+ * the current Bulletin chain height.
+ *
+ * Returned by {@link getBulletinAllowanceStatus}. Where `AuthorizationStatus`
+ * reports the raw quota and absolute `expiration` block, this adds the two
+ * derived fields every consumer otherwise re-computes by hand: how many
+ * blocks are left and whether the authorization is usable *right now*.
+ */
+export interface BulletinAllowanceStatus extends AuthorizationStatus {
+    /** Blocks until expiry; 0 if expired or not authorized. */
+    remainingBlocks: number;
+    /** `authorized && currentBlock < expiration` — the chain's only hard gate. */
+    usable: boolean;
+}
+
+/**
  * Options for {@link CloudStorageClient.fetchBytes} / {@link CloudStorageClient.fetchJson}.
  */
 export interface QueryOptions {

--- a/product-sdk/pending-changesets/bulletin-allowance-status.md
+++ b/product-sdk/pending-changesets/bulletin-allowance-status.md
@@ -10,6 +10,13 @@ New `getBulletinAllowanceStatus(api, slotAddress)` returns
 the existing `checkAuthorization` quota read with a `System.Number`
 current-block read. `BulletinAllowanceStatus extends AuthorizationStatus` with
 the two derived fields every consumer re-computes by hand:
-`remainingBlocks` (`max(0, expiration - currentBlock)`) and `usable`
-(`authorized && currentBlock < expiration` — the chain's only hard gate).
+`remainingBlocks` (`max(0, expiration - currentBlock)`) and `usable`.
+
+`usable` folds in every hard gate the chain enforces: the authorization must
+exist, be unexpired (`currentBlock < expiration`), **and** have quota left
+(`remainingTransactions > 0` and `remainingBytes > 0`). Expiry is not the only
+gate — the chain also rejects a store once the transaction or byte quota is
+exhausted. `usable === true` still does not guarantee a given store will fit:
+callers must size-check `remainingBytes` against their actual payload.
+
 Errors from either on-chain read propagate on the `err` channel.


### PR DESCRIPTION
## What
The SDK could grant Bulletin storage authorizations but exposed no first-class read-back of current allowance state; consumers hand-rolled the extent/expiry math.

## Change
New `getBulletinAllowanceStatus(api, slotAddress)` → `Result<BulletinAllowanceStatus, CloudStorageAuthorizationError>`, composing the existing `checkAuthorization` quota read with a `System.Number` current-block read (run in parallel) to derive `remainingBlocks` and `usable`. `BulletinAllowanceStatus extends AuthorizationStatus`.

Implements proposal cluster **C1a**. Changeset included (cloud-storage minor + umbrella minor).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
