### PR TITLE
ci(changesets): enforce pending staging

### DIFF
--- a/.github/workflows/product-sdk-ci.yml
+++ b/.github/workflows/product-sdk-ci.yml
@@ -34,7 +34,31 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Require pending changesets outside release PRs
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          pr_title=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
+          if [[ "$pr_title" == "chore(release):"* ]]; then
+            exit 0
+          fi
+
+          base_sha=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
+          ready_changesets=$(
+            git diff --relative --name-only "$base_sha"...HEAD -- .changeset \
+              | grep -E '^\.changeset/[^/]+\.md$' \
+              | grep -v '^\.changeset/README\.md$' \
+              || true
+          )
+
+          if [[ -n "$ready_changesets" ]]; then
+            echo "Changesets must stay in pending-changesets/ until a chore(release): PR promotes them:"
+            echo "$ready_changesets"
+            exit 1
+          fi
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:

--- a/product-sdk/RELEASES.md
+++ b/product-sdk/RELEASES.md
@@ -14,6 +14,10 @@ changeset file under `.changeset/`.
 2. On the PR that closes the work, move the changeset into `.changeset/`.
 3. Merging that PR to `main` is what triggers the release.
 
+CI enforces this split: only PRs whose titles start with `chore(release):`
+may change files in `.changeset/`. All other PRs must keep their changesets
+in `pending-changesets/`.
+
 ## When does a PR need a changeset?
 
 **Rule of thumb:** if your PR will change the published artifact for any


### PR DESCRIPTION
## Summary

- reject release-ready changesets from non-release PRs
- allow dedicated `chore(release):` PRs to promote pending changesets
- document the enforced pending-to-release flow

## Why

PR #266 moved its changesets from `pending-changesets/` into `.changeset/` before merge. Because those release-ready files landed on `main`, the release workflow immediately published the patch as `@parity/product-sdk@0.19.1`; opening another release PR would have duplicated that release.

This follow-up turns the two review nits into a CI rule so feature PRs cannot bypass the dedicated release PR again.

## Testing

- `pnpm check`
- `pnpm changeset status --since=origin/main`
- parsed `.github/workflows/product-sdk-ci.yml` as YAML
- regression simulation flags the two `.changeset/` additions from #266
- current follow-up diff passes with no release-ready changesets

Refs #266
