### PR TITLE
chore(e2e): bump host-api-test-sdk to 0.12.0 (fixes host-signed tx hangs)

### DIFF
--- a/product-sdk/examples/chain-client-demo/e2e/fixtures.ts
+++ b/product-sdk/examples/chain-client-demo/e2e/fixtures.ts
@@ -16,7 +16,7 @@ const PRODUCT_URL = "http://localhost:5260";
  * Paseo Asset Hub config with a configurable RPC endpoint.
  *
  * Override via `PASEO_AH_RPC` in CI/local if the default RPC has outages — but
- * the override must serve **paseo v2** (genesis `0x173cea9d…`). Any mirror still
+ * the override must serve **paseo v2** (genesis `0xbf0488db…`). Any mirror still
  * pointing at v1 paseo will hash-mismatch the spread `PASEO_ASSET_HUB.genesisHash`
  * and break the chain-handshake (manifesting as `Tracking stopped` / `BadProof`).
  */

--- a/product-sdk/examples/contracts-demo/e2e/fixtures.ts
+++ b/product-sdk/examples/contracts-demo/e2e/fixtures.ts
@@ -14,7 +14,7 @@ const PRODUCT_URL = "http://localhost:5201";
 /**
  * Paseo Asset Hub config with a configurable RPC endpoint.
  * Override via `PASEO_AH_RPC` if the default RPC has outages — but the override
- * must serve **paseo v2** (genesis `0x173cea9d…`). Any mirror still pointing at
+ * must serve **paseo v2** (genesis `0xbf0488db…`). Any mirror still pointing at
  * v1 paseo will hash-mismatch the spread `PASEO_ASSET_HUB.genesisHash` and
  * break the chain-handshake.
  */

--- a/product-sdk/examples/host-demo/e2e/fixtures.ts
+++ b/product-sdk/examples/host-demo/e2e/fixtures.ts
@@ -16,7 +16,7 @@ const PRODUCT_URL = "http://localhost:5240";
  * Paseo Asset Hub config with a configurable RPC endpoint.
  *
  * Override via `PASEO_AH_RPC` in CI/local if the default RPC has outages — but
- * the override must serve **paseo v2** (genesis `0x173cea9d…`). Any mirror still
+ * the override must serve **paseo v2** (genesis `0xbf0488db…`). Any mirror still
  * pointing at v1 paseo will hash-mismatch the spread `PASEO_ASSET_HUB.genesisHash`
  * and break the chain-handshake (manifesting as `Tracking stopped` / `BadProof`).
  */

--- a/product-sdk/examples/keys-demo/e2e/fixtures.ts
+++ b/product-sdk/examples/keys-demo/e2e/fixtures.ts
@@ -16,7 +16,7 @@ const PRODUCT_URL = "http://localhost:5270";
  * Paseo Asset Hub config with a configurable RPC endpoint.
  *
  * Override via `PASEO_AH_RPC` in CI/local if the default RPC has outages — but
- * the override must serve **paseo v2** (genesis `0x173cea9d…`). Any mirror still
+ * the override must serve **paseo v2** (genesis `0xbf0488db…`). Any mirror still
  * pointing at v1 paseo will hash-mismatch the spread `PASEO_ASSET_HUB.genesisHash`
  * and break the chain-handshake (manifesting as `Tracking stopped` / `BadProof`).
  */

--- a/product-sdk/examples/signer-demo/e2e/fixtures.ts
+++ b/product-sdk/examples/signer-demo/e2e/fixtures.ts
@@ -14,7 +14,7 @@ const PRODUCT_URL = "http://localhost:5210";
 
 /**
  * Override via `PASEO_AH_RPC` in CI/local if the default RPC has outages — but
- * the override must serve **paseo v2** (genesis `0x173cea9d…`). Any mirror still
+ * the override must serve **paseo v2** (genesis `0xbf0488db…`). Any mirror still
  * pointing at v1 paseo will hash-mismatch the spread `PASEO_ASSET_HUB.genesisHash`
  * and break the chain-handshake (manifesting as `Tracking stopped` / `BadProof`).
  */

--- a/product-sdk/examples/statement-store-demo/e2e/fixtures.ts
+++ b/product-sdk/examples/statement-store-demo/e2e/fixtures.ts
@@ -16,7 +16,7 @@ const PRODUCT_URL = "http://localhost:5220";
  * Paseo Asset Hub config with a configurable RPC endpoint.
  *
  * Override via `PASEO_AH_RPC` in CI/local if the default RPC has outages — but
- * the override must serve **paseo v2** (genesis `0x173cea9d…`). Any mirror still
+ * the override must serve **paseo v2** (genesis `0xbf0488db…`). Any mirror still
  * pointing at v1 paseo will hash-mismatch the spread `PASEO_ASSET_HUB.genesisHash`
  * and break the chain-handshake (manifesting as `Tracking stopped` / `BadProof`).
  */

--- a/product-sdk/examples/storage-demo/e2e/fixtures.ts
+++ b/product-sdk/examples/storage-demo/e2e/fixtures.ts
@@ -16,7 +16,7 @@ const PRODUCT_URL = "http://localhost:5250";
  * Paseo Asset Hub config with a configurable RPC endpoint.
  *
  * Override via `PASEO_AH_RPC` in CI/local if the default RPC has outages — but
- * the override must serve **paseo v2** (genesis `0x173cea9d…`). Any mirror still
+ * the override must serve **paseo v2** (genesis `0xbf0488db…`). Any mirror still
  * pointing at v1 paseo will hash-mismatch the spread `PASEO_ASSET_HUB.genesisHash`
  * and break the chain-handshake (manifesting as `Tracking stopped` / `BadProof`).
  */

--- a/product-sdk/examples/tx-demo/e2e/fixtures.ts
+++ b/product-sdk/examples/tx-demo/e2e/fixtures.ts
@@ -16,7 +16,7 @@ const PRODUCT_URL = "http://localhost:5200";
  * Paseo Asset Hub config with a configurable RPC endpoint.
  *
  * Override via `PASEO_AH_RPC` in CI/local if the default RPC has outages — but
- * the override must serve **paseo v2** (genesis `0x173cea9d…`). Any mirror still
+ * the override must serve **paseo v2** (genesis `0xbf0488db…`). Any mirror still
  * pointing at v1 paseo will hash-mismatch the spread `PASEO_ASSET_HUB.genesisHash`
  * and break the chain-handshake (manifesting as `Tracking stopped` / `BadProof`).
  */

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@parity/host-api-test-sdk':
-      specifier: ^0.11.0
-      version: 0.11.0
+      specifier: ^0.12.0
+      version: 0.12.0
     '@parity/truapi':
       specifier: ^0.7.0
       version: 0.7.0
@@ -87,7 +87,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -118,7 +118,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -149,7 +149,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -171,7 +171,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -199,7 +199,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -237,7 +237,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -259,7 +259,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -284,7 +284,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -318,7 +318,7 @@ importers:
     devDependencies:
       '@parity/host-api-test-sdk':
         specifier: 'catalog:'
-        version: 0.11.0(@playwright/test@1.60.0)
+        version: 0.12.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
@@ -1615,11 +1615,17 @@ packages:
   '@novasamatech/host-api@0.8.9':
     resolution: {integrity: sha512-KPh81iVv3sQckq7/oyRpFF2uYBPXJD0+7cRuXO+lnWPAxQBXK1aNUQzSq+vJUHkcGRXJd0up/IlHJ4DMfQyUhQ==}
 
+  '@novasamatech/host-api@0.9.4':
+    resolution: {integrity: sha512-9yVjbyjUVfgDnNx3sJYlRW3kcpvBQv4F1LXqQZfJco/2Egcq8WM6Yplpnubfxhvj+IXl2gEEMQbX3thZms6LUQ==}
+
   '@novasamatech/host-papp@0.8.9':
     resolution: {integrity: sha512-Z1iENq/nn3e1P/4Mj0SS98yqO7tD8841G3xNGqO+O7tSnEjxDY4keS4uy4Rhx5hYIIRcUxe3xe1g/kUbJWVa+g==}
 
   '@novasamatech/scale@0.8.9':
     resolution: {integrity: sha512-/Gt0KwfdkQZGyqd7e8YApx/QPMj/WDFrFYYOW5qxNWlbDpSUmYqNX+D1LECSokXw1vqE2m+ydBmNsAwyhJCLuQ==}
+
+  '@novasamatech/scale@0.9.4':
+    resolution: {integrity: sha512-gUdY/KgWZAv5WUUeGmflo4bhTpfpbFMImtxN2VYfRarOQbbWOzKm7uelqgv8GAQUM85982wVhULPFRDA4b2qXA==}
 
   '@novasamatech/sdk-statement@0.6.0':
     resolution: {integrity: sha512-NTqM+yS45iHgy87lVSWIpFozrTfCUWb7r4ZpsDtN1eFnfixXpDKpPXDWQsvPs+nh18r/jmoMgtlTjUltrS6mYQ==}
@@ -1640,8 +1646,8 @@ packages:
       multiformats: ^13.4.1
       polkadot-api: ^2.1.2
 
-  '@parity/host-api-test-sdk@0.11.0':
-    resolution: {integrity: sha512-yefxCF7yuyCRZRAvVjPvBFnkA7HvYo3l1mlqyv2jhLwRLQ7LqkHpB1TnkH14LCW2qT7e23TzC3XKAL2ATvS3MA==}
+  '@parity/host-api-test-sdk@0.12.0':
+    resolution: {integrity: sha512-0+F7kUA35UzweaP1S7AHl0XeMor9v8BH7Hbi8NbNsk9OGYp3uOqqYQ6Tpv/U9in8Y2tCQQLtTGnN1LuNxcqEgA==}
     peerDependencies:
       '@playwright/test': '>=1.0.0'
     peerDependenciesMeta:
@@ -2584,6 +2590,10 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoevents@10.0.0:
+    resolution: {integrity: sha512-PmIJ3BNxOzgVgnS1r/Pvyj6eZx/xUV2JCPogh0brD6smDIwjRlr1KBl9yoRX323PlfaNrBDDnfCgC9SL00OjSg==}
+    engines: {node: ^22.0.0 || ^24.0.0 || >=26.0.0}
+
   nanoevents@9.1.0:
     resolution: {integrity: sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2601,6 +2611,11 @@ packages:
   nanoid@5.1.9:
     resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
     engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanoid@6.0.0:
+    resolution: {integrity: sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   neverthrow@8.2.0:
@@ -3792,6 +3807,14 @@ snapshots:
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
+  '@novasamatech/host-api@0.9.4':
+    dependencies:
+      '@novasamatech/scale': 0.9.4
+      nanoevents: 10.0.0
+      nanoid: 6.0.0
+      neverthrow: 8.2.0
+      scale-ts: 1.6.1
+
   '@novasamatech/host-papp@0.8.9(esbuild@0.28.1)':
     dependencies:
       '@noble/ciphers': 2.2.0
@@ -3816,6 +3839,11 @@ snapshots:
       - utf-8-validate
 
   '@novasamatech/scale@0.8.9':
+    dependencies:
+      '@polkadot-api/utils': 0.4.0
+      scale-ts: 1.6.1
+
+  '@novasamatech/scale@0.9.4':
     dependencies:
       '@polkadot-api/utils': 0.4.0
       scale-ts: 1.6.1
@@ -3871,9 +3899,9 @@ snapshots:
       multiformats: 13.4.2
       polkadot-api: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
 
-  '@parity/host-api-test-sdk@0.11.0(@playwright/test@1.60.0)':
+  '@parity/host-api-test-sdk@0.12.0(@playwright/test@1.60.0)':
     dependencies:
-      '@novasamatech/host-api': 0.8.9
+      '@novasamatech/host-api': 0.9.4
     optionalDependencies:
       '@playwright/test': 1.60.0
 
@@ -4801,6 +4829,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoevents@10.0.0: {}
+
   nanoevents@9.1.0: {}
 
   nanoid@3.3.12: {}
@@ -4808,6 +4838,8 @@ snapshots:
   nanoid@5.1.11: {}
 
   nanoid@5.1.9: {}
+
+  nanoid@6.0.0: {}
 
   neverthrow@8.2.0:
     optionalDependencies:

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
   - "scripts/bench-consumer"
 
 catalog:
-  "@parity/host-api-test-sdk": ^0.11.0
+  "@parity/host-api-test-sdk": ^0.12.0
   "@parity/truapi": ^0.7.0
   "@playwright/test": ^1.60.0
   "@polkadot-api/json-rpc-provider": ^0.2.0


### PR DESCRIPTION
### Description

Bumps the end-to-end test host from 0.11.0 to 0.12.0. This unblocks the E2E job, which was failing on every test that signs a transaction through the host. Also corrects a stale genesis hash in the e2e fixture comments.

### Changes

`product-sdk/pnpm-workspace.yaml`: Catalog entry `@parity/host-api-test-sdk` goes from `^0.11.0` to `^0.12.0`. This one line is the fix.

`product-sdk/pnpm-lock.yaml`: Lockfile update for the bump. Nothing else in the workspace moves. The test host's transitive `@novasamatech/host-api` goes 0.8.9 to 0.9.4 and brings `@novasamatech/scale` 0.9.4, both test-only.

`product-sdk/examples/*/e2e/fixtures.ts` (8 files): Comment only. The `PASEO_AH_RPC` note cited genesis `0x173cea9d...`, the value that chain had before a reset. Corrected to `0xbf0488db...`. No behaviour change.

No changeset: `@parity/host-api-test-sdk` is a development dependency of the private `examples/*` packages only, and `pnpm changeset status` reports no packages to bump.

### Why these changes

Test host 0.11.0 is built against `@parity/truapi` 0.4.1 while `@parity/product-sdk-host` is on 0.7.0. Between those versions the `derivationIndex` field of `ProductAccountId` grew by one byte (plain number to tagged union). Read requests survived because that field is last in those requests and the extra byte was left unread. The signing request has four fields after it, so all of them shifted and the test host could not decode it. Its transport logs the decode failure and drops the message without answering, so the demo waits for a reply that never comes. That is why these failed as silent 90 second timeouts with no error.

Test host 0.12.0 is built against truapi 0.6.0, whose generated codecs and wire table are identical to 0.7.0.

### Testing

Before, on CI (job exit code 1):

```
FAIL  contracts-demo  e2e/query.spec.ts:44   connection-status stuck on "connecting", 90s timeout
FAIL  contracts-demo  e2e/submit.spec.ts:35  tx never lands, 90s timeout, failed on both attempts
FAIL  tx-demo         e2e/dispatch-error.spec.ts:17
FAIL  tx-demo         e2e/finalized.spec.ts:16
```

tx-demo printed no summary: the first failing package stops the whole run.

After, same suite with the bump applied (exit code 0): `54 passed, 9 skipped, 0 failed`. All four specs above now pass. The 9 skips are pre-existing `describe.skip`, unchanged by this PR.

To reproduce, from `product-sdk/`:

```
pnpm install --frozen-lockfile
pnpm check && pnpm build && pnpm typecheck && pnpm test
CI=1 pnpm test:e2e
```

`CI=1` enables retries and forces fresh dev servers, matching CI.

On a working copy you have had for a while, regenerate the chain descriptors first. That output is gitignored and its build script skips anything already built, so a stale copy reports a chain mismatch unrelated to this PR:

```
pnpm --filter "@parity/product-sdk-descriptors" run clean
pnpm --filter "@parity/product-sdk-descriptors" run build
```

The "after" numbers are from a local macOS run, so CI on Linux is the authoritative check. The suite runs against a live public testnet, so an occasional retry is normal.
