### PR TITLE
feat(host): bump truapi@0.6.0

### DIFF
--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -27,6 +27,7 @@ import { AccountId, type PolkadotSigner } from "polkadot-api";
 
 import type {
     ContextualAlias as WireAlias,
+    DerivationIndex,
     HostAccountConnectionStatusSubscribeItem,
     HostAccountCreateProofResponse as WireRingVRFProof,
     HostRequestLoginResponse,
@@ -54,16 +55,22 @@ import type { HostSubscription } from "./types.js";
  * - `RingLocation` — where the ring lives (`{ chainId, junctions }`; junctions
  *   address the ring via `PalletInstance` / `CollectionId` steps).
  * - `ProductProofContext` — the product-scoped proof context
- *   (`{ productId, suffix }`), hashed by the host into the 32-byte context a
+ *   (`{ productId, suffix }`), expanded by the host into the 32-byte context a
  *   proof or alias is bound to.
+ * - `DerivationIndex` — the tagged selector `ProductProofContext.suffix`
+ *   carries: `{ tag: "Left", value: number }` for a plain index, or
+ *   `{ tag: "Right", value: HexString }` for a raw 32-byte index.
  */
-export type { ProductProofContext, RingLocation } from "@parity/truapi";
+export type { DerivationIndex, ProductProofContext, RingLocation } from "@parity/truapi";
 
 // The account/alias shapes come from `@parity/truapi`'s generated specs; we
 // derive the SDK-facing views from them so the field inventory tracks the
-// protocol automatically, and override only the byte fields the adapter
-// decodes (the wire types carry `0x`-prefixed `HexString`s, whereas these
-// surface decoded `Uint8Array`s). Same pattern as `@parity/product-sdk-statement-store`.
+// protocol automatically, and override only the fields the adapter re-encodes:
+// byte fields decoded from `0x`-prefixed `HexString`s to `Uint8Array`s, and
+// the tagged derivation-index selector kept as a plain `number` (wrapped back
+// into `Left` at the wire boundary). Shapes re-exported verbatim (e.g.
+// `ProductProofContext`) track the wire as-is. Same pattern as
+// `@parity/product-sdk-statement-store`.
 
 /**
  * One of the user's existing wallet accounts, surfaced through the host and
@@ -86,10 +93,14 @@ export type HostAccount = Omit<WireLegacyAccount, "publicKey"> & {
  *
  * Combines `@parity/truapi`'s `ProductAccountId` (the `{ dotNsIdentifier,
  * derivationIndex }` lookup key) with the `ProductAccount` payload, with
- * `publicKey` decoded to bytes.
+ * `publicKey` decoded to bytes and `derivationIndex` kept as the plain
+ * numeric index (the adapter wraps it into the wire's tagged
+ * {@link DerivationIndex} selector).
  */
-export type ProductAccount = ProductAccountId &
+export type ProductAccount = Omit<ProductAccountId, "derivationIndex"> &
     Omit<WireProductAccount, "publicKey"> & {
+        /** Plain account index within the product subtree. */
+        derivationIndex: number;
         /** Raw public key bytes. */
         publicKey: Uint8Array;
     };
@@ -217,6 +228,14 @@ function toHostExtensions(
     }));
 }
 
+/** Build the wire `ProductAccountId`, wrapping the plain index as a `Left` selector. */
+function toWireProductAccountId(
+    dotNsIdentifier: string,
+    derivationIndex: number,
+): ProductAccountId {
+    return { dotNsIdentifier, derivationIndex: { tag: "Left", value: derivationIndex } };
+}
+
 /** Build an {@link AccountsProvider} over a TruAPI client's `account` / `signing` domains. */
 function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
     const account = client.account;
@@ -233,7 +252,9 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
         },
         getProductAccount(dotNsIdentifier, derivationIndex = 0) {
             return account
-                .getAccount({ productAccountId: { dotNsIdentifier, derivationIndex } })
+                .getAccount({
+                    productAccountId: toWireProductAccountId(dotNsIdentifier, derivationIndex),
+                })
                 .map((response) => ({
                     publicKey: fromHex(response.account.publicKey),
                     dotNsIdentifier,
@@ -272,10 +293,10 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
                 }));
         },
         getProductAccountSigner(account_) {
-            const productAccountId = {
-                dotNsIdentifier: account_.dotNsIdentifier,
-                derivationIndex: account_.derivationIndex,
-            };
+            const productAccountId = toWireProductAccountId(
+                account_.dotNsIdentifier,
+                account_.derivationIndex,
+            );
 
             return {
                 publicKey: account_.publicKey,
@@ -428,7 +449,12 @@ if (import.meta.vitest) {
         );
         expect(calls[0]).toEqual([
             "getAccount",
-            { productAccountId: { dotNsIdentifier: "app.dot", derivationIndex: 2 } },
+            {
+                productAccountId: {
+                    dotNsIdentifier: "app.dot",
+                    derivationIndex: { tag: "Left", value: 2 },
+                },
+            },
         ]);
         expect(account).toEqual({
             publicKey: fromHex("0xaa"),
@@ -443,7 +469,7 @@ if (import.meta.vitest) {
         const provider = adaptAccountsProvider(client);
         const proof = await provider
             .createRingVRFProof(
-                { productId: "app.dot", suffix: "0x00" },
+                { productId: "app.dot", suffix: { tag: "Left", value: 0 } },
                 { chainId: "0x01", junctions: [{ tag: "PalletInstance", value: 1 }] },
                 new Uint8Array([1, 2, 3]),
             )
@@ -453,7 +479,7 @@ if (import.meta.vitest) {
             );
         expect(calls[0][0]).toBe("createAccountProof");
         expect(calls[0][1]).toEqual({
-            context: { productId: "app.dot", suffix: "0x00" },
+            context: { productId: "app.dot", suffix: { tag: "Left", value: 0 } },
             ringLocation: { chainId: "0x01", junctions: [{ tag: "PalletInstance", value: 1 }] },
             message: toHex(new Uint8Array([1, 2, 3])),
         });
@@ -478,7 +504,7 @@ if (import.meta.vitest) {
         expect(calls.at(-1)).toEqual([
             "signRaw",
             {
-                account: { dotNsIdentifier: "app.dot", derivationIndex: 0 },
+                account: { dotNsIdentifier: "app.dot", derivationIndex: { tag: "Left", value: 0 } },
                 payload: { tag: "Bytes", value: { bytes: toHex(new Uint8Array([9, 9])) } },
             },
         ]);
@@ -565,7 +591,7 @@ if (import.meta.vitest) {
         expect(calls.at(-1)).toEqual([
             "createTransaction",
             {
-                signer: { dotNsIdentifier: "app.dot", derivationIndex: 0 },
+                signer: { dotNsIdentifier: "app.dot", derivationIndex: { tag: "Left", value: 0 } },
                 genesisHash: toHex(new Uint8Array([0x01, 0x02])),
                 callData: toHex(new Uint8Array([0xca, 0x11])),
                 extensions: expectedHostExtensions,

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -70,6 +70,7 @@ export type { HostErrorPayload } from "./errors.js";
 export { getAccountsProvider } from "./accounts.js";
 export type {
     AccountsProvider,
+    DerivationIndex,
     HostAccount,
     ProductAccount,
     ContextualAlias,

--- a/product-sdk/packages/host/src/payments.ts
+++ b/product-sdk/packages/host/src/payments.ts
@@ -97,7 +97,7 @@ function adaptPaymentManager(client: TrUApiClient): PaymentManager {
  * const payments = await getPaymentManager();
  * if (payments) {
  *   const sub = payments.subscribeBalance((b) => { ... });
- *   await payments.topUp(1_000_000n, { tag: "ProductAccount", value: { derivationIndex: 0 } });
+ *   await payments.topUp(1_000_000n, { tag: "ProductAccount", value: { derivationIndex: { tag: "Left", value: 0 } } });
  *   const { id } = await payments.requestPayment(500n, "0x…");
  *   sub.unsubscribe();
  * }

--- a/product-sdk/packages/host/src/testing.ts
+++ b/product-sdk/packages/host/src/testing.ts
@@ -193,6 +193,7 @@ export function createFakeTruApiClient(options?: CreateFakeTruApiClientOptions):
                     ringIndex: 0,
                     ringRevision: 0,
                 }),
+            signVrf: () => okAsync({ preOutput: publicKey, proof: signature }),
             connectionStatusSubscribe: () => inertObservable(),
         },
         signing: {

--- a/product-sdk/packages/host/src/truapi.ts
+++ b/product-sdk/packages/host/src/truapi.ts
@@ -183,6 +183,8 @@ export async function createHostPreimageManager(): Promise<PreimageManager | nul
 // Resource-allocation / permission types, re-exported verbatim from
 // `@parity/truapi` (imported above for the local signatures):
 // - `AllocatableResource` — resource types requestable via `requestResourceAllocation`.
+//   Since truapi 0.6.0 its `SmartContractAllowance` variant carries the tagged
+//   `DerivationIndex` selector (`{ tag: "Left", value: number }` for a plain index).
 // - `AllocationOutcome` — per-resource outcome, the string union
 //   `"Allocated" | "Rejected" | "NotAvailable"` (RFC-10).
 // - `RemotePermission` — permission the dapp asks the host to grant via `requestPermission`.

--- a/product-sdk/packages/signer/src/index.ts
+++ b/product-sdk/packages/signer/src/index.ts
@@ -60,6 +60,7 @@ export type {
     HostProviderOptions,
     ProductAccount,
     ContextualAlias,
+    DerivationIndex,
     ProductProofContext,
     RingLocation,
     RingVRFProof,

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -3,6 +3,7 @@
 import { deriveH160, ss58Encode } from "@parity/product-sdk-address";
 import {
     getAccountsProvider,
+    type ProductProofContext,
     type RemotePermission,
     requestPermission,
 } from "@parity/product-sdk-host";
@@ -145,17 +146,12 @@ export interface RingLocation {
 }
 
 /**
- * A product-scoped proof context, hashed by the host into the 32-byte context
- * a proof or alias is bound to.
- *
- * Matches the product-sdk's `ProductProofContext` codec shape.
+ * A product-scoped proof context (`{ productId, suffix }`) and the tagged
+ * `DerivationIndex` selector its `suffix` carries. Re-exported from
+ * `@parity/product-sdk-host` — host is a hard dependency, so the wire shapes
+ * come from one place rather than a structural copy that could drift.
  */
-export interface ProductProofContext {
-    /** dotNS product identifier (e.g. "my-product.dot") scoping the context. */
-    productId: string;
-    /** Hex-encoded suffix distinguishing contexts within the product. */
-    suffix: string;
-}
+export type { DerivationIndex, ProductProofContext } from "@parity/product-sdk-host";
 
 /**
  * A Ring VRF proof plus the values needed to verify it downstream.

--- a/product-sdk/packages/signer/src/providers/index.ts
+++ b/product-sdk/packages/signer/src/providers/index.ts
@@ -13,6 +13,7 @@ export type {
     HostProviderOptions,
     ProductAccount,
     ContextualAlias,
+    DerivationIndex,
     ProductProofContext,
     RingLocation,
     RingVRFProof,

--- a/product-sdk/pending-changesets/truapi-0-6-0.md
+++ b/product-sdk/pending-changesets/truapi-0-6-0.md
@@ -1,0 +1,19 @@
+---
+"@parity/product-sdk-host": minor
+"@parity/product-sdk-signer": minor
+"@parity/product-sdk": minor
+---
+
+Update `@parity/truapi` to 0.6.0. Product-account derivation indexes are now
+tagged `DerivationIndex` selectors on the wire (`{ tag: "Left", value: number }`
+for a plain index, `{ tag: "Right", value: <32-byte hex> }` for a raw index).
+The ergonomic account surfaces keep plain numbers — `getProductAccount(id,
+index)` and `ProductAccount.derivationIndex` are unchanged, with the host
+adapter wrapping them as `Left` — but the pass-through shapes track the
+protocol: `ProductProofContext.suffix` (ring VRF contexts, exported from both
+host and signer) is now the tagged selector instead of a hex string, and
+`PaymentTopUpSource`'s `ProductAccount` source and `AllocatableResource`'s
+`SmartContractAllowance` value carry it too. The
+`DerivationIndex` type is exported from host and signer. The release also
+brings the host's new sr25519 `account.signVrf` API (not yet wrapped by an SDK
+accessor).

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^0.11.0
       version: 0.11.0
     '@parity/truapi':
-      specifier: ^0.5.1
-      version: 0.5.1
+      specifier: ^0.6.0
+      version: 0.6.0
     '@playwright/test':
       specifier: ^1.60.0
       version: 1.60.0
@@ -535,7 +535,7 @@ importers:
         version: link:../result
       '@parity/truapi':
         specifier: 'catalog:'
-        version: 0.5.1
+        version: 0.6.0
       '@polkadot-api/json-rpc-provider':
         specifier: ^0.2.0
         version: 0.2.0
@@ -1648,8 +1648,8 @@ packages:
       '@playwright/test':
         optional: true
 
-  '@parity/truapi@0.5.1':
-    resolution: {integrity: sha512-5AV6YoqnUKXj2wJ/qt/J2i3jpFawhEVkY165V5fSDccGkgK2oVHxlSfLwscXpZp4DxwFTL1FmvkhwhuqPDIdtA==}
+  '@parity/truapi@0.6.0':
+    resolution: {integrity: sha512-fhjnlyuZbS4QSYD+G037APq23/YpkkkAmkYUj4F7EXxhl5G3X5cGh1ieBRkPPHOkKIUjoDiQPbJRQgqiSbqbGQ==}
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -3877,7 +3877,7 @@ snapshots:
     optionalDependencies:
       '@playwright/test': 1.60.0
 
-  '@parity/truapi@0.5.1':
+  '@parity/truapi@0.6.0':
     dependencies:
       '@noble/hashes': 2.2.0
       neverthrow: 8.2.0

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   "@parity/host-api-test-sdk": ^0.11.0
-  "@parity/truapi": ^0.5.1
+  "@parity/truapi": ^0.6.0
   "@playwright/test": ^1.60.0
   "@polkadot-api/json-rpc-provider": ^0.2.0
   "@polkadot-api/substrate-bindings": ^0.20.3


### PR DESCRIPTION
## What

Bump `@parity/truapi` from v0.5.1 to [v0.6.0](https://github.com/paritytech/truapi/releases/tag/%40parity%2Ftruapi%400.6.0).

The release represents product-account derivation indexes as **tagged** `DerivationIndex` selectors (RFC 0022):

```typescript
// a plain numeric index, expanded by hosts to the internal 32-byte index
{ tag: "Left", value: number }
// a raw 32-byte index
{ tag: "Right", value: HexString }
```
It also adds the sr25519 account.signVrf API (RFC 0023).

## What changed
- Ergonomic surfaces keep plain numbers: `getProductAccount(id, index)` and `ProductAccount.derivationIndex` are unchanged, and the host adapter wraps them as Left at the wire boundary. 
- Signer now re-exports `DerivationIndex` and `ProductProofContext` from host instead of keeping structural copies. 