### PR TITLE
feat(identity): discover and verify DotNS addresses

### DIFF
--- a/product-sdk/packages/sdk/src/identity/dotns-abis.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-abis.ts
@@ -238,6 +238,39 @@ export const DOTNS_PROTOCOL_REGISTRY_ABI: AbiEntry[] = [
         outputs: [{ name: "node", type: "bytes32" }],
         stateMutability: "view",
     },
+    {
+        type: "function",
+        name: "get",
+        inputs: [{ name: "key", type: "bytes32" }],
+        outputs: [{ name: "addr", type: "address" }],
+        stateMutability: "view",
+    },
+];
+
+/**
+ * `RootGatewayDispatcher.TARGET`, the PoP controller it forwards to. `immutable`,
+ * so a rotation means a new dispatcher and a new pallet value, which is why
+ * discovery starts at the pallet rather than here.
+ */
+export const DOTNS_ROOT_GATEWAY_DISPATCHER_ABI: AbiEntry[] = [
+    {
+        type: "function",
+        name: "TARGET",
+        inputs: [],
+        outputs: [{ name: "", type: "address" }],
+        stateMutability: "view",
+    },
+];
+
+/** `DotnsPopController.protocolRegistry`, the only hop that names the registry. */
+export const DOTNS_POP_CONTROLLER_ABI: AbiEntry[] = [
+    {
+        type: "function",
+        name: "protocolRegistry",
+        inputs: [],
+        outputs: [{ name: "", type: "address" }],
+        stateMutability: "view",
+    },
 ];
 
 /** `IPopRules.PopStatus`. Ordering is meaningful: a user meets a tier when `userStatus >= status`. */
@@ -258,11 +291,13 @@ export const POP_STATUS = { NoStatus: 0, PopLite: 1, PopFull: 2, Reserved: 3 } a
  * So extending this module to another network means resolving its TLD, which
  * `resolveTld` already does — not adding a second address table.
  *
- * Each address answers `DotnsProtocolRegistry.get(bytes32)` under its
- * `DotnsConstants` key (the name below, right-padded to 32 bytes) and has a
- * `Revive.AccountInfoOf` entry. They are pinned rather than resolved at runtime,
- * so re-verify after a redeploy; `protocolRegistry` is the address to walk from
- * if we ever resolve the rest dynamically.
+ * Five answer `DotnsProtocolRegistry.get(bytes32)` under the keys in
+ * `DOTNS_REGISTRY_KEYS`, two of which differ from the field name used here.
+ * `protocolRegistry` has no key and comes from the gateway walk. All six have a
+ * `Revive.AccountInfoOf` entry.
+ *
+ * Pinned, not resolved at runtime: re-verify after a redeploy, or have the
+ * client do it with `verifyDotNsAddresses`.
  */
 export const DOTNS_ADDRESSES = {
     registry: "0xf34054fd76BbF85f216cf9908226D5f0A72E50CA",

--- a/product-sdk/packages/sdk/src/identity/dotns-abis.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-abis.ts
@@ -281,10 +281,10 @@ export const POP_STATUS = { NoStatus: 0, PopLite: 1, PopFull: 2, Reserved: 3 } a
  *
  * Not a per-network table, despite what the old name (`PASEO_ASSETHUB_DOTNS`)
  * implied: every DotNS network is deployed through the same CREATE3 factory, so
- * the addresses are identical everywhere and **only the TLD differs**. Verified
- * on both Paseo Asset Hub Next V2 and Previewnet — `protocolRegistry.get(...)`
- * returns the same registry on each, and all six addresses hold contracts on
- * both. `paritytech/dotns` `DEPLOYMENTS.md` states the mechanism, and
+ * the addresses are identical everywhere and **only the TLD differs**, `.paseo`
+ * on Paseo Asset Hub Next V2 and `.test` on Previewnet. Verified on both:
+ * `protocolRegistry.get(...)` returns the same registry on each, and all six
+ * addresses hold contracts on both. `paritytech/dotns` `DEPLOYMENTS.md` states the mechanism, and
  * `preview-net-v1` confirms it from the deploy side: the TLD is passed only as
  * registry init calldata, so it moves no address.
  *

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
@@ -452,6 +452,31 @@ describe("verifyDotNsAddresses", () => {
         if (v.ok) expect(v.value.registry.toLowerCase()).toBe(moved);
     });
 
+    test("a discovered client is still checked against its own overrides", async () => {
+        // The hole the first pass at this left: short circuiting for discovered
+        // clients skipped override drift, so verify reported ok while the client
+        // called an address the chain disagreed with. A false all clear is worse
+        // than the false alarm it replaced.
+        const wrong = addr("f1");
+        const { runtime, gatewayApi } = agreeing();
+        const opts = {
+            runtime,
+            gatewayApi,
+            addressSource: "discovered",
+            registryAddress: wrong,
+        } as const;
+
+        const inUse = await resolveDotNsAddresses(opts);
+        expect(inUse.ok && inUse.value.registry.toLowerCase()).toBe(wrong);
+
+        const v = await verifyDotNsAddresses(opts);
+        expect(v.ok).toBe(false);
+        if (!v.ok) {
+            expect(v.error.reason).toBe("AddressMismatch");
+            expect(v.error.message.toLowerCase()).toContain(wrong);
+        }
+    });
+
     test("verifying then using the client is one walk, not two", async () => {
         const { runtime, gatewayApi } = agreeing();
         const opts = { runtime, gatewayApi, addressSource: "discovered" } as const;

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
@@ -104,13 +104,13 @@ function walkChain(options: WalkOptions = {}) {
 }
 
 /** Addresses lowercased for comparison: viem checksums every one it decodes. */
-const lower = (a: Record<string, string>) =>
-    Object.fromEntries(Object.entries(a).map(([k, v]) => [k, v.toLowerCase()]));
+const lower = (a: object): Record<string, string> =>
+    Object.fromEntries(Object.entries(a).map(([k, v]) => [k, String(v).toLowerCase()]));
 
 function expectAddresses(actual: { ok: boolean; value?: unknown }, expected: DotNsAddresses) {
     expect(actual.ok).toBe(true);
     if (!actual.ok) return;
-    expect(lower(actual.value as Record<string, string>)).toEqual(lower(expected));
+    expect(lower(actual.value as object)).toEqual(lower(expected));
 }
 
 /** Walks performed, counted by `TARGET` since exactly one walk calls it exactly once. */
@@ -397,9 +397,10 @@ describe("verifyDotNsAddresses", () => {
 
     test("casing does not count as a disagreement", async () => {
         // Chain reads come back lowercase; the pinned table is EIP-55.
-        const lowered = Object.fromEntries(
-            Object.entries(DOTNS_ADDRESSES).map(([k, v]) => [k, v.toLowerCase()]),
-        ) as DotNsAddresses;
+        const lowered: Partial<DotNsAddresses> = {};
+        for (const [role, address] of Object.entries(DOTNS_ADDRESSES)) {
+            lowered[role as keyof DotNsAddresses] = address.toLowerCase() as `0x${string}`;
+        }
         const { runtime, gatewayApi } = agreeing(lowered);
         expect((await verifyDotNsAddresses({ runtime, gatewayApi })).ok).toBe(true);
     });

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./dotns-abis.js";
 import {
     DOTNS_REGISTRY_KEYS,
+    sameAddress,
     type DotNsAddresses,
     type DotNsGatewayQueryApi,
     discoverDotNsAddresses,
@@ -434,6 +435,7 @@ describe("verifyDotNsAddresses", () => {
 });
 
 describe("the new ABI fragments round-trip", () => {
+    // Decoded addresses are checksummed, so they never match a literal on casing.
     test("get, TARGET and protocolRegistry encode and decode", async () => {
         const { runtime } = walkChain();
         const dispatcher = createContract(
@@ -441,7 +443,7 @@ describe("the new ABI fragments round-trip", () => {
             DISPATCHER,
             DOTNS_ROOT_GATEWAY_DISPATCHER_ABI as never,
         ) as never as { TARGET: { query: () => Promise<{ success: boolean; value: unknown }> } };
-        expect((await dispatcher.TARGET.query()).value).toBe(POP_CONTROLLER);
+        expect(sameAddress((await dispatcher.TARGET.query()).value, POP_CONTROLLER)).toBe(true);
 
         const controller = createContract(
             runtime,
@@ -450,7 +452,12 @@ describe("the new ABI fragments round-trip", () => {
         ) as never as {
             protocolRegistry: { query: () => Promise<{ success: boolean; value: unknown }> };
         };
-        expect((await controller.protocolRegistry.query()).value).toBe(DISCOVERED.protocolRegistry);
+        expect(
+            sameAddress(
+                (await controller.protocolRegistry.query()).value,
+                DISCOVERED.protocolRegistry,
+            ),
+        ).toBe(true);
 
         const registry = createContract(
             runtime,
@@ -459,8 +466,11 @@ describe("the new ABI fragments round-trip", () => {
         ) as never as {
             get: { query: (key: string) => Promise<{ success: boolean; value: unknown }> };
         };
-        expect((await registry.get.query(DOTNS_REGISTRY_KEYS.popRules)).value).toBe(
-            DISCOVERED.popRules,
-        );
+        expect(
+            sameAddress(
+                (await registry.get.query(DOTNS_REGISTRY_KEYS.popRules)).value,
+                DISCOVERED.popRules,
+            ),
+        ).toBe(true);
     });
 });

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
@@ -436,6 +436,30 @@ describe("verifyDotNsAddresses", () => {
         if (!r.ok) expect(r.error.reason).toBe("AddressMismatch");
     });
 
+    test("a discovered client has nothing to disagree with", async () => {
+        // The gap that let the false alarm through: no test passed addressSource
+        // here. A client on "discovered" calls what the walk found, so drift
+        // against the pinned table is not drift it is exposed to.
+        const moved = addr("e1");
+        const { runtime, gatewayApi } = agreeing({ registry: moved });
+        const opts = { runtime, gatewayApi, addressSource: "discovered" } as const;
+
+        const inUse = await resolveDotNsAddresses(opts);
+        expect(inUse.ok && inUse.value.registry.toLowerCase()).toBe(moved);
+
+        const v = await verifyDotNsAddresses(opts);
+        expect(v.ok).toBe(true);
+        if (v.ok) expect(v.value.registry.toLowerCase()).toBe(moved);
+    });
+
+    test("verifying then using the client is one walk, not two", async () => {
+        const { runtime, gatewayApi } = agreeing();
+        const opts = { runtime, gatewayApi, addressSource: "discovered" } as const;
+        await verifyDotNsAddresses(opts);
+        await resolveDotNsAddresses(opts);
+        expect(walkCount(runtime)).toBe(1);
+    });
+
     test("a walk that cannot complete is a discovery failure, not a mismatch", async () => {
         const { runtime, gatewayApi } = walkChain({ dispatcher: undefined });
         const r = await verifyDotNsAddresses({ runtime, gatewayApi });

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
@@ -1,0 +1,466 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+//
+// The gateway walk and the startup check. Contract hops run through
+// `createFakeContractRuntime`, which uses the real codec and no chain; the
+// pallet read is a hand-written object, since `ContractRuntime` does not
+// declare it.
+//
+// Every fake here answers on `(dest, functionName)`, not on `functionName`
+// alone. The walk calls three different contracts and two of them would
+// otherwise answer for each other.
+import { type AbiEntry, type ContractRuntime, createContract } from "@parity/product-sdk-contracts";
+import { createFakeContractRuntime, fakeDryRunResult } from "@parity/product-sdk-contracts/testing";
+import { describe, expect, test } from "vitest";
+import {
+    DOTNS_ADDRESSES,
+    DOTNS_POP_CONTROLLER_ABI,
+    DOTNS_PROTOCOL_REGISTRY_ABI,
+    DOTNS_ROOT_GATEWAY_DISPATCHER_ABI,
+} from "./dotns-abis.js";
+import {
+    DOTNS_REGISTRY_KEYS,
+    type DotNsAddresses,
+    type DotNsGatewayQueryApi,
+    discoverDotNsAddresses,
+    resolveDotNsAddresses,
+    verifyDotNsAddresses,
+} from "./dotns-addresses.js";
+
+const ZERO = "0x0000000000000000000000000000000000000000";
+
+/** A distinct H160, so a test can never pass by confusing two roles. */
+const addr = (byte: string) => `0x${byte.repeat(20)}` as const;
+
+/**
+ * What the fake chain reports. Deliberately disjoint from `DOTNS_ADDRESSES`:
+ * if a pinned value leaks into a discovered result, these assertions catch it.
+ */
+const DISCOVERED = {
+    registry: addr("a1"),
+    reverseResolver: addr("a2"),
+    resolver: addr("a3"),
+    registrarController: addr("a4"),
+    popRules: addr("a5"),
+    protocolRegistry: addr("a6"),
+} satisfies DotNsAddresses;
+
+const DISPATCHER = addr("b1");
+const POP_CONTROLLER = addr("b2");
+
+const WALK_ABIS: AbiEntry[] = [
+    ...DOTNS_PROTOCOL_REGISTRY_ABI,
+    ...DOTNS_ROOT_GATEWAY_DISPATCHER_ABI,
+    ...DOTNS_POP_CONTROLLER_ABI,
+];
+
+const ROLE_BY_KEY = new Map(
+    Object.entries(DOTNS_REGISTRY_KEYS).map(([role, key]) => [key as string, role]),
+);
+
+interface WalkOptions {
+    /** What the pallet reports. `undefined` models storage with no value set. */
+    dispatcher?: unknown;
+    target?: unknown;
+    protocolRegistry?: unknown;
+    get?: Partial<Record<keyof DotNsAddresses, unknown>>;
+}
+
+/**
+ * A chain that answers the whole walk. Every hop is overridable so a test can
+ * break exactly one of them and leave the rest working.
+ */
+function walkChain(options: WalkOptions = {}) {
+    const target = options.target ?? POP_CONTROLLER;
+    const registry = options.protocolRegistry ?? DISCOVERED.protocolRegistry;
+
+    const runtime = createFakeContractRuntime({
+        abi: WALK_ABIS,
+        onQuery: ({ dest, functionName, args }) => {
+            const at = dest.toLowerCase();
+            if (functionName === "TARGET" && at === DISPATCHER.toLowerCase()) return target;
+            if (functionName === "protocolRegistry" && at === POP_CONTROLLER.toLowerCase()) {
+                return registry;
+            }
+            if (functionName === "get" && at === String(registry).toLowerCase()) {
+                const role = ROLE_BY_KEY.get(String(args?.[0]));
+                if (!role) return ZERO; // an unknown key is what a wrong key looks like
+                const override = options.get?.[role as keyof DotNsAddresses];
+                return override ?? DISCOVERED[role as keyof DotNsAddresses];
+            }
+            return undefined;
+        },
+    });
+
+    const dispatcher = "dispatcher" in options ? options.dispatcher : DISPATCHER;
+    const gatewayApi = {
+        query: {
+            DotnsGateway: { DispatcherAddress: { getValue: async () => dispatcher } },
+        },
+    } as DotNsGatewayQueryApi;
+
+    return { runtime, gatewayApi };
+}
+
+/** Walks performed, counted by `TARGET` since exactly one walk calls it exactly once. */
+const walkCount = (runtime: { calls: ReadonlyArray<{ functionName?: string }> }) =>
+    runtime.calls.filter((c) => c.functionName === "TARGET").length;
+
+describe("DOTNS_REGISTRY_KEYS", () => {
+    test("each key is the DotnsConstants literal, not a keccak hash", () => {
+        // `bytes32("registry")` is the UTF-8 bytes left-aligned and right-padded
+        // with zeros. Hardcoded rather than derived: deriving them here with the
+        // same helper the source uses would agree with any mistake it makes.
+        expect(DOTNS_REGISTRY_KEYS).toEqual({
+            registry: "0x7265676973747279000000000000000000000000000000000000000000000000",
+            registrarController:
+                "0x636f6e74726f6c6c657200000000000000000000000000000000000000000000",
+            reverseResolver: "0x726576657273655265736f6c7665720000000000000000000000000000000000",
+            resolver: "0x7265736f6c766572000000000000000000000000000000000000000000000000",
+            popRules: "0x706f7052756c6573000000000000000000000000000000000000000000000000",
+        });
+    });
+
+    test("the controller key is `controller`, not `registrar`", () => {
+        // The issue asked for `registrar`, which is the ERC-721 token contract,
+        // not the commit-reveal controller this field holds. Both answer `get`
+        // with a live address, so the wrong key fails silently.
+        const registrar = `0x${Buffer.from("registrar").toString("hex").padEnd(64, "0")}`;
+        expect(DOTNS_REGISTRY_KEYS.registrarController).not.toBe(registrar);
+    });
+
+    test("the resolver key is `resolver`, not `contentResolver`", () => {
+        const contentResolver = `0x${Buffer.from("contentResolver").toString("hex").padEnd(64, "0")}`;
+        expect(DOTNS_REGISTRY_KEYS.resolver).not.toBe(contentResolver);
+    });
+
+    test("every discoverable address has a key, and every key an address", () => {
+        // Adding a seventh address should fail here until it is discoverable.
+        // `protocolRegistry` is the exception: it has no DotnsConstants key and
+        // is reached through the pop controller instead.
+        const discoverable = Object.keys(DOTNS_ADDRESSES).filter((r) => r !== "protocolRegistry");
+        expect(Object.keys(DOTNS_REGISTRY_KEYS).sort()).toEqual(discoverable.sort());
+    });
+
+    test("no two roles share a key", () => {
+        const keys = Object.values(DOTNS_REGISTRY_KEYS);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+});
+
+describe("discoverDotNsAddresses", () => {
+    test("walks pallet to dispatcher to controller to registry", async () => {
+        const { runtime, gatewayApi } = walkChain();
+        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(r).toEqual({ ok: true, value: DISCOVERED });
+    });
+
+    test("reads every role from the chain, never from the pinned table", async () => {
+        // The assertion that matters: not one discovered value equals its pinned
+        // counterpart, so a fallback to DOTNS_ADDRESSES cannot pass this.
+        const { runtime, gatewayApi } = walkChain();
+        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        for (const role of Object.keys(DOTNS_ADDRESSES) as (keyof DotNsAddresses)[]) {
+            expect(r.value[role].toLowerCase()).not.toBe(DOTNS_ADDRESSES[role].toLowerCase());
+        }
+    });
+
+    test("accepts a wrapped H160 as well as a plain hex string", async () => {
+        // PAPI decodes H160 as a fixed-size binary wrapper, and the wrapper class
+        // has changed across majors. Both shapes must work.
+        const wrapped = walkChain({ dispatcher: { asHex: () => DISPATCHER } });
+        expect(await discoverDotNsAddresses(wrapped)).toEqual({ ok: true, value: DISCOVERED });
+        const plain = walkChain({ dispatcher: DISPATCHER });
+        expect(await discoverDotNsAddresses(plain)).toEqual({ ok: true, value: DISCOVERED });
+    });
+
+    test("the five registry reads run concurrently, not one after another", async () => {
+        const { runtime, gatewayApi } = walkChain();
+        await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(runtime.calls.filter((c) => c.functionName === "get")).toHaveLength(5);
+        // Two contract hops plus one batch of five. The pallet read is not here:
+        // it goes through gatewayApi, so it never reaches runtime.calls.
+        expect(runtime.calls).toHaveLength(7);
+    });
+
+    test("an unset dispatcher address fails, naming the pallet", async () => {
+        const { runtime, gatewayApi } = walkChain({ dispatcher: undefined });
+        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.reason).toBe("AddressDiscovery");
+        expect(r.error.message).toContain("DotnsGateway.DispatcherAddress");
+    });
+
+    test("a zero dispatcher address fails rather than walking into the void", async () => {
+        const { runtime, gatewayApi } = walkChain({ dispatcher: ZERO });
+        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+        if (!r.ok) expect(r.error.reason).toBe("AddressDiscovery");
+    });
+
+    test("a reverting TARGET() fails", async () => {
+        const { runtime, gatewayApi } = walkChain({ target: fakeDryRunResult({ revert: true }) });
+        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.reason).toBe("AddressDiscovery");
+        expect(r.error.message).toContain("TARGET");
+    });
+
+    test("a zero protocolRegistry() fails", async () => {
+        const { runtime, gatewayApi } = walkChain({ protocolRegistry: ZERO });
+        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.reason).toBe("AddressDiscovery");
+        expect(r.error.message).toContain("protocolRegistry");
+    });
+
+    test("an unset role names which role is missing", async () => {
+        // A wrong key returns address(0), not an error, so the role name is the
+        // only clue the caller gets.
+        const { runtime, gatewayApi } = walkChain({ get: { popRules: ZERO } });
+        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.reason).toBe("AddressDiscovery");
+        expect(r.error.message).toContain("popRules");
+    });
+
+    test("a failed read never becomes a pinned value", async () => {
+        const { runtime, gatewayApi } = walkChain({ get: { registry: ZERO } });
+        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+    });
+
+    test("falls back to the runtime's own api when no gatewayApi is given", async () => {
+        const { runtime } = walkChain();
+        const api = runtime.api as unknown as Record<string, unknown>;
+        api.query = {
+            ...(api.query as object),
+            DotnsGateway: { DispatcherAddress: { getValue: async () => DISPATCHER } },
+        };
+        expect(await discoverDotNsAddresses({ runtime })).toEqual({ ok: true, value: DISCOVERED });
+    });
+
+    test("a runtime without the pallet fails legibly instead of throwing", async () => {
+        // Polkadot and Kusama Asset Hub have no DotnsGateway pallet at all.
+        const { runtime } = walkChain();
+        const r = await discoverDotNsAddresses({ runtime });
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.reason).toBe("AddressDiscovery");
+        expect(r.error.message).toContain("DotnsGateway");
+    });
+});
+
+describe("resolveDotNsAddresses", () => {
+    test("defaults to the pinned table and reads nothing", async () => {
+        const runtime = {} as ContractRuntime; // any read would throw
+        expect(await resolveDotNsAddresses({ runtime })).toEqual({
+            ok: true,
+            value: { ...DOTNS_ADDRESSES },
+        });
+    });
+
+    test("a per-field override wins over the pinned table", async () => {
+        const runtime = {} as ContractRuntime;
+        const r = await resolveDotNsAddresses({ runtime, registryAddress: addr("c1") });
+        expect(r).toEqual({
+            ok: true,
+            value: { ...DOTNS_ADDRESSES, registry: addr("c1") },
+        });
+    });
+
+    test("addressSource discovered walks the gateway", async () => {
+        const { runtime, gatewayApi } = walkChain();
+        const r = await resolveDotNsAddresses({ runtime, gatewayApi, addressSource: "discovered" });
+        expect(r).toEqual({ ok: true, value: DISCOVERED });
+    });
+
+    test("a per-field override wins over a discovered address too", async () => {
+        const { runtime, gatewayApi } = walkChain();
+        const r = await resolveDotNsAddresses({
+            runtime,
+            gatewayApi,
+            addressSource: "discovered",
+            registryAddress: addr("c1"),
+        });
+        expect(r).toEqual({ ok: true, value: { ...DISCOVERED, registry: addr("c1") } });
+    });
+
+    test("the cache holds the walk, not the merged result", async () => {
+        // Two calls differing only in their override must both be right off one
+        // walk. Caching the merged set would serve the first call's override to
+        // the second.
+        const { runtime, gatewayApi } = walkChain();
+        const base = { runtime, gatewayApi, addressSource: "discovered" } as const;
+        const one = await resolveDotNsAddresses({ ...base, registryAddress: addr("c1") });
+        const two = await resolveDotNsAddresses({ ...base, registryAddress: addr("c2") });
+        expect(one).toEqual({ ok: true, value: { ...DISCOVERED, registry: addr("c1") } });
+        expect(two).toEqual({ ok: true, value: { ...DISCOVERED, registry: addr("c2") } });
+        expect(walkCount(runtime)).toBe(1);
+    });
+
+    test("caches the walk per runtime", async () => {
+        const { runtime, gatewayApi } = walkChain();
+        const opts = { runtime, gatewayApi, addressSource: "discovered" } as const;
+        await resolveDotNsAddresses(opts);
+        await resolveDotNsAddresses(opts);
+        expect(walkCount(runtime)).toBe(1);
+    });
+
+    test("concurrent first calls share one walk", async () => {
+        const { runtime, gatewayApi } = walkChain();
+        const opts = { runtime, gatewayApi, addressSource: "discovered" } as const;
+        const results = await Promise.all([
+            resolveDotNsAddresses(opts),
+            resolveDotNsAddresses(opts),
+            resolveDotNsAddresses(opts),
+        ]);
+        expect(walkCount(runtime)).toBe(1);
+        for (const r of results) expect(r).toEqual({ ok: true, value: DISCOVERED });
+    });
+
+    test("a failed walk is not cached, so a later call retries", async () => {
+        // A walk usually fails because the RPC blinked, not because the
+        // deployment moved. Caching that would strand the client for the life of
+        // the runtime.
+        const pallet: { value: unknown } = { value: undefined };
+        const { runtime } = walkChain();
+        const gatewayApi = {
+            query: { DotnsGateway: { DispatcherAddress: { getValue: async () => pallet.value } } },
+        } as DotNsGatewayQueryApi;
+        const opts = { runtime, gatewayApi, addressSource: "discovered" } as const;
+
+        expect((await resolveDotNsAddresses(opts)).ok).toBe(false);
+        pallet.value = DISPATCHER;
+        expect(await resolveDotNsAddresses(opts)).toEqual({ ok: true, value: DISCOVERED });
+    });
+
+    test("pinned and discovered are cached apart on one runtime", async () => {
+        const { runtime, gatewayApi } = walkChain();
+        expect(await resolveDotNsAddresses({ runtime, gatewayApi })).toEqual({
+            ok: true,
+            value: { ...DOTNS_ADDRESSES },
+        });
+        expect(
+            await resolveDotNsAddresses({ runtime, gatewayApi, addressSource: "discovered" }),
+        ).toEqual({ ok: true, value: DISCOVERED });
+    });
+});
+
+describe("verifyDotNsAddresses", () => {
+    /** A chain whose walk lands exactly on the pinned table. */
+    const agreeing = (overrides: Partial<DotNsAddresses> = {}) => {
+        const answers = { ...DOTNS_ADDRESSES, ...overrides };
+        const runtime = createFakeContractRuntime({
+            abi: WALK_ABIS,
+            onQuery: ({ dest, functionName, args }) => {
+                const at = dest.toLowerCase();
+                if (functionName === "TARGET") return POP_CONTROLLER;
+                if (functionName === "protocolRegistry") return answers.protocolRegistry;
+                if (functionName === "get" && at === answers.protocolRegistry.toLowerCase()) {
+                    const role = ROLE_BY_KEY.get(String(args?.[0]));
+                    return role ? answers[role as keyof DotNsAddresses] : ZERO;
+                }
+                return undefined;
+            },
+        });
+        const gatewayApi = {
+            query: { DotnsGateway: { DispatcherAddress: { getValue: async () => DISPATCHER } } },
+        } as DotNsGatewayQueryApi;
+        return { runtime, gatewayApi };
+    };
+
+    test("passes when the walk agrees with the pinned table", async () => {
+        const { runtime, gatewayApi } = agreeing();
+        expect(await verifyDotNsAddresses({ runtime, gatewayApi })).toEqual({
+            ok: true,
+            value: { ...DOTNS_ADDRESSES },
+        });
+    });
+
+    test("casing does not count as a disagreement", async () => {
+        // Chain reads come back lowercase; the pinned table is EIP-55.
+        const lowered = Object.fromEntries(
+            Object.entries(DOTNS_ADDRESSES).map(([k, v]) => [k, v.toLowerCase()]),
+        ) as DotNsAddresses;
+        const { runtime, gatewayApi } = agreeing(lowered);
+        expect((await verifyDotNsAddresses({ runtime, gatewayApi })).ok).toBe(true);
+    });
+
+    test("fails loudly, naming the role and both addresses", async () => {
+        const { runtime, gatewayApi } = agreeing({ registry: addr("d1") });
+        const r = await verifyDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.reason).toBe("AddressMismatch");
+        expect(r.error.message).toContain("registry");
+        expect(r.error.message).toContain(DOTNS_ADDRESSES.registry);
+        expect(r.error.message).toContain(addr("d1"));
+    });
+
+    test("lists every disagreeing role, not just the first", async () => {
+        const { runtime, gatewayApi } = agreeing({
+            registry: addr("d1"),
+            popRules: addr("d2"),
+        });
+        const r = await verifyDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+        if (r.ok) return;
+        expect(r.error.message).toContain("registry");
+        expect(r.error.message).toContain("popRules");
+    });
+
+    test("checks the caller's overrides, not only the pinned table", async () => {
+        // A product that overrides an address wants that address verified. The
+        // pinned value it replaced is not what it will call.
+        const { runtime, gatewayApi } = agreeing();
+        const r = await verifyDotNsAddresses({ runtime, gatewayApi, registryAddress: addr("d1") });
+        expect(r.ok).toBe(false);
+        if (!r.ok) expect(r.error.reason).toBe("AddressMismatch");
+    });
+
+    test("a walk that cannot complete is a discovery failure, not a mismatch", async () => {
+        const { runtime, gatewayApi } = walkChain({ dispatcher: undefined });
+        const r = await verifyDotNsAddresses({ runtime, gatewayApi });
+        expect(r.ok).toBe(false);
+        if (!r.ok) expect(r.error.reason).toBe("AddressDiscovery");
+    });
+});
+
+describe("the new ABI fragments round-trip", () => {
+    test("get, TARGET and protocolRegistry encode and decode", async () => {
+        const { runtime } = walkChain();
+        const dispatcher = createContract(
+            runtime,
+            DISPATCHER,
+            DOTNS_ROOT_GATEWAY_DISPATCHER_ABI as never,
+        ) as never as { TARGET: { query: () => Promise<{ success: boolean; value: unknown }> } };
+        expect((await dispatcher.TARGET.query()).value).toBe(POP_CONTROLLER);
+
+        const controller = createContract(
+            runtime,
+            POP_CONTROLLER,
+            DOTNS_POP_CONTROLLER_ABI as never,
+        ) as never as {
+            protocolRegistry: { query: () => Promise<{ success: boolean; value: unknown }> };
+        };
+        expect((await controller.protocolRegistry.query()).value).toBe(DISCOVERED.protocolRegistry);
+
+        const registry = createContract(
+            runtime,
+            DISCOVERED.protocolRegistry,
+            DOTNS_PROTOCOL_REGISTRY_ABI as never,
+        ) as never as {
+            get: { query: (key: string) => Promise<{ success: boolean; value: unknown }> };
+        };
+        expect((await registry.get.query(DOTNS_REGISTRY_KEYS.popRules)).value).toBe(
+            DISCOVERED.popRules,
+        );
+    });
+});

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.test.ts
@@ -103,6 +103,16 @@ function walkChain(options: WalkOptions = {}) {
     return { runtime, gatewayApi };
 }
 
+/** Addresses lowercased for comparison: viem checksums every one it decodes. */
+const lower = (a: Record<string, string>) =>
+    Object.fromEntries(Object.entries(a).map(([k, v]) => [k, v.toLowerCase()]));
+
+function expectAddresses(actual: { ok: boolean; value?: unknown }, expected: DotNsAddresses) {
+    expect(actual.ok).toBe(true);
+    if (!actual.ok) return;
+    expect(lower(actual.value as Record<string, string>)).toEqual(lower(expected));
+}
+
 /** Walks performed, counted by `TARGET` since exactly one walk calls it exactly once. */
 const walkCount = (runtime: { calls: ReadonlyArray<{ functionName?: string }> }) =>
     runtime.calls.filter((c) => c.functionName === "TARGET").length;
@@ -152,8 +162,7 @@ describe("DOTNS_REGISTRY_KEYS", () => {
 describe("discoverDotNsAddresses", () => {
     test("walks pallet to dispatcher to controller to registry", async () => {
         const { runtime, gatewayApi } = walkChain();
-        const r = await discoverDotNsAddresses({ runtime, gatewayApi });
-        expect(r).toEqual({ ok: true, value: DISCOVERED });
+        expectAddresses(await discoverDotNsAddresses({ runtime, gatewayApi }), DISCOVERED);
     });
 
     test("reads every role from the chain, never from the pinned table", async () => {
@@ -172,9 +181,9 @@ describe("discoverDotNsAddresses", () => {
         // PAPI decodes H160 as a fixed-size binary wrapper, and the wrapper class
         // has changed across majors. Both shapes must work.
         const wrapped = walkChain({ dispatcher: { asHex: () => DISPATCHER } });
-        expect(await discoverDotNsAddresses(wrapped)).toEqual({ ok: true, value: DISCOVERED });
+        expectAddresses(await discoverDotNsAddresses(wrapped), DISCOVERED);
         const plain = walkChain({ dispatcher: DISPATCHER });
-        expect(await discoverDotNsAddresses(plain)).toEqual({ ok: true, value: DISCOVERED });
+        expectAddresses(await discoverDotNsAddresses(plain), DISCOVERED);
     });
 
     test("the five registry reads run concurrently, not one after another", async () => {
@@ -244,7 +253,7 @@ describe("discoverDotNsAddresses", () => {
             ...(api.query as object),
             DotnsGateway: { DispatcherAddress: { getValue: async () => DISPATCHER } },
         };
-        expect(await discoverDotNsAddresses({ runtime })).toEqual({ ok: true, value: DISCOVERED });
+        expectAddresses(await discoverDotNsAddresses({ runtime }), DISCOVERED);
     });
 
     test("a runtime without the pallet fails legibly instead of throwing", async () => {
@@ -279,7 +288,7 @@ describe("resolveDotNsAddresses", () => {
     test("addressSource discovered walks the gateway", async () => {
         const { runtime, gatewayApi } = walkChain();
         const r = await resolveDotNsAddresses({ runtime, gatewayApi, addressSource: "discovered" });
-        expect(r).toEqual({ ok: true, value: DISCOVERED });
+        expectAddresses(r, DISCOVERED);
     });
 
     test("a per-field override wins over a discovered address too", async () => {
@@ -290,7 +299,7 @@ describe("resolveDotNsAddresses", () => {
             addressSource: "discovered",
             registryAddress: addr("c1"),
         });
-        expect(r).toEqual({ ok: true, value: { ...DISCOVERED, registry: addr("c1") } });
+        expectAddresses(r, { ...DISCOVERED, registry: addr("c1") });
     });
 
     test("the cache holds the walk, not the merged result", async () => {
@@ -301,8 +310,8 @@ describe("resolveDotNsAddresses", () => {
         const base = { runtime, gatewayApi, addressSource: "discovered" } as const;
         const one = await resolveDotNsAddresses({ ...base, registryAddress: addr("c1") });
         const two = await resolveDotNsAddresses({ ...base, registryAddress: addr("c2") });
-        expect(one).toEqual({ ok: true, value: { ...DISCOVERED, registry: addr("c1") } });
-        expect(two).toEqual({ ok: true, value: { ...DISCOVERED, registry: addr("c2") } });
+        expectAddresses(one, { ...DISCOVERED, registry: addr("c1") });
+        expectAddresses(two, { ...DISCOVERED, registry: addr("c2") });
         expect(walkCount(runtime)).toBe(1);
     });
 
@@ -323,7 +332,7 @@ describe("resolveDotNsAddresses", () => {
             resolveDotNsAddresses(opts),
         ]);
         expect(walkCount(runtime)).toBe(1);
-        for (const r of results) expect(r).toEqual({ ok: true, value: DISCOVERED });
+        for (const r of results) expectAddresses(r, DISCOVERED);
     });
 
     test("a failed walk is not cached, so a later call retries", async () => {
@@ -339,7 +348,7 @@ describe("resolveDotNsAddresses", () => {
 
         expect((await resolveDotNsAddresses(opts)).ok).toBe(false);
         pallet.value = DISPATCHER;
-        expect(await resolveDotNsAddresses(opts)).toEqual({ ok: true, value: DISCOVERED });
+        expectAddresses(await resolveDotNsAddresses(opts), DISCOVERED);
     });
 
     test("pinned and discovered are cached apart on one runtime", async () => {
@@ -348,9 +357,10 @@ describe("resolveDotNsAddresses", () => {
             ok: true,
             value: { ...DOTNS_ADDRESSES },
         });
-        expect(
+        expectAddresses(
             await resolveDotNsAddresses({ runtime, gatewayApi, addressSource: "discovered" }),
-        ).toEqual({ ok: true, value: DISCOVERED });
+            DISCOVERED,
+        );
     });
 });
 
@@ -401,8 +411,8 @@ describe("verifyDotNsAddresses", () => {
         if (r.ok) return;
         expect(r.error.reason).toBe("AddressMismatch");
         expect(r.error.message).toContain("registry");
-        expect(r.error.message).toContain(DOTNS_ADDRESSES.registry);
-        expect(r.error.message).toContain(addr("d1"));
+        expect(r.error.message.toLowerCase()).toContain(DOTNS_ADDRESSES.registry.toLowerCase());
+        expect(r.error.message.toLowerCase()).toContain(addr("d1"));
     });
 
     test("lists every disagreeing role, not just the first", async () => {

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
@@ -294,12 +294,14 @@ export async function verifyDotNsAddresses(
     );
     if (!discovered.ok) return discovered;
 
-    // A discovered client already calls whatever the walk found, so there is
-    // nothing left to disagree with. Comparing it against the pinned table would
-    // report drift the client is not exposed to, and name an address it never uses.
-    if (opts.addressSource === "discovered") return ok(withOverrides(discovered.value, opts));
-
-    const inUse = withOverrides(DOTNS_ADDRESSES, opts);
+    // Compare what this client actually calls, which is the pinned table or the
+    // walk depending on the source, with the caller's overrides on top either
+    // way. A discovered client can still drift, through an override that
+    // disagrees with the chain; it is only the pinned base that cannot apply.
+    const inUse = withOverrides(
+        opts.addressSource === "discovered" ? discovered.value : DOTNS_ADDRESSES,
+        opts,
+    );
     const drift = (Object.keys(inUse) as (keyof DotNsAddresses)[])
         .filter((role) => !sameAddress(inUse[role], discovered.value[role]))
         .map((role) => `${role}: using ${inUse[role]}, chain says ${discovered.value[role]}`);

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
@@ -7,10 +7,20 @@
  * rather than reaching for a constant, so "which address do I call?" has one
  * answer and the gateway walk can plug in behind it without touching them.
  */
-import type { ContractRuntime } from "@parity/product-sdk-contracts";
-import { type Result, ok } from "@parity/result";
-import { DOTNS_ADDRESSES } from "./dotns-abis.js";
-import type { DotNsError } from "./dotns-errors.js";
+import {
+    type AbiEntry,
+    type ContractRuntime,
+    QUERY_FALLBACK_ORIGIN,
+    createContract,
+} from "@parity/product-sdk-contracts";
+import { type Result, err, ok } from "@parity/result";
+import {
+    DOTNS_ADDRESSES,
+    DOTNS_POP_CONTROLLER_ABI,
+    DOTNS_PROTOCOL_REGISTRY_ABI,
+    DOTNS_ROOT_GATEWAY_DISPATCHER_ABI,
+} from "./dotns-abis.js";
+import { DotNsError } from "./dotns-errors.js";
 import type { DotNsClientOptions } from "./dotns-registry.js";
 
 type HexString = `0x${string}`;
@@ -109,5 +119,165 @@ function withOverrides(base: DotNsAddresses, opts: DotNsClientOptions): DotNsAdd
 export async function resolveDotNsAddresses(
     opts: DotNsClientOptions,
 ): Promise<Result<DotNsAddresses, DotNsError>> {
-    return ok(withOverrides(DOTNS_ADDRESSES, opts));
+    if (opts.addressSource !== "discovered") return ok(withOverrides(DOTNS_ADDRESSES, opts));
+
+    // Cache the walk, not the merged set: two callers differing only in their
+    // overrides must share one walk and still each get their own answer.
+    const walked = await cachedPerRuntime(walkCache, opts.runtime, "discovered", () =>
+        discoverDotNsAddresses(opts),
+    );
+    return walked.ok ? ok(withOverrides(walked.value, opts)) : walked;
+}
+
+/**
+ * Reads `DotnsGateway.DispatcherAddress`, the pallet storage the walk starts
+ * from. Structural because `ContractRuntime` does not declare it.
+ */
+export type DotNsGatewayQueryApi = {
+    query: {
+        DotnsGateway: {
+            DispatcherAddress: {
+                getValue: () => Promise<{ asHex(): string } | string | undefined>;
+            };
+        };
+    };
+};
+
+const discoveryFailed = (step: string, cause?: unknown) =>
+    err(new DotNsError("AddressDiscovery", `DotNS address discovery failed: ${step}`, { cause }));
+
+function contractAt(opts: DotNsClientOptions, address: HexString, abi: AbiEntry[]) {
+    // Same untyped-by-construction handle as dotns-registry's contractOf.
+    return createContract(opts.runtime, address, abi as any) as any;
+}
+
+async function readAddress(
+    contract: {
+        [m: string]: { query: (o: object) => Promise<{ success: boolean; value: unknown }> };
+    },
+    method: string,
+    origin: string,
+): Promise<Result<HexString, DotNsError>> {
+    const res = await contract[method].query({ origin });
+    if (!res.success) return discoveryFailed(`${method}() failed`, res.value);
+    const value = res.value;
+    if (typeof value !== "string" || isZero(value)) {
+        return discoveryFailed(`${method}() returned no address`);
+    }
+    return ok(value as HexString);
+}
+
+/** PAPI hands back H160 as a wrapper or a hex string depending on the major. */
+function asH160(value: unknown): HexString | null {
+    if (typeof value === "string") return value as HexString;
+    if (value && typeof (value as { asHex?: unknown }).asHex === "function") {
+        return (value as { asHex(): string }).asHex() as HexString;
+    }
+    return null;
+}
+
+function gatewayOf(opts: DotNsClientOptions): DotNsGatewayQueryApi | null {
+    if (opts.gatewayApi) return opts.gatewayApi;
+    const api = opts.runtime?.api as unknown as Partial<DotNsGatewayQueryApi> | undefined;
+    const getValue = api?.query?.DotnsGateway?.DispatcherAddress?.getValue;
+    return typeof getValue === "function" ? (api as DotNsGatewayQueryApi) : null;
+}
+
+/**
+ * Locate the live deployment from chain state, trusting nothing pinned here.
+ *
+ * Pallet -> `dispatcher.TARGET()` -> `popController.protocolRegistry()` ->
+ * `get(key)` per role. The first three are sequential because each answer is
+ * the next call's address; the role reads are not, so they go together.
+ *
+ * A failed or zero read is always an error: falling back to the pinned table
+ * would recreate the situation this exists to detect, and hide it better.
+ */
+export async function discoverDotNsAddresses(
+    opts: DotNsClientOptions,
+): Promise<Result<DotNsAddresses, DotNsError>> {
+    try {
+        const gateway = gatewayOf(opts);
+        if (!gateway) {
+            return discoveryFailed(
+                "no DotnsGateway.DispatcherAddress storage on this runtime; pass opts.gatewayApi",
+            );
+        }
+        const dispatcher = asH160(await gateway.query.DotnsGateway.DispatcherAddress.getValue());
+        if (!dispatcher || isZero(dispatcher)) {
+            return discoveryFailed("DotnsGateway.DispatcherAddress is unset");
+        }
+
+        const origin = opts.origin ?? QUERY_FALLBACK_ORIGIN;
+        const target = await readAddress(
+            contractAt(opts, dispatcher, DOTNS_ROOT_GATEWAY_DISPATCHER_ABI),
+            "TARGET",
+            origin,
+        );
+        if (!target.ok) return target;
+
+        const protocolRegistry = await readAddress(
+            contractAt(opts, target.value, DOTNS_POP_CONTROLLER_ABI),
+            "protocolRegistry",
+            origin,
+        );
+        if (!protocolRegistry.ok) return protocolRegistry;
+
+        const registry = contractAt(opts, protocolRegistry.value, DOTNS_PROTOCOL_REGISTRY_ABI);
+        const roles = Object.entries(DOTNS_REGISTRY_KEYS) as [
+            keyof typeof DOTNS_REGISTRY_KEYS,
+            HexString,
+        ][];
+        const found = await Promise.all(
+            roles.map(async ([role, key]) => {
+                const res = await registry.get.query(key, { origin });
+                if (!res.success) return discoveryFailed(`get(${role}) failed`, res.value);
+                const value = res.value;
+                // A wrong key is not an error on chain: it returns address(0),
+                // so the role name is the only clue the caller gets.
+                if (typeof value !== "string" || isZero(value)) {
+                    return discoveryFailed(`${role} is unset on the protocol registry`);
+                }
+                return ok([role, value as HexString] as const);
+            }),
+        );
+        const failed = found.find((r) => !r.ok);
+        if (failed && !failed.ok) return failed;
+
+        const byRole = Object.fromEntries(found.flatMap((r) => (r.ok ? [r.value] : []))) as Omit<
+            DotNsAddresses,
+            "protocolRegistry"
+        >;
+        return ok({ ...byRole, protocolRegistry: protocolRegistry.value });
+    } catch (cause) {
+        return discoveryFailed("unexpected error", cause);
+    }
+}
+
+const walkCache: RuntimeCache<DotNsAddresses> = new WeakMap();
+
+/**
+ * Walk the gateway and report every role whose live address differs from the
+ * one this client would call. Meant for startup: it fails loudly once, rather
+ * than making every later read pay for the check.
+ */
+export async function verifyDotNsAddresses(
+    opts: DotNsClientOptions,
+): Promise<Result<DotNsAddresses, DotNsError>> {
+    const discovered = await discoverDotNsAddresses(opts);
+    if (!discovered.ok) return discovered;
+
+    const inUse = withOverrides(DOTNS_ADDRESSES, opts);
+    const drift = (Object.keys(inUse) as (keyof DotNsAddresses)[])
+        .filter((role) => !sameAddress(inUse[role], discovered.value[role]))
+        .map((role) => `${role}: using ${inUse[role]}, chain says ${discovered.value[role]}`);
+
+    return drift.length
+        ? err(
+              new DotNsError(
+                  "AddressMismatch",
+                  `DotNS addresses disagree with the deployment — ${drift.join("; ")}`,
+              ),
+          )
+        : ok(inUse);
 }

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Where the DotNS contract addresses come from.
+ *
+ * Every entry point in `./dotns-registry.js` asks {@link resolveDotNsAddresses}
+ * rather than reaching for a constant, so "which address do I call?" has one
+ * answer and the gateway walk can plug in behind it without touching them.
+ */
+import type { ContractRuntime } from "@parity/product-sdk-contracts";
+import { type Result, ok } from "@parity/result";
+import { DOTNS_ADDRESSES } from "./dotns-abis.js";
+import type { DotNsError } from "./dotns-errors.js";
+import type { DotNsClientOptions } from "./dotns-registry.js";
+
+type HexString = `0x${string}`;
+
+export interface DotNsAddresses {
+    registry: HexString;
+    reverseResolver: HexString;
+    resolver: HexString;
+    registrarController: HexString;
+    popRules: HexString;
+    protocolRegistry: HexString;
+}
+
+/**
+ * The `DotnsProtocolRegistry.get(bytes32)` key each role answers under, from
+ * `DotnsConstants`. Solidity's `bytes32("name")` is the UTF-8 bytes
+ * right-padded with zeros, which is what these literals are.
+ *
+ * Two are not the name you would guess, and guessing wrong is silent: `get`
+ * answers with a live address for the contract you did not want, and it
+ * surfaces much later as a revert. `registrarController` is the commit-reveal
+ * controller, key `controller` — `registrar` is the ERC-721 holding name
+ * ownership. `resolver` is the forward address resolver — `contentResolver`
+ * holds contenthash and text records, which nothing here calls.
+ *
+ * `protocolRegistry` has no key at all, so it cannot be looked up in the
+ * registry it is. The walk reaches it via `popController.protocolRegistry()`.
+ */
+export const DOTNS_REGISTRY_KEYS = {
+    registry: "0x7265676973747279000000000000000000000000000000000000000000000000",
+    registrarController: "0x636f6e74726f6c6c657200000000000000000000000000000000000000000000",
+    reverseResolver: "0x726576657273655265736f6c7665720000000000000000000000000000000000",
+    resolver: "0x7265736f6c766572000000000000000000000000000000000000000000000000",
+    popRules: "0x706f7052756c6573000000000000000000000000000000000000000000000000",
+} as const satisfies Record<Exclude<keyof DotNsAddresses, "protocolRegistry">, HexString>;
+
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export function isZero(addr: unknown): boolean {
+    return typeof addr === "string" && addr.toLowerCase() === ZERO_ADDRESS;
+}
+
+/** Case-insensitive H160 compare: chain reads are lowercase, our table is EIP-55. */
+export function sameAddress(a: unknown, b: unknown): boolean {
+    return typeof a === "string" && typeof b === "string" && a.toLowerCase() === b.toLowerCase();
+}
+
+/** A per-runtime, per-key cache of chain reads that cannot change under us. */
+export type RuntimeCache<T> = WeakMap<ContractRuntime, Map<string, Promise<Result<T, DotNsError>>>>;
+
+/**
+ * Read `key` once per runtime and hand every later caller the same answer.
+ *
+ * Stores the in-flight promise rather than the resolved value, so concurrent
+ * first calls share one read instead of racing. A failed read is dropped from
+ * the cache: those are usually the RPC blinking rather than the deployment
+ * moving, and keeping one would strand the client for the life of the runtime.
+ */
+export function cachedPerRuntime<T>(
+    cache: RuntimeCache<T>,
+    runtime: ContractRuntime,
+    key: string,
+    load: () => Promise<Result<T, DotNsError>>,
+): Promise<Result<T, DotNsError>> {
+    let byKey = cache.get(runtime);
+    if (!byKey) {
+        byKey = new Map();
+        cache.set(runtime, byKey);
+    }
+    const cached = byKey.get(key);
+    if (cached) return cached;
+
+    const pending = load();
+    byKey.set(key, pending);
+    pending.then((result) => {
+        if (!result.ok) byKey?.delete(key);
+    });
+    return pending;
+}
+
+function withOverrides(base: DotNsAddresses, opts: DotNsClientOptions): DotNsAddresses {
+    return {
+        registry: opts.registryAddress ?? base.registry,
+        reverseResolver: opts.reverseResolverAddress ?? base.reverseResolver,
+        resolver: opts.resolverAddress ?? base.resolver,
+        registrarController: opts.registrarControllerAddress ?? base.registrarController,
+        popRules: opts.popRulesAddress ?? base.popRules,
+        protocolRegistry: opts.protocolRegistryAddress ?? base.protocolRegistry,
+    };
+}
+
+/**
+ * Async because the discovered source reads the chain. The pinned source does
+ * no IO, so a caller that only validates a name still pays nothing for it.
+ */
+export async function resolveDotNsAddresses(
+    opts: DotNsClientOptions,
+): Promise<Result<DotNsAddresses, DotNsError>> {
+    return ok(withOverrides(DOTNS_ADDRESSES, opts));
+}

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
@@ -21,6 +21,7 @@ import {
     DOTNS_ROOT_GATEWAY_DISPATCHER_ABI,
 } from "./dotns-abis.js";
 import { DotNsError } from "./dotns-errors.js";
+import type { SS58String } from "polkadot-api";
 import type { DotNsClientOptions } from "./dotns-registry.js";
 
 type HexString = `0x${string}`;
@@ -116,6 +117,15 @@ function withOverrides(base: DotNsAddresses, opts: DotNsClientOptions): DotNsAdd
  * Async because the discovered source reads the chain. The pinned source does
  * no IO, so a caller that only validates a name still pays nothing for it.
  */
+const walkCache: RuntimeCache<DotNsAddresses> = new WeakMap();
+
+/**
+ * Constant, unlike the TLD cache which keys on the protocol registry address.
+ * Nothing else selects the deployment: `gatewayApi` is required to describe the
+ * same chain as `runtime`, and the walk derives every address from there.
+ */
+const WALK_KEY = "discovered";
+
 export async function resolveDotNsAddresses(
     opts: DotNsClientOptions,
 ): Promise<Result<DotNsAddresses, DotNsError>> {
@@ -123,7 +133,7 @@ export async function resolveDotNsAddresses(
 
     // Cache the walk, not the merged set: two callers differing only in their
     // overrides must share one walk and still each get their own answer.
-    const walked = await cachedPerRuntime(walkCache, opts.runtime, "discovered", () =>
+    const walked = await cachedPerRuntime(walkCache, opts.runtime, WALK_KEY, () =>
         discoverDotNsAddresses(opts),
     );
     return walked.ok ? ok(withOverrides(walked.value, opts)) : walked;
@@ -146,9 +156,20 @@ export type DotNsGatewayQueryApi = {
 const discoveryFailed = (step: string, cause?: unknown) =>
     err(new DotNsError("AddressDiscovery", `DotNS address discovery failed: ${step}`, { cause }));
 
-function contractAt(opts: DotNsClientOptions, address: HexString, abi: AbiEntry[]) {
-    // Same untyped-by-construction handle as dotns-registry's contractOf.
-    return createContract(opts.runtime, address, abi as any) as any;
+/**
+ * `createContract` is generic over a typed ABI def; these minimal literal ABIs
+ * are called by name via `.query()`, so the handle is untyped by construction.
+ */
+export function contractOf(runtime: ContractRuntime, address: HexString, abi: AbiEntry[]) {
+    return createContract(runtime, address, abi as any) as any;
+}
+
+/**
+ * Origin for a read. Passing the fallback explicitly rather than letting the
+ * contracts layer substitute it keeps each query from logging a warning.
+ */
+export function readOrigin(opts: DotNsClientOptions): SS58String {
+    return opts.origin ?? QUERY_FALLBACK_ORIGIN;
 }
 
 async function readAddress(
@@ -208,22 +229,26 @@ export async function discoverDotNsAddresses(
             return discoveryFailed("DotnsGateway.DispatcherAddress is unset");
         }
 
-        const origin = opts.origin ?? QUERY_FALLBACK_ORIGIN;
+        const origin = readOrigin(opts);
         const target = await readAddress(
-            contractAt(opts, dispatcher, DOTNS_ROOT_GATEWAY_DISPATCHER_ABI),
+            contractOf(opts.runtime, dispatcher, DOTNS_ROOT_GATEWAY_DISPATCHER_ABI),
             "TARGET",
             origin,
         );
         if (!target.ok) return target;
 
         const protocolRegistry = await readAddress(
-            contractAt(opts, target.value, DOTNS_POP_CONTROLLER_ABI),
+            contractOf(opts.runtime, target.value, DOTNS_POP_CONTROLLER_ABI),
             "protocolRegistry",
             origin,
         );
         if (!protocolRegistry.ok) return protocolRegistry;
 
-        const registry = contractAt(opts, protocolRegistry.value, DOTNS_PROTOCOL_REGISTRY_ABI);
+        const registry = contractOf(
+            opts.runtime,
+            protocolRegistry.value,
+            DOTNS_PROTOCOL_REGISTRY_ABI,
+        );
         const roles = Object.entries(DOTNS_REGISTRY_KEYS) as [
             keyof typeof DOTNS_REGISTRY_KEYS,
             HexString,
@@ -254,8 +279,6 @@ export async function discoverDotNsAddresses(
     }
 }
 
-const walkCache: RuntimeCache<DotNsAddresses> = new WeakMap();
-
 /**
  * Walk the gateway and report every role whose live address differs from the
  * one this client would call. Meant for startup: it fails loudly once, rather
@@ -264,8 +287,17 @@ const walkCache: RuntimeCache<DotNsAddresses> = new WeakMap();
 export async function verifyDotNsAddresses(
     opts: DotNsClientOptions,
 ): Promise<Result<DotNsAddresses, DotNsError>> {
-    const discovered = await discoverDotNsAddresses(opts);
+    // Through the cache, so verifying at startup and then using the client is
+    // one walk rather than two.
+    const discovered = await cachedPerRuntime(walkCache, opts.runtime, WALK_KEY, () =>
+        discoverDotNsAddresses(opts),
+    );
     if (!discovered.ok) return discovered;
+
+    // A discovered client already calls whatever the walk found, so there is
+    // nothing left to disagree with. Comparing it against the pinned table would
+    // report drift the client is not exposed to, and name an address it never uses.
+    if (opts.addressSource === "discovered") return ok(withOverrides(discovered.value, opts));
 
     const inUse = withOverrides(DOTNS_ADDRESSES, opts);
     const drift = (Object.keys(inUse) as (keyof DotNsAddresses)[])

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
@@ -53,7 +53,7 @@ export function isZero(addr: unknown): boolean {
     return typeof addr === "string" && addr.toLowerCase() === ZERO_ADDRESS;
 }
 
-/** Case-insensitive H160 compare: chain reads are lowercase, our table is EIP-55. */
+/** viem checksums every decoded `address`, so a read is EIP-55 whatever the chain sent. */
 export function sameAddress(a: unknown, b: unknown): boolean {
     return typeof a === "string" && typeof b === "string" && a.toLowerCase() === b.toLowerCase();
 }

--- a/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-addresses.ts
@@ -253,6 +253,9 @@ export async function discoverDotNsAddresses(
             keyof typeof DOTNS_REGISTRY_KEYS,
             HexString,
         ][];
+        // Not readAddress: that calls the method with no arguments, and these
+        // need the role name in the error rather than the method name, since
+        // every one of them is the same `get`.
         const found = await Promise.all(
             roles.map(async ([role, key]) => {
                 const res = await registry.get.query(key, { origin });

--- a/product-sdk/packages/sdk/src/identity/dotns-errors.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-errors.ts
@@ -18,6 +18,8 @@ export type DotNsErrorReason =
     | "NameUnavailable" // already registered
     | "NameReserved" // governance-held, or a base stem held by another user
     | "OwnerStatusInsufficient" // the owner lacks the personhood tier the label requires
+    | "AddressDiscovery" // the gateway walk could not locate the deployment
+    | "AddressMismatch" // a discovered address disagrees with the one in use
     | "RegistryCall" // the on-chain contract call failed
     | "Decode"; // the contract returned something we couldn't decode
 

--- a/product-sdk/packages/sdk/src/identity/dotns-registry.test.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-registry.test.ts
@@ -14,6 +14,7 @@ import { ss58ToH160 } from "@parity/product-sdk-address";
 import type { SS58String } from "polkadot-api";
 import { describe, expect, test } from "vitest";
 import {
+    DOTNS_POP_CONTROLLER_ABI,
     DOTNS_POP_RULES_ABI,
     DOTNS_PROTOCOL_REGISTRY_ABI,
     DOTNS_REGISTRAR_CONTROLLER_ABI,
@@ -21,9 +22,11 @@ import {
     DOTNS_RESOLVER_ABI,
     DOTNS_RESOLVER_WRITE_ABI,
     DOTNS_REVERSE_RESOLVER_ABI,
+    DOTNS_ROOT_GATEWAY_DISPATCHER_ABI,
     DOTNS_ADDRESSES,
     POP_STATUS,
 } from "./dotns-abis.js";
+import { DOTNS_REGISTRY_KEYS, type DotNsGatewayQueryApi } from "./dotns-addresses.js";
 import { DotNsError } from "./dotns-errors.js";
 import {
     isDotNsAvailable,
@@ -1150,5 +1153,157 @@ describe("the resolver pointer is an allowlist, not a denylist", () => {
             resolverAddress: custom,
         });
         expect(r).toEqual({ ok: true, value: { address: TARGET, name: "dim2.dot", owner: OWNER } });
+    });
+});
+
+describe("the discovered addresses reach every entry point", () => {
+    // The wiring these tests exist for: a client asking for discovery must not
+    // then read the TLD, or any name, from the pinned table. Reading one from
+    // each source is the same mismatch the issue is about, one layer down.
+    const DISPATCHER = `0x${"b1".repeat(20)}`;
+    const POP_CONTROLLER = `0x${"b2".repeat(20)}`;
+    const D_REGISTRY = `0x${"a1".repeat(20)}`;
+    const D_RESOLVER = `0x${"a3".repeat(20)}`;
+    const D_CONTROLLER = `0x${"a4".repeat(20)}`;
+    const D_POP_RULES = `0x${"a5".repeat(20)}`;
+    const D_PROTOCOL_REGISTRY = `0x${"a6".repeat(20)}`;
+    const D_REVERSE = `0x${"a2".repeat(20)}`;
+
+    const DISCOVERED: Record<string, string> = {
+        [DOTNS_REGISTRY_KEYS.registry]: D_REGISTRY,
+        [DOTNS_REGISTRY_KEYS.reverseResolver]: D_REVERSE,
+        [DOTNS_REGISTRY_KEYS.resolver]: D_RESOLVER,
+        [DOTNS_REGISTRY_KEYS.registrarController]: D_CONTROLLER,
+        [DOTNS_REGISTRY_KEYS.popRules]: D_POP_RULES,
+    };
+
+    const gatewayApi = {
+        query: { DotnsGateway: { DispatcherAddress: { getValue: async () => DISPATCHER } } },
+    } as DotNsGatewayQueryApi;
+
+    /**
+     * A chain where the discovered contracts answer and the pinned ones stay
+     * silent, so anything still calling a pinned address reads `undefined`.
+     */
+    function discoveringRuntime(answers: Record<string, unknown> = {}) {
+        return createFakeContractRuntime({
+            abi: [
+                ...ALL_ABIS,
+                ...DOTNS_PROTOCOL_REGISTRY_ABI,
+                ...DOTNS_ROOT_GATEWAY_DISPATCHER_ABI,
+                ...DOTNS_POP_CONTROLLER_ABI,
+            ],
+            onQuery: ({ dest, functionName, args }) => {
+                const at = dest.toLowerCase();
+                if (functionName === "TARGET") return POP_CONTROLLER;
+                if (functionName === "protocolRegistry") return D_PROTOCOL_REGISTRY;
+                if (functionName === "get") return DISCOVERED[String(args?.[0])] ?? ZERO;
+                if (at !== D_PROTOCOL_REGISTRY.toLowerCase() && functionName === "tld") {
+                    return undefined; // only the discovered registry knows the TLD
+                }
+                if (functionName === "tld" || functionName === "tldNode") {
+                    return functionName === "tld" ? ".paseo" : dotNsTld(".paseo").node;
+                }
+                if (functionName && functionName in answers) return answers[functionName];
+                return undefined;
+            },
+        });
+    }
+
+    const destsFor = (runtime: ReturnType<typeof discoveringRuntime>, fn: string) =>
+        runtime.calls.filter((c) => c.functionName === fn).map((c) => c.dest.toLowerCase());
+
+    test("resolveTld reads the TLD from the discovered protocol registry", async () => {
+        const runtime = discoveringRuntime();
+        const r = await resolveTld({ runtime, gatewayApi, addressSource: "discovered" });
+        expect(r).toEqual({ ok: true, value: dotNsTld(".paseo") });
+        expect(destsFor(runtime, "tld")).toEqual([D_PROTOCOL_REGISTRY.toLowerCase()]);
+        expect(destsFor(runtime, "tld")).not.toContain(
+            DOTNS_ADDRESSES.protocolRegistry.toLowerCase(),
+        );
+    });
+
+    test("resolveDotNs reads the discovered registry", async () => {
+        const runtime = discoveringRuntime({ owner: OWNER, resolver: ZERO });
+        const r = await resolveDotNs("dim2.paseo", {
+            runtime,
+            gatewayApi,
+            addressSource: "discovered",
+        });
+        expect(r).toEqual({ ok: true, value: { name: "dim2.paseo", owner: OWNER } });
+        expect(destsFor(runtime, "owner")).toEqual([D_REGISTRY.toLowerCase()]);
+    });
+
+    test("resolveDotNs asks the discovered forward resolver", async () => {
+        const runtime = discoveringRuntime({
+            owner: OWNER,
+            resolver: D_RESOLVER,
+            addressOf: TARGET,
+        });
+        const r = await resolveDotNs("dim2.paseo", {
+            runtime,
+            gatewayApi,
+            addressSource: "discovered",
+        });
+        expect(r).toEqual({
+            ok: true,
+            value: { address: TARGET, name: "dim2.paseo", owner: OWNER },
+        });
+        expect(destsFor(runtime, "addressOf")).toEqual([D_RESOLVER.toLowerCase()]);
+    });
+
+    test("reverseDotNs reads the discovered reverse resolver", async () => {
+        const runtime = discoveringRuntime({ nameOf: "dim2.paseo" });
+        const r = await reverseDotNs(OWNER, { runtime, gatewayApi, addressSource: "discovered" });
+        expect(r).toEqual({ ok: true, value: "dim2.paseo" });
+        expect(destsFor(runtime, "nameOf")).toEqual([D_REVERSE.toLowerCase()]);
+    });
+
+    test("isDotNsAvailable reads the discovered controller and pop rules", async () => {
+        const runtime = discoveringRuntime({ available: true, classifyName: OPEN });
+        const r = await isDotNsAvailable("dim2.paseo", {
+            runtime,
+            gatewayApi,
+            addressSource: "discovered",
+        });
+        expect(r).toEqual({ ok: true, value: true });
+        expect(destsFor(runtime, "available")).toEqual([D_CONTROLLER.toLowerCase()]);
+        expect(destsFor(runtime, "classifyName")).toEqual([D_POP_RULES.toLowerCase()]);
+    });
+
+    test("setDotNsRecord writes through the discovered registry and resolver", async () => {
+        const runtime = discoveringRuntime({ resolver: ZERO });
+        const r = await setDotNsRecord(
+            { name: "dim2.paseo", address: TARGET },
+            { runtime, gatewayApi, addressSource: "discovered", origin: SIGNER },
+        );
+        expect(r.ok).toBe(true);
+        expect(destsFor(runtime, "resolver")).toEqual([D_REGISTRY.toLowerCase()]);
+    });
+
+    test("prepareDotNsRegistration reads the discovered controller", async () => {
+        const runtime = discoveringRuntime({
+            available: true,
+            makeCommitment: `0x${"ab".repeat(32)}`,
+            priceWithoutCheck: [1n, POP_STATUS.NoStatus, POP_STATUS.PopFull, ""],
+            transferFloor: 0n,
+            minCommitmentAge: 60n,
+            maxCommitmentAge: 86400n,
+        });
+        const r = await prepareDotNsRegistration(
+            { name: "dim2.paseo", owner: OWNER },
+            { runtime, gatewayApi, addressSource: "discovered", origin: SIGNER },
+        );
+        expect(r.ok).toBe(true);
+        expect(destsFor(runtime, "available")).toEqual([D_CONTROLLER.toLowerCase()]);
+        expect(destsFor(runtime, "priceWithoutCheck")).toEqual([D_POP_RULES.toLowerCase()]);
+    });
+
+    test("the walk runs once, no matter how many entry points are called", async () => {
+        const runtime = discoveringRuntime({ owner: OWNER, resolver: ZERO, nameOf: "dim2.paseo" });
+        const opts = { runtime, gatewayApi, addressSource: "discovered" } as const;
+        await resolveDotNs("dim2.paseo", opts);
+        await reverseDotNs(OWNER, opts);
+        expect(runtime.calls.filter((c) => c.functionName === "TARGET")).toHaveLength(1);
     });
 });

--- a/product-sdk/packages/sdk/src/identity/dotns-registry.test.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-registry.test.ts
@@ -857,7 +857,7 @@ describe("resolveTld", () => {
 
     test("an absent getter falls back to .dot, because that TLD was compiled in", async () => {
         // Pre-b4096968 deployments had no tld() and no way to be anything but
-        // `.dot`. Verified against Paseo Asset Hub Previewnet.
+        // `.dot`. No live deployment is known to still be one.
         const runtime = registryRuntime({ tld: NO_GETTER, tldNode: NO_GETTER });
         expect(await resolveTld({ runtime })).toEqual({ ok: true, value: DOT_TLD });
     });
@@ -1055,8 +1055,8 @@ describe("the deployment's TLD reaches every entry point", () => {
     });
 
     test("a legacy deployment with no tld() getter still resolves .dot names", async () => {
-        // Paseo Asset Hub Previewnet: both getters revert empty, and `dim2` is
-        // owned there under the `.dot` root. The fix must not break it.
+        // Guards the pre-b4096968 shape, which Previewnet was thought to have
+        // until it reported `.test`. Kept: nothing proves the shape is extinct.
         const runtime = createFakeContractRuntime({
             abi: [...ALL_ABIS, ...DOTNS_PROTOCOL_REGISTRY_ABI],
             onQuery: ({ functionName }) => {

--- a/product-sdk/packages/sdk/src/identity/dotns-registry.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-registry.ts
@@ -12,7 +12,7 @@
  *
  * **Names are rooted at the network's TLD, which is per deployment.** It is
  * fixed when `DotnsProtocolRegistry.initialize` runs, has no setter, and is
- * published as `tld()`. `.paseo` on Paseo Asset Hub Next V2, `.dot` on
+ * published as `tld()`. `.paseo` on Paseo Asset Hub Next V2, `.test` on
  * Previewnet, and operators can choose others. Every entry point that hashes a
  * name therefore asks the chain first, through {@link resolveTld}, and callers
  * can supply `opts.tld` to skip the read. Hashing under the wrong root returns a
@@ -65,6 +65,7 @@ import {
 } from "./dotns-abis.js";
 import { DotNsError } from "./dotns-errors.js";
 import {
+    type DotNsGatewayQueryApi,
     type RuntimeCache,
     cachedPerRuntime,
     isZero,
@@ -117,6 +118,29 @@ export interface DotNsClientOptions {
      * the whole set is CREATE3-deterministic.
      */
     protocolRegistryAddress?: HexString;
+    /**
+     * Where the addresses come from. `"pinned"` (the default) uses the
+     * {@link DOTNS_ADDRESSES} table; `"discovered"` walks the gateway on the
+     * chain `runtime` points at, so nothing is trusted from this bundle.
+     *
+     * Pinned is the default because the table is currently correct and a walk
+     * costs four round trips on the first call. Discovery is the honest choice
+     * once a deployment has moved, and its trust root is
+     * `DotnsGateway.DispatcherAddress` — a governance-set value on the chain the
+     * caller already trusts for every name read. Per-field address overrides win
+     * over either source.
+     */
+    addressSource?: "pinned" | "discovered";
+    /**
+     * Typed API for the chain hosting the `DotnsGateway` pallet, needed only by
+     * `"discovered"`.
+     *
+     * Optional because `runtime.api` is usually the same chain and is used when
+     * it carries the pallet. `ContractRuntime` does not declare that storage, so
+     * it is probed rather than assumed; on a chain without the pallet, discovery
+     * fails with `AddressDiscovery` instead of throwing.
+     */
+    gatewayApi?: DotNsGatewayQueryApi;
     /**
      * The deployment's TLD, when you already know it.
      *
@@ -218,8 +242,8 @@ function isEmptyRevert(value: unknown): boolean {
  *     via the protocol registry"). Before that commit the TLD was a
  *     compile-time constant and `.dot` was the only value it could hold, so
  *     this is the one case where the fallback is provably right rather than
- *     merely plausible. Verified against Paseo Asset Hub Previewnet, where both
- *     getters revert empty and `dim2` is owned under the `.dot` root;
+ *     merely plausible. No live deployment is known to still take this
+ *     branch: Previewnet was cited for it, but reports `.test`;
  *   - anything else → `err`. A dispatch failure, a revert carrying a reason, an
  *     undecodable answer, or a TLD we cannot use.
  *
@@ -369,7 +393,9 @@ export async function resolveDotNs(
         return err(nameError(name, normalized, tld));
     }
     const node = namehash(normalized, tld);
-    const registryAddr = opts.registryAddress ?? DOTNS_ADDRESSES.registry;
+    const addrs = await resolveDotNsAddresses(opts);
+    if (!addrs.ok) return addrs;
+    const registryAddr = addrs.value.registry;
     const origin = readOrigin(opts);
     log.debug("resolveDotNs", { name: normalized, node, registry: registryAddr });
 
@@ -414,7 +440,7 @@ export async function resolveDotNs(
         // way; before this, the read and write paths disagreed about what a
         // pointer meant.
         const resolverAddr = resolverRes.value as HexString;
-        const forwardAddr = opts.resolverAddress ?? DOTNS_ADDRESSES.resolver;
+        const forwardAddr = addrs.value.resolver;
         if (!sameAddress(resolverAddr, forwardAddr)) {
             return ok({ name: normalized, owner });
         }
@@ -450,7 +476,9 @@ export async function reverseDotNs(
     address: string,
     opts: DotNsClientOptions,
 ): Promise<Result<string | null, DotNsError>> {
-    const reverseAddr = opts.reverseResolverAddress ?? DOTNS_ADDRESSES.reverseResolver;
+    const addrs = await resolveDotNsAddresses(opts);
+    if (!addrs.ok) return addrs;
+    const reverseAddr = addrs.value.reverseResolver;
     log.debug("reverseDotNs", { address, reverseResolver: reverseAddr });
     try {
         const reverse = contractOf(
@@ -508,7 +536,9 @@ export async function isDotNsAvailable(
     }
     // The registrar takes the bare label, without the TLD suffix.
     const label = stripSuffix(normalized, tld.suffix);
-    const controllerAddr = opts.registrarControllerAddress ?? DOTNS_ADDRESSES.registrarController;
+    const addrs = await resolveDotNsAddresses(opts);
+    if (!addrs.ok) return addrs;
+    const controllerAddr = addrs.value.registrarController;
     log.debug("isDotNsAvailable", { name: normalized, label, controller: controllerAddr });
 
     try {
@@ -517,11 +547,7 @@ export async function isDotNsAvailable(
             controllerAddr as HexString,
             DOTNS_REGISTRAR_CONTROLLER_ABI,
         );
-        const popRules = contractOf(
-            opts.runtime,
-            (opts.popRulesAddress ?? DOTNS_ADDRESSES.popRules) as HexString,
-            DOTNS_POP_RULES_ABI,
-        );
+        const popRules = contractOf(opts.runtime, addrs.value.popRules, DOTNS_POP_RULES_ABI);
         const origin = readOrigin(opts);
         const [res, classified] = await Promise.all([
             controller.available.query(label, { origin }),
@@ -589,8 +615,10 @@ export async function setDotNsRecord(
         return err(new DotNsError("MissingOrigin", "setDotNsRecord needs opts.origin (SS58)"));
     }
     const node = namehash(normalized, tld);
-    const registryAddr = opts.registryAddress ?? DOTNS_ADDRESSES.registry;
-    const resolverAddr = opts.resolverAddress ?? DOTNS_ADDRESSES.resolver;
+    const addrs = await resolveDotNsAddresses(opts);
+    if (!addrs.ok) return addrs;
+    const registryAddr = addrs.value.registry;
+    const resolverAddr = addrs.value.resolver;
     try {
         const registry = contractOf(opts.runtime, registryAddr as HexString, DOTNS_REGISTRY_ABI);
         const currentRes = await registry.resolver.query(node, { origin });
@@ -745,8 +773,10 @@ export async function prepareDotNsRegistration(
     }
     // The registrar takes the bare label, without the TLD suffix.
     const label = stripSuffix(normalized, tld.suffix);
-    const controllerAddr = opts.registrarControllerAddress ?? DOTNS_ADDRESSES.registrarController;
-    const popRulesAddr = opts.popRulesAddress ?? DOTNS_ADDRESSES.popRules;
+    const addrs = await resolveDotNsAddresses(opts);
+    if (!addrs.ok) return addrs;
+    const controllerAddr = addrs.value.registrarController;
+    const popRulesAddr = addrs.value.popRules;
     const secret = `0x${bytesToHex(randomBytes(32))}` as HexString;
     const registration = { label, owner: args.owner, secret, reserved: args.reserved ?? false };
     // register compares msg.sender against the owner; msg.sender is derived

--- a/product-sdk/packages/sdk/src/identity/dotns-registry.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-registry.ts
@@ -41,13 +41,7 @@
  * expiry getter), so `DotNsRecord.expiresAt` is always omitted.
  */
 import { err, ok, type Result } from "@parity/result";
-import {
-    type AbiEntry,
-    type BatchableCall,
-    createContract,
-    QUERY_FALLBACK_ORIGIN,
-} from "@parity/product-sdk-contracts";
-import type { ContractRuntime } from "@parity/product-sdk-contracts";
+import type { AbiEntry, BatchableCall, ContractRuntime } from "@parity/product-sdk-contracts";
 import { bytesToHex, randomBytes } from "@parity/product-sdk-crypto";
 import { ss58ToH160 } from "@parity/product-sdk-address";
 import { createLogger } from "@parity/product-sdk-logger";
@@ -68,7 +62,9 @@ import {
     type DotNsGatewayQueryApi,
     type RuntimeCache,
     cachedPerRuntime,
+    contractOf,
     isZero,
+    readOrigin,
     resolveDotNsAddresses,
     sameAddress,
 } from "./dotns-addresses.js";
@@ -129,6 +125,13 @@ export interface DotNsClientOptions {
      * `DotnsGateway.DispatcherAddress` — a governance-set value on the chain the
      * caller already trusts for every name read. Per-field address overrides win
      * over either source.
+     *
+     * Discovery also selects the address `setDotNsRecord` and
+     * `prepareDotNsRegistration` build calls against, so it decides where a
+     * signed transaction goes, not only where a read comes from. A pinned
+     * address constrains that destination even against a hostile RPC; a
+     * discovered one does not. Use {@link verifyDotNsAddresses} at startup if
+     * that matters.
      */
     addressSource?: "pinned" | "discovered";
     /**
@@ -186,20 +189,6 @@ export interface SetRecordArgs {
      * {@link RegisterDotNsArgs.owner}.
      */
     address: string;
-}
-
-function contractOf(runtime: ContractRuntime, address: HexString, abi: AbiEntry[]) {
-    // createContract is generic over a typed ABI def; these minimal literal ABIs
-    // are called by name via .query(), so the handle is untyped by construction.
-    return createContract(runtime, address, abi as any) as any;
-}
-
-/**
- * Origin for a read. Passing the fallback explicitly rather than letting the
- * contracts layer substitute it keeps each query from logging a warning.
- */
-function readOrigin(opts: DotNsClientOptions): SS58String {
-    return opts.origin ?? QUERY_FALLBACK_ORIGIN;
 }
 
 // ── The deployment's TLD ─────────────────────────────────────────────

--- a/product-sdk/packages/sdk/src/identity/dotns-registry.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-registry.ts
@@ -64,6 +64,13 @@ import {
     POP_STATUS,
 } from "./dotns-abis.js";
 import { DotNsError } from "./dotns-errors.js";
+import {
+    type RuntimeCache,
+    cachedPerRuntime,
+    isZero,
+    resolveDotNsAddresses,
+    sameAddress,
+} from "./dotns-addresses.js";
 import { isResolvableDotNsName, isValidDotNsName, normalizeDotNsName } from "./dotns.js";
 import {
     DOT_TLD,
@@ -78,8 +85,6 @@ import type { DotNsRecord } from "./types.js";
 const log = createLogger("identity:dotns");
 
 type HexString = `0x${string}`;
-
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 /** Shared inputs for a DotNS registry call. */
 export interface DotNsClientOptions {
@@ -165,21 +170,12 @@ function contractOf(runtime: ContractRuntime, address: HexString, abi: AbiEntry[
     return createContract(runtime, address, abi as any) as any;
 }
 
-function isZero(addr: unknown): boolean {
-    return typeof addr === "string" && addr.toLowerCase() === ZERO_ADDRESS;
-}
-
 /**
  * Origin for a read. Passing the fallback explicitly rather than letting the
  * contracts layer substitute it keeps each query from logging a warning.
  */
 function readOrigin(opts: DotNsClientOptions): SS58String {
     return opts.origin ?? QUERY_FALLBACK_ORIGIN;
-}
-
-/** Case-insensitive H160 compare: chain reads are lowercase, our table is EIP-55. */
-function sameAddress(a: unknown, b: unknown): boolean {
-    return typeof a === "string" && typeof b === "string" && a.toLowerCase() === b.toLowerCase();
 }
 
 // ── The deployment's TLD ─────────────────────────────────────────────
@@ -189,14 +185,11 @@ function sameAddress(a: unknown, b: unknown): boolean {
 // (runtime, protocol registry) and cache it: it cannot change under us.
 
 /**
- * Cached TLD per runtime, then per protocol-registry address.
- *
- * Keyed on the address as well as the runtime because the address is
- * overridable, and one runtime pointed at two registries has two TLDs. The
- * value is the in-flight promise rather than the resolved TLD, so concurrent
- * first calls share one read instead of racing.
+ * Cached TLD per runtime, then per protocol-registry address. Keyed on the
+ * address as well because it is overridable, and one runtime pointed at two
+ * registries has two TLDs.
  */
-const tldCache = new WeakMap<ContractRuntime, Map<string, Promise<Result<DotNsTld, DotNsError>>>>();
+const tldCache: RuntimeCache<DotNsTld> = new WeakMap();
 
 /** An empty-payload revert: the contract ran and refused, telling us nothing. */
 function isEmptyRevert(value: unknown): boolean {
@@ -253,24 +246,10 @@ export async function resolveTld(opts: DotNsClientOptions): Promise<Result<DotNs
               );
     }
 
-    const address = (opts.protocolRegistryAddress ?? DOTNS_ADDRESSES.protocolRegistry) as HexString;
-    let perAddress = tldCache.get(opts.runtime);
-    if (!perAddress) {
-        perAddress = new Map();
-        tldCache.set(opts.runtime, perAddress);
-    }
-    const cached = perAddress.get(address);
-    if (cached) return cached;
-
-    const pending = readTld(opts, address);
-    perAddress.set(address, pending);
-    // Only a successful read is worth keeping: a failure is usually transient
-    // (RPC, not deployment), and caching it would strand the client for the
-    // life of the runtime.
-    pending.then((result) => {
-        if (!result.ok) perAddress?.delete(address);
-    });
-    return pending;
+    const addresses = await resolveDotNsAddresses(opts);
+    if (!addresses.ok) return addresses;
+    const address = addresses.value.protocolRegistry;
+    return cachedPerRuntime(tldCache, opts.runtime, address, () => readTld(opts, address));
 }
 
 async function readTld(

--- a/product-sdk/packages/sdk/src/identity/index.ts
+++ b/product-sdk/packages/sdk/src/identity/index.ts
@@ -48,6 +48,15 @@ export {
 export type { DotNsTld } from "./dotns-namehash.js";
 export { POP_STATUS, DOTNS_ADDRESSES } from "./dotns-abis.js";
 
+// Where those addresses come from: the pinned table, or the gateway walk.
+export {
+    DOTNS_REGISTRY_KEYS,
+    discoverDotNsAddresses,
+    resolveDotNsAddresses,
+    verifyDotNsAddresses,
+} from "./dotns-addresses.js";
+export type { DotNsAddresses, DotNsGatewayQueryApi } from "./dotns-addresses.js";
+
 // Context alias utilities (deprecated)
 export { deriveContextAlias, verifyContextAlias } from "./product-account.js";
 

--- a/product-sdk/pending-changesets/dotns-address-discovery.md
+++ b/product-sdk/pending-changesets/dotns-address-discovery.md
@@ -10,7 +10,9 @@ The addresses in `DOTNS_ADDRESSES` are correct today, but nothing checked that. 
 
 **`verifyDotNsAddresses(opts)`** does the same walk once and reports every role whose live address differs from the one the client would call, listing all of them rather than the first. Meant for startup: a product that keeps the pinned table can still fail loudly when a redeploy moves something.
 
-Both take their trust root from `DotnsGateway.DispatcherAddress`, a governance-set value on the chain the caller already relies on for every name read — a stronger anchor than a constant in a bundle, though neither defends against a hostile RPC.
+Both take their trust root from `DotnsGateway.DispatcherAddress`, a governance-set value on the chain the caller already relies on for every name read, a stronger anchor than a constant in a bundle.
+
+One thing to weigh before enabling it: discovery also selects the address the write helpers build calls against, so it decides where a signed transaction goes and not only where a read comes from. A pinned address constrains that destination even against a hostile RPC, and a discovered one does not. `verifyDotNsAddresses` is the check for products that want the pinned constraint and an alarm when it goes stale.
 
 **New exports.** `resolveDotNsAddresses`, `discoverDotNsAddresses`, `verifyDotNsAddresses`, `DOTNS_REGISTRY_KEYS`, and the types `DotNsAddresses` and `DotNsGatewayQueryApi`.
 

--- a/product-sdk/pending-changesets/dotns-address-discovery.md
+++ b/product-sdk/pending-changesets/dotns-address-discovery.md
@@ -1,0 +1,25 @@
+---
+"@parity/product-sdk": minor
+---
+
+**Resolve the DotNS contract addresses from chain state, instead of only trusting the pinned table.**
+
+The addresses in `DOTNS_ADDRESSES` are correct today, but nothing checked that. An earlier default set had no code deployed at any of its addresses, and every read returned "unregistered" with no error anywhere — the same silent shape as the TLD bug fixed in the previous release. This adds the two things that make that detectable.
+
+**`addressSource: "discovered"`** walks the deployment from chain state and trusts nothing compiled into the bundle: `DotnsGateway.DispatcherAddress` (pallet storage) → `dispatcher.TARGET()` → `popController.protocolRegistry()` → `protocolRegistry.get(key)` for the registry, registrar controller, forward resolver, reverse resolver and PoP rules. Four round trips, cached per runtime. The default stays `"pinned"`, which reads nothing.
+
+**`verifyDotNsAddresses(opts)`** does the same walk once and reports every role whose live address differs from the one the client would call, listing all of them rather than the first. Meant for startup: a product that keeps the pinned table can still fail loudly when a redeploy moves something.
+
+Both take their trust root from `DotnsGateway.DispatcherAddress`, a governance-set value on the chain the caller already relies on for every name read — a stronger anchor than a constant in a bundle, though neither defends against a hostile RPC.
+
+**New exports.** `resolveDotNsAddresses`, `discoverDotNsAddresses`, `verifyDotNsAddresses`, `DOTNS_REGISTRY_KEYS`, and the types `DotNsAddresses` and `DotNsGatewayQueryApi`.
+
+**New `DotNsClientOptions` fields.** `addressSource?: "pinned" | "discovered"` (default `"pinned"`) and `gatewayApi?: DotNsGatewayQueryApi`. The gateway API is optional: `runtime.api` is used when it carries the pallet, and is probed rather than assumed, so a chain without `DotnsGateway` — Polkadot and Kusama Asset Hub — fails with a typed error rather than throwing.
+
+**Two new `DotNsErrorReason` members**, so a `switch` over the union in consumer code is no longer exhaustive: `"AddressDiscovery"` when the walk cannot locate the deployment, and `"AddressMismatch"` when verification finds drift. They are separate from `"RegistryCall"` because they are not per-call failures — the first means the client cannot find the deployment at all.
+
+**The registry keys are not the field names.** `registrarController` answers under `bytes32("controller")`, not `"registrar"` — that is the ERC-721 holding name ownership, a different contract at a different address. `resolver` answers under `"resolver"`, not `"contentResolver"`. Both wrong keys return a live address rather than an error, so the mistake surfaces much later as a revert. `protocolRegistry` has no key at all and is reached through the walk.
+
+**Behaviour unchanged by default.** Every existing call keeps reading the pinned table, no new round trips, and no published signature changed. Per-field address overrides continue to win over whichever source is in use.
+
+**Also corrected: Previewnet's TLD is `.test`, not `.dot`.** Documentation only — no behaviour change. The `.dot` fallback for a deployment whose `tld()` getter reverts empty is still correct for anything predating `dotns` `b4096968`, but Previewnet was cited as the live example and is not one. No live deployment is currently known to take that branch.


### PR DESCRIPTION
Closes #303
Part of #286

### Description

Adds a way to resolve the DotNS contract addresses from chain state instead of only trusting the table compiled into the SDK, and a startup check that reports when that table has gone stale. The pinned table stays the default, so nothing changes unless a product opts in.

### Changes

`packages/sdk/src/identity/dotns-addresses.ts` (new). Owns address resolution. `resolveDotNsAddresses` is the single entry point, `discoverDotNsAddresses` walks the deployment from chain state, `verifyDotNsAddresses` compares what a client calls against what the chain says. Also holds `DOTNS_REGISTRY_KEYS` and the shared `cachedPerRuntime` helper.

`packages/sdk/src/identity/dotns-registry.ts`. Every entry point now asks `resolveDotNsAddresses` instead of writing `opts.xAddress ?? DOTNS_ADDRESSES.x`. Ten of those expressions are gone. Adds the `addressSource` and `gatewayApi` options. `resolveTld` reuses the shared cache.

`packages/sdk/src/identity/dotns-abis.ts`. Adds `get(bytes32)` to the protocol registry ABI, plus ABIs for the gateway dispatcher and the PoP controller.

`packages/sdk/src/identity/dotns-errors.ts`. Two reasons, `AddressDiscovery` and `AddressMismatch`. A `switch` over `DotNsErrorReason` in consumer code is no longer exhaustive.

`packages/sdk/src/identity/index.ts`. Exports the four new functions and three new types.

Tests. New `dotns-addresses.test.ts` with 36 tests, and 8 added to `dotns-registry.test.ts` proving the discovered addresses reach every entry point.

### Why these changes

The addresses were pinned and nothing checked them. An earlier default set had no code deployed at any of its addresses, and every read came back as "unregistered" with no error anywhere. Issue #303 asked for either the gateway walk or a startup check. This does both, since the check is the walk plus a comparison.

Two things worth knowing before enabling discovery. The registry keys are not the field names: `registrarController` answers under `bytes32("controller")`, and `registrar` is a different contract at a different address. And discovery also selects the address the write helpers build calls against, so it decides where a signed transaction goes, not only where a read comes from.

### Testing

```
cd product-sdk
pnpm install && pnpm -r build
pnpm --filter "@parity/product-sdk" test
pnpm check
```

Before: `main` has no tests for address resolution, and 84 registry tests. The package suite is 143 tests.

After: 187 tests pass, 44 new. `pnpm check` clean, `tsc --noEmit` clean, all 38 packages build.

Also run against two live chains, driving the built package rather than a reimplementation. On Paseo Asset Hub Next V2 and on Previewnet the walk lands on all six pinned addresses and `verifyDotNsAddresses` reports no drift. That confirms the key mapping by measurement: `get(bytes32("controller"))` returns the registrar controller, and `get(bytes32("registrar"))` returns something else.

The same run also corrected a stale claim in the code. Previewnet reports TLD `.test`, not `.dot`, so four comments naming it as a `.dot` deployment were wrong and are fixed. No behaviour depends on it.

Not covered: there is no automated live test, so nothing detects rot. That is an existing tracked follow-up, and this change narrows it without closing it.