### PR TITLE
docs(changesets): fix the pending release notes

### DIFF
--- a/product-sdk/pending-changesets/README.md
+++ b/product-sdk/pending-changesets/README.md
@@ -121,3 +121,14 @@ cascades only at patch level (controlled by `updateInternalDependencies:
 "patch"` in `.changeset/config.json`) and the umbrella ends up at an
 oddly lower bump than its child. Prior waves (0.3.0 → 0.4.0,
 0.4.0 → 0.5.0) followed this policy.
+
+### Declare required-member additions
+
+When a change adds a required member to an exported interface, say so in
+the body. Existing implementations and hand-rolled test doubles break at
+compile time even though no caller changes, so the break is invisible to
+anyone reading only the call sites. The wording to copy:
+
+> **Breaking for implementors.** `signVrf` is a required member of the
+> exported `AccountsProvider` interface, so alternative implementations
+> and hand-rolled test doubles must add it. Callers are unaffected.

--- a/product-sdk/pending-changesets/host-chain-discovery.md
+++ b/product-sdk/pending-changesets/host-chain-discovery.md
@@ -21,3 +21,10 @@ the zero-arg form needs discovery, so it throws there and outside a container.
 new `chainInfo` option, so tests can drive discovery; omitting it models a host
 predating the call. The `chain.getChainInfo` binding this rides on ships in
 `@parity/truapi` 0.9.0, adopted separately.
+
+The explicit form is only unchanged on legacy hosts. On a host that serves discovery,
+`getChainAPI("paseo")` can now fail where it previously connected:
+`EnvironmentMismatchError` when the host's asset hub genesis matches a different bundled
+environment, and `GenesisMismatchError` when it matches none and the bundled asset hub
+descriptor disagrees with the host. Both surface at the call rather than at the first
+storage read, so an unchanged call site fails earlier and with a different error type.

--- a/product-sdk/pending-changesets/host-ring-vrf-sign.md
+++ b/product-sdk/pending-changesets/host-ring-vrf-sign.md
@@ -9,3 +9,8 @@ registered ring-VRF member key for protocols that carry their own proof, as oppo
 `RingVrfKeyHandle` as the alias and proof calls, from `listRingVrfKeys` /
 `findRingVrfKeyHandle`, and hands back the signature as bytes. `SignerManager` does not
 wrap it; call the host package's `AccountsProvider` directly.
+
+**Breaking for implementors.** `ringVrfSign` is a required member of the exported
+`AccountsProvider` interface, so alternative implementations and hand-rolled test doubles
+must add it. Callers are unaffected, and the fake at `@parity/product-sdk-host/testing`
+already implements it.

--- a/product-sdk/pending-changesets/truapi-09-ring-vrf-keys.md
+++ b/product-sdk/pending-changesets/truapi-09-ring-vrf-keys.md
@@ -24,3 +24,10 @@ The signer package's re-exported `RingLocation` now uses TrUAPI's `` chainId: `0
 instead of a plain `string`; callers loading chain IDs from configuration must narrow or validate
 them before assignment. Custom `HostProviderOptions.loadAccountsProvider` implementations must
 also provide the newly required `registerRingVrfKey` and `listRingVrfKeys` methods.
+
+`findRingVrfKeyHandle` is exported from `@parity/product-sdk-host`, not from
+`@parity/product-sdk-signer`, which re-exports the ring-VRF types only. A product depending on
+the signer package alone needs `@parity/product-sdk-host` as a second direct dependency for the
+selection step. Prefer the helper over an inline comparison: it requires the junction path to
+match in order and compares chain and collection ids case-insensitively, so a shortcut that
+checks only `chainId` can pick a key registered for a different ring on the same chain.


### PR DESCRIPTION
### Description

Fixes the prose in three of the seven changesets parked for the 0.22.0 wave, and records the
convention that would have caught the main omission. No code. Nothing is promoted to
`.changeset/`, so this publishes nothing.

### Changes

`pending-changesets/host-ring-vrf-sign.md`: declares `ringVrfSign` as a required member of
the exported `AccountsProvider`. Wording and wrapping copied from `accounts-sign-vrf.md`,
which documents the same kind of break for `signVrf`.

`pending-changesets/host-chain-discovery.md`: the explicit `getChainAPI(env)` form is
unchanged only on legacy hosts. On a discovery-capable host it throws
`EnvironmentMismatchError` when the host's asset hub genesis matches a different bundled
environment, and `GenesisMismatchError` when it matches none and the bundled asset hub
descriptor disagrees. Both surface at the call, not at the first storage read.

`pending-changesets/truapi-09-ring-vrf-keys.md`: `findRingVrfKeyHandle` is exported from
`@parity/product-sdk-host`, not from `@parity/product-sdk-signer`, which re-exports the
ring-VRF types only. Also why the inline comparison is a trap: the helper matches the
junction path in order and compares chain and collection ids case-insensitively, so a
shortcut checking only `chainId` can pick a key registered for a different ring on the same
chain.

`pending-changesets/README.md`: new `Declare required-member additions` subsection, so the
next author states the break instead of rediscovering the need for it. Quotes the pattern
inline rather than pointing at `accounts-sign-vrf.md`, which is deleted once the wave is
consumed.

### Why these changes

Four members became required on `AccountsProvider` since host 0.15.1: `listRingVrfKeys`,
`registerRingVrfKey`, `ringVrfSign` and `signVrf`. Three were documented, `ringVrfSign` was
not. Implementations and hand-rolled test doubles break at compile time even though no
caller changes, so the break is invisible to anyone reading only call sites.

The chain-discovery changeset said calls passing an environment keep the previous behaviour
on legacy hosts, which is true, and said nothing about discovery-capable hosts, where an
unchanged call site can now fail earlier and with a different error type.


