### PR TITLE
feat(host,signer): wrap account.signVrf in the accounts surface

### DIFF
--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -6,7 +6,8 @@
  * `getAccountsProvider()` returns the full accounts surface — user identity
  * (`getUserId` / `requestLogin`), the user's existing wallet accounts
  * (`getLegacyAccounts`), app-scoped product accounts (`getProductAccount` /
- * `getProductAccountAlias`), Ring VRF proofs (`createRingVRFProof`), connection
+ * `getProductAccountAlias`), Ring VRF proofs (`createRingVRFProof`), sr25519 VRF
+ * signatures over a caller-supplied Merlin transcript (`signVrf`), connection
  * status, and PAPI `PolkadotSigner` factories for both product and legacy
  * accounts.
  *
@@ -40,9 +41,12 @@ import type {
     VersionedHostAccountCreateProofError,
     VersionedHostAccountGetAliasError,
     VersionedHostAccountGetError,
+    VersionedHostAccountSignVrfError,
     VersionedHostGetLegacyAccountsError,
     VersionedHostGetUserIdError,
     VersionedHostRequestLoginError,
+    VrfSignature as WireVrfSignature,
+    VrfTranscriptItem as WireVrfTranscriptItem,
     scale,
 } from "@parity/truapi";
 
@@ -106,10 +110,8 @@ export type ProductAccount = Omit<ProductAccountId, "derivationIndex"> &
     };
 
 /**
- * How callers address a product account: the app identifier plus an optional
- * index within its subtree, defaulting to 0.
- *
- * A {@link ProductAccount} satisfies this, so an account returned by
+ * How callers address a product account: app identifier plus an optional index,
+ * defaulting to 0. A {@link ProductAccount} satisfies this, so an account from
  * {@link AccountsProvider.getProductAccount} can be passed straight back in.
  */
 export type ProductAccountRef = Omit<ProductAccountId, "derivationIndex"> & {
@@ -140,6 +142,21 @@ export type RingVRFProof = Omit<WireRingVRFProof, "proof" | "contextualAlias"> &
     /** Alias derived for the request's context. */
     contextualAlias: ContextualAlias;
 };
+
+/**
+ * One `append_message(label, value)` call replayed against a VRF transcript.
+ * Merlin labels are ASCII by convention: use `utf8ToBytes("round")`.
+ *
+ * Derived from `@parity/truapi`'s `VrfTranscriptItem`, decoded to bytes.
+ */
+export type VrfTranscriptItem = { [K in keyof WireVrfTranscriptItem]: Uint8Array };
+
+/**
+ * An sr25519 VRF signature: the pre-output and its DLEQ proof.
+ *
+ * Derived from `@parity/truapi`'s `VrfSignature`, decoded to bytes.
+ */
+export type VrfSignature = { [K in keyof WireVrfSignature]: Uint8Array };
 
 /**
  * Accounts provider handle, backed by `truApi.account.*` / `truApi.signing.*`.
@@ -185,6 +202,30 @@ export interface AccountsProvider {
         location: RingLocation,
         message: Uint8Array,
     ): ResultAsync<RingVRFProof, scale.CallErrorValue<VersionedHostAccountCreateProofError>>;
+    /**
+     * Produce an sr25519 VRF signature from a product account (RFC-0023).
+     *
+     * The host builds a Merlin transcript from `transcriptLabel` and `items`,
+     * then signs it with the account's key. Unlike {@link createRingVRFProof},
+     * this names the signing account instead of proving ring membership.
+     *
+     * The caller owns four things the types cannot enforce:
+     *
+     * - Domain separation. A label borrowed from another protocol makes the
+     *   output replayable across both.
+     * - Freshness. The VRF is deterministic, so per-round values belong in
+     *   `items`.
+     * - Size. Hosts cap the transcript at 32 items and 8 KiB total.
+     * - Authorization. An `AutoSigning` allowance makes these calls silent. It
+     *   is not VRF-scoped, so it covers other signing by that account too.
+     *
+     * Hosts predating the call reject it through the error channel.
+     */
+    signVrf(
+        account: ProductAccountRef,
+        transcriptLabel: Uint8Array,
+        items: VrfTranscriptItem[],
+    ): ResultAsync<VrfSignature, scale.CallErrorValue<VersionedHostAccountSignVrfError>>;
     /**
      * Build a `PolkadotSigner` for a product account. Signing routes through the
      * host's `createTransaction` path: the host decodes the metadata and forwards
@@ -241,11 +282,10 @@ function toHostExtensions(
 }
 
 /**
- * Build the wire `ProductAccountId` from a {@link ProductAccountRef}: default the
- * index to 0 and wrap it as a `Left` selector.
+ * Build the wire `ProductAccountId`: default the index to 0, wrap it as `Left`.
  *
- * The parameter is destructured rather than spread so that a full
- * {@link ProductAccount} can be passed in without its `publicKey` reaching the wire.
+ * Destructured rather than spread, so passing a full {@link ProductAccount}
+ * cannot leak its `publicKey` onto the wire.
  */
 function toWireProductAccountId({
     dotNsIdentifier,
@@ -308,6 +348,21 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
                     },
                     ringIndex: response.ringIndex,
                     ringRevision: response.ringRevision,
+                }));
+        },
+        signVrf(account_, transcriptLabel, items) {
+            return account
+                .signVrf({
+                    account: toWireProductAccountId(account_),
+                    transcriptLabel: toHex(transcriptLabel),
+                    items: items.map(({ label, value }) => ({
+                        label: toHex(label),
+                        value: toHex(value),
+                    })),
+                })
+                .map((response) => ({
+                    preOutput: fromHex(response.preOutput),
+                    proof: fromHex(response.proof),
                 }));
         },
         getProductAccountSigner(account_) {
@@ -430,6 +485,7 @@ if (import.meta.vitest) {
                     ringIndex: 3,
                     ringRevision: 7,
                 }),
+                signVrf: method("signVrf", { preOutput: "0xaa11", proof: "0xbb22" }),
                 connectionStatusSubscribe: () => ({
                     subscribe: () => ({ unsubscribe: vi.fn() }),
                     [Symbol.observable as symbol]() {
@@ -525,6 +581,65 @@ if (import.meta.vitest) {
             ringIndex: 3,
             ringRevision: 7,
         });
+    });
+
+    test("signVrf hex-encodes the transcript and decodes the signature", async () => {
+        const calls: Array<[string, unknown]> = [];
+        const client = makeFakeClient({ onCall: (m, a) => calls.push([m, a]) });
+        const provider = adaptAccountsProvider(client);
+        const transcriptLabel = new Uint8Array([1, 2, 3]);
+        const itemLabel = new Uint8Array([4]);
+        const itemValue = new Uint8Array([5, 6]);
+        const signature = await provider
+            .signVrf({ dotNsIdentifier: "app.dot", derivationIndex: 3 }, transcriptLabel, [
+                { label: itemLabel, value: itemValue },
+            ])
+            .match(
+                (s) => s,
+                () => null,
+            );
+        expect(calls[0]).toEqual([
+            "signVrf",
+            {
+                account: { dotNsIdentifier: "app.dot", derivationIndex: { tag: "Left", value: 3 } },
+                transcriptLabel: toHex(transcriptLabel),
+                items: [{ label: toHex(itemLabel), value: toHex(itemValue) }],
+            },
+        ]);
+        expect(signature).toEqual({ preOutput: fromHex("0xaa11"), proof: fromHex("0xbb22") });
+    });
+
+    test("signVrf defaults the derivation index", async () => {
+        const calls: Array<[string, unknown]> = [];
+        const client = makeFakeClient({ onCall: (m, a) => calls.push([m, a]) });
+        const provider = adaptAccountsProvider(client);
+        await provider.signVrf({ dotNsIdentifier: "app.dot" }, new Uint8Array([1]), []).match(
+            (s) => s,
+            () => null,
+        );
+        expect((calls[0][1] as { account: unknown }).account).toEqual({
+            dotNsIdentifier: "app.dot",
+            derivationIndex: { tag: "Left", value: 0 },
+        });
+    });
+
+    test("signVrf sends only the id fields when given a full product account", async () => {
+        const calls: Array<[string, unknown]> = [];
+        const client = makeFakeClient({ onCall: (m, a) => calls.push([m, a]) });
+        const provider = adaptAccountsProvider(client);
+        const account: ProductAccount = {
+            dotNsIdentifier: "app.dot",
+            derivationIndex: 1,
+            publicKey: new Uint8Array(32).fill(0xaa),
+        };
+        await provider.signVrf(account, new Uint8Array([1]), []).match(
+            (s) => s,
+            () => null,
+        );
+        expect(Object.keys((calls[0][1] as { account: object }).account)).toEqual([
+            "dotNsIdentifier",
+            "derivationIndex",
+        ]);
     });
 
     test("the product signer signs bytes via signing.signRaw", async () => {

--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -106,6 +106,18 @@ export type ProductAccount = Omit<ProductAccountId, "derivationIndex"> &
     };
 
 /**
+ * How callers address a product account: the app identifier plus an optional
+ * index within its subtree, defaulting to 0.
+ *
+ * A {@link ProductAccount} satisfies this, so an account returned by
+ * {@link AccountsProvider.getProductAccount} can be passed straight back in.
+ */
+export type ProductAccountRef = Omit<ProductAccountId, "derivationIndex"> & {
+    /** Plain account index within the product subtree. Defaults to 0. */
+    derivationIndex?: number;
+};
+
+/**
  * A contextual alias obtained from Ring VRF.
  *
  * Proves account membership in a ring without revealing which account.
@@ -228,11 +240,17 @@ function toHostExtensions(
     }));
 }
 
-/** Build the wire `ProductAccountId`, wrapping the plain index as a `Left` selector. */
-function toWireProductAccountId(
-    dotNsIdentifier: string,
-    derivationIndex: number,
-): ProductAccountId {
+/**
+ * Build the wire `ProductAccountId` from a {@link ProductAccountRef}: default the
+ * index to 0 and wrap it as a `Left` selector.
+ *
+ * The parameter is destructured rather than spread so that a full
+ * {@link ProductAccount} can be passed in without its `publicKey` reaching the wire.
+ */
+function toWireProductAccountId({
+    dotNsIdentifier,
+    derivationIndex = 0,
+}: ProductAccountRef): ProductAccountId {
     return { dotNsIdentifier, derivationIndex: { tag: "Left", value: derivationIndex } };
 }
 
@@ -253,7 +271,7 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
         getProductAccount(dotNsIdentifier, derivationIndex = 0) {
             return account
                 .getAccount({
-                    productAccountId: toWireProductAccountId(dotNsIdentifier, derivationIndex),
+                    productAccountId: toWireProductAccountId({ dotNsIdentifier, derivationIndex }),
                 })
                 .map((response) => ({
                     publicKey: fromHex(response.account.publicKey),
@@ -293,10 +311,7 @@ function adaptAccountsProvider(client: TrUApiClient): AccountsProvider {
                 }));
         },
         getProductAccountSigner(account_) {
-            const productAccountId = toWireProductAccountId(
-                account_.dotNsIdentifier,
-                account_.derivationIndex,
-            );
+            const productAccountId = toWireProductAccountId(account_);
 
             return {
                 publicKey: account_.publicKey,
@@ -461,6 +476,27 @@ if (import.meta.vitest) {
             dotNsIdentifier: "app.dot",
             derivationIndex: 2,
         });
+    });
+
+    test("getProductAccount defaults the derivation index in both the request and the result", async () => {
+        const calls: Array<[string, unknown]> = [];
+        const client = makeFakeClient({ onCall: (m, a) => calls.push([m, a]) });
+        const provider = adaptAccountsProvider(client);
+        const account = await provider.getProductAccount("app.dot").match(
+            (a) => a,
+            () => null,
+        );
+        expect(calls[0]).toEqual([
+            "getAccount",
+            {
+                productAccountId: {
+                    dotNsIdentifier: "app.dot",
+                    derivationIndex: { tag: "Left", value: 0 },
+                },
+            },
+        ]);
+        // The resolved index must reach the caller too, not just the wire.
+        expect(account?.derivationIndex).toBe(0);
     });
 
     test("createRingVRFProof hex-encodes the message and decodes the proof response", async () => {

--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -114,7 +114,7 @@ export type ProductAccount = Omit<ProductAccountId, "derivationIndex"> &
  * defaulting to 0. A {@link ProductAccount} satisfies this, so an account from
  * {@link AccountsProvider.getProductAccount} can be passed straight back in.
  */
-export type ProductAccountRef = Omit<ProductAccountId, "derivationIndex"> & {
+export type ProductAccountLookup = Omit<ProductAccountId, "derivationIndex"> & {
     /** Plain account index within the product subtree. Defaults to 0. */
     derivationIndex?: number;
 };
@@ -222,7 +222,7 @@ export interface AccountsProvider {
      * Hosts predating the call reject it through the error channel.
      */
     signVrf(
-        account: ProductAccountRef,
+        account: ProductAccountLookup,
         transcriptLabel: Uint8Array,
         items: VrfTranscriptItem[],
     ): ResultAsync<VrfSignature, scale.CallErrorValue<VersionedHostAccountSignVrfError>>;
@@ -290,7 +290,7 @@ function toHostExtensions(
 function toWireProductAccountId({
     dotNsIdentifier,
     derivationIndex = 0,
-}: ProductAccountRef): ProductAccountId {
+}: ProductAccountLookup): ProductAccountId {
     return { dotNsIdentifier, derivationIndex: { tag: "Left", value: derivationIndex } };
 }
 

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -78,6 +78,8 @@ export type {
     ProductProofContext,
     RingLocation,
     RingVRFProof,
+    VrfSignature,
+    VrfTranscriptItem,
 } from "./accounts.js";
 
 // Higher-level permission wrappers

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -73,7 +73,7 @@ export type {
     DerivationIndex,
     HostAccount,
     ProductAccount,
-    ProductAccountRef,
+    ProductAccountLookup,
     ContextualAlias,
     ProductProofContext,
     RingLocation,

--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -73,6 +73,7 @@ export type {
     DerivationIndex,
     HostAccount,
     ProductAccount,
+    ProductAccountRef,
     ContextualAlias,
     ProductProofContext,
     RingLocation,

--- a/product-sdk/packages/host/src/testing.ts
+++ b/product-sdk/packages/host/src/testing.ts
@@ -360,6 +360,26 @@ if (import.meta.vitest) {
             expect(userId?.primaryUsername).toBe("carol.dot");
         });
 
+        test("signVrf round-trips through the real adapter", async () => {
+            // The fake is the only way a product can test a VRF flow: there is no
+            // dev-provider implementation and the e2e test host does not expose the
+            // call. So the fake's wire shape has to stay decodable by the adapter.
+            createFakeHost();
+            const accounts = await getAccountsProvider();
+            const signature = await accounts
+                ?.signVrf({ dotNsIdentifier: "app.dot" }, new Uint8Array([1]), [
+                    { label: new Uint8Array([2]), value: new Uint8Array([3]) },
+                ])
+                .match(
+                    (s) => s,
+                    () => null,
+                );
+            expect(signature?.preOutput).toBeInstanceOf(Uint8Array);
+            expect(signature?.proof).toBeInstanceOf(Uint8Array);
+            expect(signature?.preOutput).toHaveLength(32);
+            expect(signature?.proof).toHaveLength(64);
+        });
+
         test("statement store resolves", async () => {
             createFakeHost();
             expect(await getStatementStore()).not.toBeNull();

--- a/product-sdk/packages/signer/src/index.ts
+++ b/product-sdk/packages/signer/src/index.ts
@@ -59,9 +59,12 @@ export { HostProvider } from "./providers/host.js";
 export type {
     HostProviderOptions,
     ProductAccount,
+    ProductAccountLookup,
     ContextualAlias,
     DerivationIndex,
     ProductProofContext,
     RingLocation,
     RingVRFProof,
+    VrfSignature,
+    VrfTranscriptItem,
 } from "./providers/host.js";

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -3,9 +3,12 @@
 import { deriveH160, ss58Encode } from "@parity/product-sdk-address";
 import {
     getAccountsProvider,
+    type ProductAccountLookup,
     type ProductProofContext,
     type RemotePermission,
     requestPermission,
+    type VrfSignature,
+    type VrfTranscriptItem,
 } from "@parity/product-sdk-host";
 import { createLogger } from "@parity/product-sdk-logger";
 
@@ -146,12 +149,17 @@ export interface RingLocation {
 }
 
 /**
- * A product-scoped proof context (`{ productId, suffix }`) and the tagged
- * `DerivationIndex` selector its `suffix` carries. Re-exported from
- * `@parity/product-sdk-host` — host is a hard dependency, so the wire shapes
- * come from one place rather than a structural copy that could drift.
+ * Proof-context, account-reference and VRF shapes re-exported from
+ * `@parity/product-sdk-host`. Host is a hard dependency, so these come from one
+ * place rather than a structural copy that could drift.
  */
-export type { DerivationIndex, ProductProofContext } from "@parity/product-sdk-host";
+export type {
+    DerivationIndex,
+    ProductAccountLookup,
+    ProductProofContext,
+    VrfSignature,
+    VrfTranscriptItem,
+} from "@parity/product-sdk-host";
 
 /**
  * A Ring VRF proof plus the values needed to verify it downstream.
@@ -202,6 +210,11 @@ export interface AccountsProvider {
         location: RingLocation,
         message: Uint8Array,
     ) => NeverthrowResultAsync<RingVRFProof, unknown>;
+    signVrf: (
+        account: ProductAccountLookup,
+        transcriptLabel: Uint8Array,
+        items: VrfTranscriptItem[],
+    ) => NeverthrowResultAsync<VrfSignature, unknown>;
     subscribeAccountConnectionStatus: (
         callback: (status: string) => void,
     ) => { unsubscribe: () => void } | (() => void);
@@ -510,6 +523,42 @@ export class HostProvider implements SignerProvider {
             const message =
                 cause instanceof Error ? cause.message : "Failed to create Ring VRF proof";
             log.error("failed to create Ring VRF proof", { error: message });
+            return err(new HostRejectedError(message));
+        }
+    }
+
+    /**
+     * Produce an sr25519 VRF signature from a product account (RFC-0023).
+     *
+     * The host replays `transcriptLabel` and `items` into a Merlin transcript
+     * and signs it. Requires a prior successful `connect()`.
+     *
+     * See `AccountsProvider.signVrf` for what the caller owns: domain
+     * separation, freshness, transcript size, and the `AutoSigning` trade-off.
+     */
+    async signVrf(
+        account: ProductAccountLookup,
+        transcriptLabel: Uint8Array,
+        items: VrfTranscriptItem[],
+    ): Promise<Result<VrfSignature, SignerError>> {
+        if (!this.accountsProvider) {
+            return err(new HostUnavailableError("Host provider is not connected"));
+        }
+
+        try {
+            const signature = (await this.accountsProvider
+                .signVrf(account, transcriptLabel, items)
+                .match(
+                    (result) => result,
+                    (error) => {
+                        throw new Error(`Host rejected VRF signing request: ${formatError(error)}`);
+                    },
+                )) as VrfSignature;
+
+            return ok(signature);
+        } catch (cause) {
+            const message = cause instanceof Error ? cause.message : "Failed to sign VRF";
+            log.error("failed to sign VRF", { error: message });
             return err(new HostRejectedError(message));
         }
     }
@@ -881,6 +930,17 @@ if (import.meta.vitest) {
                         },
                         ringIndex: 0,
                         ringRevision: 0,
+                    });
+                },
+            }),
+            signVrf: vi.fn().mockReturnValue({
+                match: async (onOk: (v: unknown) => unknown, onErr: (e: unknown) => unknown) => {
+                    if (shouldReject) {
+                        return onErr(options.error ?? "Unknown");
+                    }
+                    return onOk({
+                        preOutput: new Uint8Array(32).fill(0x04),
+                        proof: new Uint8Array(64).fill(0x05),
                     });
                 },
             }),
@@ -1387,6 +1447,62 @@ if (import.meta.vitest) {
                 expect(result.value).toHaveLength(1);
                 expect(result.value[0].publicKey).toEqual(productPubkey);
             }
+        });
+    });
+
+    describe("HostProvider.signVrf", () => {
+        const account = { dotNsIdentifier: "myapp.dot", derivationIndex: 0 };
+        const label = new Uint8Array([1, 2, 3]);
+        const items = [{ label: new Uint8Array([4]), value: new Uint8Array([5]) }];
+
+        async function connectedProvider(mockProvider: ReturnType<typeof createMockProvider>) {
+            const provider = new HostProvider({
+                maxRetries: 1,
+                loadAccountsProvider: loadProvider(mockProvider),
+                requestChainSubmitPermissionFn: grantPermission(),
+                productAccount: { dotNsIdentifier: "myapp.dot", requestName: false },
+            });
+            await provider.connect();
+            return provider;
+        }
+
+        test("forwards the request and returns the decoded signature", async () => {
+            const mockProvider = createMockProvider({
+                accounts: [{ publicKey: new Uint8Array(32).fill(0xa2), name: undefined }],
+            });
+            const provider = await connectedProvider(mockProvider);
+
+            const result = await provider.signVrf(account, label, items);
+
+            expect(mockProvider.signVrf).toHaveBeenCalledWith(account, label, items);
+            expect(result.ok).toBe(true);
+            if (result.ok) {
+                expect(result.value.preOutput).toEqual(new Uint8Array(32).fill(0x04));
+                expect(result.value.proof).toEqual(new Uint8Array(64).fill(0x05));
+            }
+        });
+
+        test("returns HostUnavailableError before connect", async () => {
+            const provider = new HostProvider({ maxRetries: 1 });
+            const result = await provider.signVrf(account, label, items);
+            expect(result.ok).toBe(false);
+            if (!result.ok) expect(result.error).toBeInstanceOf(HostUnavailableError);
+        });
+
+        test("surfaces a host rejection as HostRejectedError", async () => {
+            const mockProvider = createMockProvider({
+                accounts: [{ publicKey: new Uint8Array(32).fill(0xa2), name: undefined }],
+            });
+            const provider = await connectedProvider(mockProvider);
+            mockProvider.signVrf.mockReturnValue({
+                match: async (_onOk: (v: unknown) => unknown, onErr: (e: unknown) => unknown) =>
+                    onErr({ tag: "v1", value: { tag: "SignVrfErr::Rejected" } }),
+            });
+
+            const result = await provider.signVrf(account, label, items);
+
+            expect(result.ok).toBe(false);
+            if (!result.ok) expect(result.error).toBeInstanceOf(HostRejectedError);
         });
     });
 

--- a/product-sdk/packages/signer/src/signer-manager.ts
+++ b/product-sdk/packages/signer/src/signer-manager.ts
@@ -18,9 +18,12 @@ import { HostProvider } from "./providers/host.js";
 import type {
     ContextualAlias,
     ProductAccount,
+    ProductAccountLookup,
     ProductProofContext,
     RingLocation,
     RingVRFProof,
+    VrfSignature,
+    VrfTranscriptItem,
 } from "./providers/host.js";
 import type { SignerProvider } from "./providers/types.js";
 import { withRetry } from "./retry.js";
@@ -441,6 +444,30 @@ export class SignerManager {
             );
         }
         return host.createRingVRFProof(context, location, message);
+    }
+
+    /**
+     * Produce an sr25519 VRF signature from a product account (RFC-0023).
+     *
+     * The host replays `transcriptLabel` and `items` into a Merlin transcript
+     * and signs it with the account's key. Only available when connected via
+     * the host provider; returns HOST_UNAVAILABLE otherwise.
+     *
+     * See `AccountsProvider.signVrf` for what the caller owns: domain
+     * separation, freshness, transcript size, and the `AutoSigning` trade-off.
+     */
+    async signVrf(
+        account: ProductAccountLookup,
+        transcriptLabel: Uint8Array,
+        items: VrfTranscriptItem[],
+    ): Promise<Result<VrfSignature, SignerError>> {
+        if (this.isDestroyed) return err(new DestroyedError());
+
+        const host = this.getHostProvider();
+        if (!host) {
+            return err(new HostUnavailableError("VRF signing requires a host provider connection"));
+        }
+        return host.signVrf(account, transcriptLabel, items);
     }
 
     /**
@@ -1010,6 +1037,67 @@ if (import.meta.vitest) {
                 expect(result.value.primaryUsername).toBe("alice.dot");
             }
             expect(fakeHostProvider.getUserId).toHaveBeenCalledTimes(1);
+            manager.destroy();
+        });
+    });
+
+    describe("SignerManager.signVrf", () => {
+        const account = { dotNsIdentifier: "myapp.dot", derivationIndex: 0 };
+        const label = new Uint8Array([1, 2, 3]);
+        const items = [{ label: new Uint8Array([4]), value: new Uint8Array([5]) }];
+
+        test("returns HostUnavailableError when not connected via host (dev provider)", async () => {
+            const manager = new SignerManager({ createProvider: () => mockProvider() });
+            await manager.connect("dev");
+            await flush();
+
+            const result = await manager.signVrf(account, label, items);
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error).toBeInstanceOf(HostUnavailableError);
+                expect(result.error.message).toMatch(/host provider/i);
+            }
+            manager.destroy();
+        });
+
+        test("returns DestroyedError after destroy()", async () => {
+            const manager = new SignerManager({ createProvider: () => mockProvider() });
+            await manager.connect("dev");
+            await flush();
+            manager.destroy();
+
+            const result = await manager.signVrf(account, label, items);
+            expect(result.ok).toBe(false);
+            if (!result.ok) expect(result.error).toBeInstanceOf(DestroyedError);
+        });
+
+        test("delegates to HostProvider.signVrf when connected via host", async () => {
+            const signature = {
+                preOutput: new Uint8Array(32).fill(0x04),
+                proof: new Uint8Array(64).fill(0x05),
+            };
+            const fakeHostProvider = {
+                type: "host" as const,
+                connect: vi.fn().mockResolvedValue(ok([mockAccount()])),
+                disconnect: vi.fn(),
+                onStatusChange: vi.fn().mockReturnValue(() => {}),
+                onAccountsChange: vi.fn().mockReturnValue(() => {}),
+                signVrf: vi.fn().mockResolvedValue(ok(signature)),
+            };
+
+            const manager = new SignerManager({
+                createProvider: (type) =>
+                    type === "host"
+                        ? (fakeHostProvider as unknown as SignerProvider)
+                        : mockProvider(),
+            });
+            await manager.connect("host");
+            await flush();
+
+            const result = await manager.signVrf(account, label, items);
+            expect(result.ok).toBe(true);
+            if (result.ok) expect(result.value).toEqual(signature);
+            expect(fakeHostProvider.signVrf).toHaveBeenCalledWith(account, label, items);
             manager.destroy();
         });
     });

--- a/product-sdk/pending-changesets/accounts-sign-vrf.md
+++ b/product-sdk/pending-changesets/accounts-sign-vrf.md
@@ -1,0 +1,40 @@
+---
+"@parity/product-sdk-host": minor
+"@parity/product-sdk-signer": minor
+"@parity/product-sdk": minor
+---
+
+**Wrap `account.signVrf` (RFC-0023) in the accounts surface (#288).**
+
+Producing an sr25519 VRF over a caller-supplied Merlin transcript previously meant
+reaching for the raw `getTruApi()` client. `AccountsProvider` now has
+`signVrf(account, transcriptLabel, items)`, with `HostProvider.signVrf` and
+`SignerManager.signVrf` alongside `createRingVRFProof`. Bytes in, bytes out: the adapter
+owns the hex encoding and the tagged derivation-index selector, and errors use the same
+`Result` channel as every other account call.
+
+New exported types, also re-exported from `@parity/product-sdk-signer`:
+`VrfTranscriptItem`, `VrfSignature`, and `ProductAccountLookup`
+(`{ dotNsIdentifier, derivationIndex? }`), which a `ProductAccount` satisfies.
+
+**Breaking for implementors.** `signVrf` is a required member of the exported
+`AccountsProvider` interface, so alternative implementations and hand-rolled test doubles
+must add it. Callers are unaffected, and the fake at `@parity/product-sdk-host/testing`
+already implements it.
+
+**Host-only.** There is no `DevProvider` implementation and the e2e test host does not
+expose the call, so this returns `HOST_UNAVAILABLE` outside a host container, matching
+`createRingVRFProof`. Use `createFakeHost()` for local tests.
+
+The caller owns four things the types cannot enforce:
+
+- *Domain separation* — a label borrowed from another protocol makes the output
+  replayable across both.
+- *Freshness* — the VRF is deterministic, so per-round values must enter the transcript
+  as items; otherwise every call returns the same signature.
+- *Size* — hosts cap the transcript at 32 items and 8 KiB total and reject anything
+  larger as an unknown error. The SDK does not pre-validate.
+- *Authorization* — an `AutoSigning` allowance makes these calls silent. It is not
+  VRF-scoped, so granting it also authorizes other signing with that account.
+
+Hosts predating the call reject it through the error channel rather than hanging.


### PR DESCRIPTION
Closes #288
Part of #286

### Description

Adds `signVrf` to the accounts surface so products can produce an sr25519 VRF signature
over a Merlin transcript without going through the raw truAPI client.

### Changes

| File | Change | Impact |
|---|---|---|
| `packages/host/src/accounts.ts` | `signVrf` on `AccountsProvider` and its adapter, plus the `VrfTranscriptItem`, `VrfSignature` and `ProductAccountLookup` types | New public method. Callers pass and receive `Uint8Array`; the adapter handles hex encoding and the tagged derivation index |
| `packages/host/src/index.ts` | Export the three new types | Types are usable by name |
| `packages/host/src/testing.ts` | Test driving the shipped fake through the real adapter | Catches a fake that stops matching what the adapter decodes. This fake is the only way a product can test a VRF flow |
| `packages/signer/src/providers/host.ts` | `HostProvider.signVrf`, the internal provider interface, and type re-exports from host | Same call reachable from the signer, with the signer error types |
| `packages/signer/src/signer-manager.ts` | `SignerManager.signVrf` | Reachable from the object most products already hold |
| `packages/signer/src/index.ts` | Export the three types | Types are usable by name |
| `pending-changesets/accounts-sign-vrf.md` | Changeset, minor for host, signer and the umbrella | Release notes and version bumps |

Two earlier commits also route `getProductAccount` and `getProductAccountSigner` through
one account-reference type, so the tagged derivation index is built in a single place.

### Why these changes

The hosts have implemented `account.signVrf` for a while, but no SDK accessor exposed it.
Products that needed it had to call `getTruApi()` directly and hand roll hex encoding,
account addressing and error handling. That also pins the product to the truAPI wire
format, which the SDK is supposed to absorb.

The concrete consumer is the airdrop lottery ticket on the People chain, which cannot be
produced in hosted mode today.

### Breaking change

`AccountsProvider` is an exported interface and `signVrf` is a required member, so
anything that implements it, including hand written test doubles, must add the method.
Code that only calls the provider is unaffected. The fake in
`@parity/product-sdk-host/testing` already implements it.

### Testing

```bash
cd product-sdk
pnpm install
pnpm -r build
pnpm -r --no-bail test -- --run
pnpm typecheck
pnpm check
```

Unit test results:
```
 pnpm --filter "@parity/product-sdk-host"   test -- --run
 pnpm --filter "@parity/product-sdk-signer" test -- --run
```

| Package | Before | After |
|---|---|---|
| `@parity/product-sdk-host` | 87 passed | 92 passed |
| `@parity/product-sdk-signer` | 107 passed | 113 passed |

All other packages are unchanged and green. `pnpm typecheck` and `pnpm check` are clean.