### PR TITLE
refactor(sdk): deprecate the context-alias helpers and drop the ring stubs

### DIFF
--- a/product-sdk/packages/sdk/src/identity/index.ts
+++ b/product-sdk/packages/sdk/src/identity/index.ts
@@ -3,8 +3,12 @@
 /**
  * @parity/product-sdk/identity
  *
- * Identity utilities: DotNS name resolution, context-alias derivation,
- * and Ring VRF anonymous aliases.
+ * Identity utilities: DotNS name resolution, plus the deprecated context-alias
+ * helpers.
+ *
+ * For real Ring VRF aliases and proofs, use `SignerManager`'s
+ * `getProductAccountAlias` and `createRingVRFProof` from
+ * `@parity/product-sdk-signer`.
  */
 
 // DotNS utilities
@@ -19,21 +23,13 @@ export {
 } from "./dotns.js";
 export type { PeopleUsernameChain, PeopleUsernameQueryApi } from "./dotns.js";
 
-// Context alias utilities
-export {
-    deriveContextAlias,
-    verifyContextAlias,
-    deriveAnonymousAlias,
-    createRingProof,
-    verifyRingProof,
-} from "./product-account.js";
+// Context alias utilities (deprecated)
+export { deriveContextAlias, verifyContextAlias } from "./product-account.js";
 
 // Types
 export type {
     DotNsRecord,
     ContextAliasInfo,
-    AnonymousAliasInfo,
-    RingLocation,
     VerificationResult,
     OnChainIdentity,
 } from "./types.js";

--- a/product-sdk/packages/sdk/src/identity/product-account.test.ts
+++ b/product-sdk/packages/sdk/src/identity/product-account.test.ts
@@ -1,0 +1,102 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Frozen vectors for the deprecated context-alias helpers.
+ *
+ * These pin current behaviour so the deprecation cannot silently alter the
+ * derivation. Never re-derive: a caller may use the value as a plain
+ * identifier, where different output bytes would be a silent break.
+ */
+import { ss58Decode, ss58Encode } from "@parity/product-sdk-address";
+import { blake2b256 } from "@parity/product-sdk-crypto";
+import { describe, expect, it } from "vitest";
+import { deriveContextAlias, verifyContextAlias } from "./product-account.js";
+
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const CONTEXT = "voting-round-1";
+
+/** Recomputes the documented formula from primitives, independent of the implementation. */
+function expectedAliasPublicKey(parentAddress: string, context: string): Uint8Array {
+    const { publicKey } = ss58Decode(parentAddress);
+    const contextBytes = new TextEncoder().encode(context);
+    const combined = new Uint8Array(publicKey.length + contextBytes.length);
+    combined.set(publicKey, 0);
+    combined.set(contextBytes, publicKey.length);
+    return blake2b256(combined);
+}
+
+describe("deriveContextAlias", () => {
+    it("returns blake2b256(parentPublicKey || context), encoded at the given prefix", () => {
+        const alias = deriveContextAlias(ALICE, CONTEXT);
+        const expected = expectedAliasPublicKey(ALICE, CONTEXT);
+
+        expect(alias.address).toBe(ss58Encode(expected, 42));
+    });
+
+    it("matches a frozen vector for a known parent and context", () => {
+        const alias = deriveContextAlias(ALICE, CONTEXT);
+
+        expect(alias.address).toBe("5GPTdhxkG9wNKhCSN1vZrCwrf3fwvAf4j487vqrkVzvRMH6F");
+        expect(alias.h160Address).toBe("0x93d10a91de267ba79b27fbec373e5a3b2e86a283");
+        expect(alias.parentAddress).toBe(ALICE);
+        expect(alias.context).toBe(CONTEXT);
+    });
+
+    it("defaults to ss58 prefix 42", () => {
+        expect(deriveContextAlias(ALICE, CONTEXT).address).toBe(
+            deriveContextAlias(ALICE, CONTEXT, 42).address,
+        );
+    });
+
+    it("changes only the encoding when the ss58 prefix changes, not the key", () => {
+        const at42 = deriveContextAlias(ALICE, CONTEXT, 42);
+        const at0 = deriveContextAlias(ALICE, CONTEXT, 0);
+
+        expect(at0.address).not.toBe(at42.address);
+        expect(Array.from(ss58Decode(at0.address).publicKey)).toEqual(
+            Array.from(ss58Decode(at42.address).publicKey),
+        );
+    });
+
+    it("derives a different alias for a different context", () => {
+        expect(deriveContextAlias(ALICE, "round-1").address).not.toBe(
+            deriveContextAlias(ALICE, "round-2").address,
+        );
+    });
+});
+
+describe("verifyContextAlias", () => {
+    it("accepts an alias derived from the same parent and context", () => {
+        const alias = deriveContextAlias(ALICE, CONTEXT);
+
+        expect(verifyContextAlias(alias.address, ALICE, CONTEXT)).toBe(true);
+    });
+
+    it("rejects a different context", () => {
+        const alias = deriveContextAlias(ALICE, CONTEXT);
+
+        expect(verifyContextAlias(alias.address, ALICE, "voting-round-2")).toBe(false);
+    });
+
+    it("rejects a different parent", () => {
+        const alias = deriveContextAlias(ALICE, CONTEXT);
+        const bob = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+        expect(verifyContextAlias(alias.address, bob, CONTEXT)).toBe(false);
+    });
+
+    it("returns false rather than throwing on an undecodable address", () => {
+        expect(verifyContextAlias("not-an-address", ALICE, CONTEXT)).toBe(false);
+    });
+
+    // Guards the byte-level comparison: `addressesEqual` from
+    // @parity/product-sdk-address compares SS58 strings exactly and would
+    // return false here, silently narrowing behaviour.
+    it("compares public keys, so it accepts an alias encoded at another prefix", () => {
+        const alias = deriveContextAlias(ALICE, CONTEXT, 42);
+        const reencoded = ss58Encode(ss58Decode(alias.address).publicKey, 0);
+
+        expect(reencoded).not.toBe(alias.address);
+        expect(verifyContextAlias(reencoded, ALICE, CONTEXT)).toBe(true);
+    });
+});

--- a/product-sdk/packages/sdk/src/identity/product-account.test.ts
+++ b/product-sdk/packages/sdk/src/identity/product-account.test.ts
@@ -10,6 +10,7 @@
 import { ss58Decode, ss58Encode } from "@parity/product-sdk-address";
 import { blake2b256 } from "@parity/product-sdk-crypto";
 import { describe, expect, it } from "vitest";
+import * as identity from "./index.js";
 import { deriveContextAlias, verifyContextAlias } from "./product-account.js";
 
 const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
@@ -98,5 +99,31 @@ describe("verifyContextAlias", () => {
 
         expect(reencoded).not.toBe(alias.address);
         expect(verifyContextAlias(reencoded, ALICE, CONTEXT)).toBe(true);
+    });
+});
+
+describe("the identity export surface", () => {
+    // These threw on every call, so no working consumer could exist. Deleting
+    // turns a guaranteed runtime throw into a compile error.
+    it("no longer exports the unimplemented ring helpers", () => {
+        for (const name of ["deriveAnonymousAlias", "createRingProof", "verifyRingProof"]) {
+            expect(name in identity).toBe(false);
+        }
+    });
+
+    it("still exports the DotNS helpers and the deprecated context-alias pair", () => {
+        for (const name of [
+            "resolveDotNs",
+            "reverseDotNs",
+            "isDotNsAvailable",
+            "resolvePeopleUsernameOwner",
+            "isValidDotNsName",
+            "normalizeDotNsName",
+            "accountIdHexToBytes",
+            "deriveContextAlias",
+            "verifyContextAlias",
+        ]) {
+            expect(name in identity).toBe(true);
+        }
     });
 });

--- a/product-sdk/packages/sdk/src/identity/product-account.ts
+++ b/product-sdk/packages/sdk/src/identity/product-account.ts
@@ -1,9 +1,12 @@
 // Copyright 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Context alias derivation
+ * Context alias derivation (deprecated, removal in 0.23.0)
  *
  * Derives a deterministic, context-bound alias from a parent account using blake2b-256.
+ *
+ * The output is a hash, not a key, so no signing key exists for the addresses
+ * returned here. See the notes on each function for what to use instead.
  *
  * NOTE: this is NOT the canonical sr25519 product-account derivation used by
  * mobile, desktop, and dotli hosts. For that, use
@@ -23,19 +26,27 @@ const log = createLogger("identity");
  * The alias is deterministically derived using:
  * aliasPublicKey = blake2b256(parentPublicKey || context)
  *
+ * @deprecated Returns addresses that no key can spend. The alias public key is a
+ *   blake2b-256 hash rather than a derived key, so no secret corresponds to the
+ *   SS58 address or to the H160: both can receive value and neither can ever
+ *   send it. Removal: `@parity/product-sdk` 0.23.0. Replace by intent:
+ *
+ *   - An account that holds or spends value:
+ *     `SignerManager.getProductAccount(dotNsIdentifier, index)` from
+ *     `@parity/product-sdk-signer`. Host-backed and actually signable.
+ *   - The address offline, with no host: `deriveProductAccountPublicKey` from
+ *     `@parity/product-sdk-keys`, the canonical sr25519 soft derivation.
+ *   - An unlinkable per-context alias:
+ *     `SignerManager.getProductAccountAlias(context, location)`, plus
+ *     `createRingVRFProof` for proofs.
+ *   - A context-scoped identifier, never used as an account: `blake2b256` from
+ *     `@parity/product-sdk/crypto`. Same bytes, without address packaging that
+ *     invites the mistake.
+ *
  * @param parentAddress - Parent account SS58 address
  * @param context - Context string for derivation (e.g. an app id or scope label)
  * @param ss58Prefix - SS58 prefix (default: 42)
  * @returns Context alias info
- *
- * @example
- * ```ts
- * const alias = deriveContextAlias(
- *   '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
- *   'voting-round-1'
- * );
- * console.log('Alias address:', alias.address);
- * ```
  */
 export function deriveContextAlias(
     parentAddress: string,
@@ -70,6 +81,12 @@ export function deriveContextAlias(
 
 /**
  * Verify that a context alias was derived from a parent account.
+ *
+ * @deprecated Recomputes {@link deriveContextAlias} from two public values and
+ *   compares the result, so it confirms a derivation relationship and nothing
+ *   more. No secret enters the operation at any point, which means there is
+ *   nothing here to authenticate: a passing result does not show that anyone
+ *   controls either account. Removal: `@parity/product-sdk` 0.23.0.
  *
  * @param aliasAddress - Context alias SS58 address
  * @param parentAddress - Claimed parent address

--- a/product-sdk/packages/sdk/src/identity/product-account.ts
+++ b/product-sdk/packages/sdk/src/identity/product-account.ts
@@ -13,7 +13,7 @@
 import { createLogger } from "@parity/product-sdk-logger";
 import { blake2b256 } from "@parity/product-sdk-crypto";
 import { ss58Encode, ss58Decode, deriveH160 } from "@parity/product-sdk-address";
-import type { ContextAliasInfo, AnonymousAliasInfo, RingLocation } from "./types.js";
+import type { ContextAliasInfo } from "./types.js";
 
 const log = createLogger("identity");
 
@@ -95,70 +95,4 @@ export function verifyContextAlias(
     } catch {
         return false;
     }
-}
-
-/**
- * Derive an anonymous alias using Ring VRF
- *
- * This creates a context-specific alias that cannot be linked
- * back to the original identity without the ring proof.
- *
- * @param context - Context for alias derivation (e.g., "voting-round-1")
- * @param ringLocation - Ring location for proof generation
- * @returns Anonymous alias info
- */
-export function deriveAnonymousAlias(
-    context: string,
-    ringLocation: RingLocation,
-): AnonymousAliasInfo {
-    log.debug("Deriving anonymous alias", { context, ringLocation });
-
-    // TODO: Implement Ring VRF alias derivation
-    // This requires the Ring VRF implementation from TruAPI
-    throw new Error(
-        "deriveAnonymousAlias() is not yet implemented. " +
-            "This requires container mode with Ring VRF support.",
-    );
-}
-
-/**
- * Create a Ring VRF proof for a message
- *
- * @param message - Message to prove
- * @param ringLocation - Ring location
- * @returns Proof bytes
- */
-export async function createRingProof(
-    message: Uint8Array,
-    ringLocation: RingLocation,
-): Promise<Uint8Array> {
-    log.debug("Creating ring proof", { ringLocation });
-
-    // TODO: Implement Ring VRF proof creation via TruAPI
-    throw new Error(
-        "createRingProof() is not yet implemented. " +
-            "This requires container mode with Ring VRF support.",
-    );
-}
-
-/**
- * Verify a Ring VRF proof
- *
- * @param message - Original message
- * @param proof - Proof bytes
- * @param alias - Expected alias
- * @returns True if proof is valid
- */
-export async function verifyRingProof(
-    message: Uint8Array,
-    proof: Uint8Array,
-    alias: string,
-): Promise<boolean> {
-    log.debug("Verifying ring proof");
-
-    // TODO: Implement Ring VRF proof verification
-    throw new Error(
-        "verifyRingProof() is not yet implemented. " +
-            "This requires container mode with Ring VRF support.",
-    );
 }

--- a/product-sdk/packages/sdk/src/identity/types.ts
+++ b/product-sdk/packages/sdk/src/identity/types.ts
@@ -18,7 +18,12 @@ export interface DotNsRecord {
     expiresAt?: number;
 }
 
-/** Context alias info: a deterministic, context-bound alias derived from a parent account */
+/**
+ * Context alias info: a deterministic, context-bound alias derived from a parent account
+ *
+ * @deprecated Returned by `deriveContextAlias`, whose addresses no key can spend.
+ *   Removal: `@parity/product-sdk` 0.23.0.
+ */
 export interface ContextAliasInfo {
     /** Alias SS58 address */
     address: string;

--- a/product-sdk/packages/sdk/src/identity/types.ts
+++ b/product-sdk/packages/sdk/src/identity/types.ts
@@ -30,24 +30,6 @@ export interface ContextAliasInfo {
     context: string;
 }
 
-/** Ring VRF alias info */
-export interface AnonymousAliasInfo {
-    /** Anonymous alias identifier */
-    alias: string;
-    /** Ring location for proof generation */
-    ringLocation: RingLocation;
-    /** Context used for alias derivation */
-    context: string;
-}
-
-/** Ring location for VRF proofs */
-export interface RingLocation {
-    /** Ring index */
-    ringIndex: number;
-    /** Member index within ring */
-    memberIndex: number;
-}
-
 /** Identity verification result */
 export interface VerificationResult {
     /** Whether identity is verified */

--- a/product-sdk/packages/signer/src/providers/host.ts
+++ b/product-sdk/packages/signer/src/providers/host.ts
@@ -137,7 +137,9 @@ export interface ContextualAlias {
  * Location of a Ring VRF ring on-chain: the hosting chain's genesis hash plus
  * the junction path addressing the ring within it.
  *
- * Matches the product-sdk's `RingLocation` codec shape.
+ * Structurally matches `RingLocation` from `@parity/truapi`, re-exported by
+ * `@parity/product-sdk-host`. Declared locally with `string` in place of the
+ * branded hex types so callers can pass plain strings.
  */
 export interface RingLocation {
     /** Genesis hash of the chain hosting the ring. */

--- a/product-sdk/pending-changesets/deprecate-context-alias.md
+++ b/product-sdk/pending-changesets/deprecate-context-alias.md
@@ -1,0 +1,43 @@
+---
+"@parity/product-sdk": minor
+"@parity/product-sdk-signer": patch
+---
+
+**Deprecate the context-alias helpers, delete the unimplemented ring-alias stubs (#287).**
+
+`deriveContextAlias` returns addresses that can receive value and can never spend it: the alias
+public key is `blake2b256(parentPublicKey || context)`, a hash rather than a derived key, so no
+secret corresponds to the SS58 address or the H160. The address encodes and validates fine, so
+nothing surfaces until value arrives at it.
+
+**Deleted:** `deriveAnonymousAlias`, `createRingProof`, `verifyRingProof`, `AnonymousAliasInfo`,
+and identity's `RingLocation`. Each function was a debug log followed by an unconditional
+`throw`, with no branch or early return, so no working consumer could exist and this break is
+compile-time only. The real ring VRF operations already live on `SignerManager` in
+`@parity/product-sdk-signer` as `getProductAccountAlias` and `createRingVRFProof`, host-backed so
+the host selects the member key within the ring. Identity's `RingLocation` was also the wrong
+shape, `{ringIndex, memberIndex}` against the protocol type `{chainId, junctions}`.
+
+**Deprecated, removal in `@parity/product-sdk` 0.23.0:** `deriveContextAlias`,
+`verifyContextAlias`, `ContextAliasInfo`. Their output is unchanged, so a caller using an alias as
+a plain identifier has a release to migrate. `verifyContextAlias` compares two public values with
+no secret involved anywhere, so it confirms a derivation relationship and authenticates nothing.
+
+The derivation output is deliberately unchanged: the same name and signature returning different
+bytes would break identifier consumers silently, with no compile error.
+
+### Migration
+
+| If you used it for | Use instead |
+|---|---|
+| An account that holds or spends value | `SignerManager.getProductAccount(dotNsIdentifier, index)` from `@parity/product-sdk-signer` |
+| The address offline, with no host | `deriveProductAccountPublicKey` from `@parity/product-sdk-keys`, the canonical sr25519 soft derivation |
+| An unlinkable per-context alias | `SignerManager.getProductAccountAlias(context, location)`, plus `createRingVRFProof` for proofs |
+| A context-scoped identifier, never used as an account | `blake2b256` from `@parity/product-sdk/crypto`: the same bytes, without address packaging |
+
+The DotNS half of `./identity` is unaffected (`resolveDotNs`, `reverseDotNs`, `isDotNsAvailable`,
+`resolvePeopleUsernameOwner` and the name helpers), and the subpath itself is not deprecated.
+
+`@parity/product-sdk-signer` takes a patch for one doc comment: its local `RingLocation` claimed
+to match the product-sdk shape, which was the opposite shape and is now deleted. No type or
+behaviour change.


### PR DESCRIPTION
Part of #286
Refs #287, which stays open for the personhood read layer.

### Description

`@parity/product-sdk/identity` exported five alias functions. Three raised an error on every
call, whatever you passed in. This PR deletes those three, so calling code now fails to build
instead of failing at runtime.

The other two work, but return an address that can receive funds and can never send them: the key
is a blake2b hash of the parent public key, and a hash has no matching private key, so nothing can
ever sign for it. Both are now deprecated, name the release that removes them (0.23.0), and list
what to use instead. Their output is unchanged, so no caller changes behaviour.

### Changes

| File | Change | Impact |
|---|---|---|
| `packages/sdk/src/identity/product-account.ts` | Deleted `deriveAnonymousAlias`, `createRingProof`, `verifyRingProof`. Deprecated `deriveContextAlias`, `verifyContextAlias` | Calls to the deleted three become compile errors. The other two are unchanged |
| `packages/sdk/src/identity/types.ts` | Deleted `AnonymousAliasInfo` and `RingLocation`. Deprecated `ContextAliasInfo` | Removes a `RingLocation` shaped `{ringIndex, memberIndex}`, the opposite of the protocol type `{chainId, junctions}` |
| `packages/sdk/src/identity/index.ts` | Dropped five exports, fixed the module docstring | Subpath no longer advertises Ring VRF helpers that do not exist |
| `packages/sdk/src/identity/product-account.test.ts` | New, 12 tests | Locks the derivation output so the deprecation cannot alter it |
| `packages/signer/src/providers/host.ts` | One doc comment | It claimed to match the product-sdk `RingLocation` shape. That was the opposite shape, and this PR deletes it |
| `pending-changesets/deprecate-context-alias.md` | New | `@parity/product-sdk` minor, `@parity/product-sdk-signer` patch |

DotNS is untouched. `resolveDotNs`, `reverseDotNs`, `resolvePeopleUsernameOwner` and the name
helpers work as before, and the subpath itself is not deprecated.

### Why these changes

Funds sent to a `deriveContextAlias` address are unrecoverable, and nothing surfaces until value
arrives, because the address validates like any other. The old docs made it worse by printing the
address in an example with no warning. This is the first time the SDK says so.

The three deleted functions could never work, so deleting them turns a guaranteed runtime error
into a compile error. A `@deprecated` tag adds nothing to a function that already throws.

The two working helpers are deprecated instead, because a caller may be using the value as a
plain identifier where the address property is irrelevant. Those callers are not broken and get a
release to move. For the same reason the output is left alone: the same function returning
different bytes would break them silently, with no compile error. Removal at a minor is in
policy, since `RELEASES.md` makes any pre-1.0 breaking change a minor.

The signer change follows from deleting identity's `RingLocation`, which a comment there pointed
at. It takes a patch because that comment ships in the published `.d.ts`, and that patch cascades
a version bump to five dependent packages containing no change, which is expected.

### Testing

From `product-sdk/`:

```bash
pnpm install
pnpm --filter "@parity/product-sdk" test
pnpm --filter "@parity/product-sdk-signer" test
pnpm build && pnpm typecheck && pnpm check
```

| Suite | Before | After |
|---|---|---|
| `@parity/product-sdk` | 1 file, 6 tests passed | 2 files, 18 tests passed |
| `@parity/product-sdk-signer` | 7 files, 113 tests passed | 7 files, 113 tests passed |
| build, typecheck, check | pass | pass |

### Related issues

#287 is a sub-issue of the #286 tracker and this PR does half of it. The substantive reason is that the three deleted functions are stubs for what #289 builds for real: `deriveAnonymousAlias` was a placeholder for ring VRF aliases, and identity's `RingLocation` was a wrong-shaped duplicate of the protocol type #289 uses. Leaving them in place would mean two same-named types of opposite shape once that lands. Neither `Part of` nor `Refs` is a closing keyword, so nothing auto-closes here.

