### PR TITLE
feat: game and prize helpers for individuality

### DIFF
--- a/product-sdk/packages/address/src/display.ts
+++ b/product-sdk/packages/address/src/display.ts
@@ -1,5 +1,7 @@
 // Copyright 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
+import { getSs58AddressInfo, type SS58String } from "@polkadot-api/substrate-bindings";
+
 /**
  * Truncate an address for display.
  *
@@ -16,25 +18,109 @@ export function truncateAddress(address: string, startChars = 6, endChars = 4): 
 }
 
 /**
- * Compare two addresses for equality.
+ * Do two addresses name the same account?
  *
- * H160 (0x-prefixed) addresses are compared case-insensitively.
- * SS58 addresses are compared exactly (base58 is case-sensitive).
- * Mixed types (SS58 vs H160) always return false - use ss58ToH160 to normalize first.
- * SS58 addresses at different prefixes (same key, different network) return false -
- * use normalizeSs58 to re-encode with the same prefix before comparing.
+ * **On the account, not on the encoding.** Two SS58 strings for one key are equal
+ * even at different network prefixes, so this cannot tell you which network an
+ * address is written for; read the prefix from {@link ss58Decode} for that. An
+ * SS58 and an H160 are never equal, whatever they encode.
+ *
+ * A non-matching pair costs a decode, roughly 20 microseconds, where an exact
+ * match costs nothing. In a loop, use {@link publicKeysEqual} instead.
  */
 export function addressesEqual(a: string, b: string): boolean {
     if (a === b) return true;
-    // H160 addresses are hex, so case-insensitive comparison is safe
     if (a.startsWith("0x") && b.startsWith("0x")) {
         return a.toLowerCase() === b.toLowerCase();
     }
-    return false;
+    // Base58 is case-significant, so lowercasing an SS58 address invalidates its
+    // checksum rather than normalising it. Decoding is the only correct test.
+    const left = getSs58AddressInfo(a as SS58String);
+    const right = getSs58AddressInfo(b as SS58String);
+    // An invalid address equals nothing, and an exact match was handled above.
+    if (!left.isValid || !right.isValid) return false;
+    return publicKeysEqual(left.publicKey, right.publicKey);
+}
+
+/**
+ * Do two public keys match? The loop half of {@link addressesEqual}: decode the
+ * needle once with {@link ss58Decode}, then compare it against each candidate.
+ *
+ * A byte comparison, so both inputs must already have decoded successfully. Two
+ * empty arrays compare equal. Unvalidated on purpose, since this runs per
+ * candidate.
+ */
+export function publicKeysEqual(a: Uint8Array, b: Uint8Array): boolean {
+    return a.length === b.length && a.every((byte, index) => byte === b[index]);
 }
 
 if (import.meta.vitest) {
     const { describe, test, expect } = import.meta.vitest;
+
+    describe("addressesEqual", () => {
+        const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+        // Alice's key written for the generic prefix and for Polkadot. Literals
+        // rather than derived, so the test pins the encodings themselves.
+        const ALICE_POLKADOT = "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5";
+
+        test("the same account under two network prefixes is equal", () => {
+            expect(ALICE_POLKADOT).not.toBe(ALICE);
+            expect(addressesEqual(ALICE, ALICE_POLKADOT)).toBe(true);
+        });
+
+        test("different accounts are not equal", () => {
+            const other = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+            expect(addressesEqual(ALICE, other)).toBe(false);
+        });
+
+        test("identical strings are equal without decoding", () => {
+            expect(addressesEqual(ALICE, ALICE)).toBe(true);
+        });
+
+        test("H160 stays case-insensitive", () => {
+            expect(
+                addressesEqual(
+                    "0x9621dde636de098b43efb0fa9b61facfe328f99d",
+                    "0x9621DDE636DE098B43EFB0FA9B61FACFE328F99D",
+                ),
+            ).toBe(true);
+        });
+
+        test("so it cannot be used as a network check", () => {
+            // Recorded because the previous behaviour was usable as a rough
+            // network check and this is no longer that.
+            expect(addressesEqual(ALICE, ALICE_POLKADOT)).toBe(true);
+        });
+
+        test("a malformed address is not equal to a valid one, and does not throw", () => {
+            expect(addressesEqual(ALICE, "not-an-address")).toBe(false);
+            expect(addressesEqual("not-an-address", "also-not")).toBe(false);
+        });
+    });
+
+    describe("publicKeysEqual", () => {
+        test("matches equal keys and rejects different ones", () => {
+            const a = new Uint8Array([1, 2, 3]);
+            expect(publicKeysEqual(a, new Uint8Array([1, 2, 3]))).toBe(true);
+            expect(publicKeysEqual(a, new Uint8Array([1, 2, 4]))).toBe(false);
+        });
+
+        test("different lengths are not equal, and do not read past the end", () => {
+            expect(publicKeysEqual(new Uint8Array([1, 2]), new Uint8Array([1, 2, 3]))).toBe(false);
+            expect(publicKeysEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2]))).toBe(false);
+        });
+
+        test("agrees with addressesEqual for one account under two prefixes", async () => {
+            // The documented escape hatch for a loop: decode once, compare keys.
+            const { ss58Decode } = await import("./ss58.js");
+            const generic = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+            const polkadot = "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5";
+            expect(
+                publicKeysEqual(ss58Decode(generic).publicKey, ss58Decode(polkadot).publicKey),
+            ).toBe(addressesEqual(generic, polkadot));
+        });
+    });
 
     describe("truncateAddress", () => {
         test("truncates with defaults", () => {

--- a/product-sdk/packages/address/src/index.ts
+++ b/product-sdk/packages/address/src/index.ts
@@ -27,7 +27,7 @@ export {
     isValidH160,
 } from "./h160.js";
 
-export { truncateAddress, addressesEqual } from "./display.js";
+export { truncateAddress, addressesEqual, publicKeysEqual } from "./display.js";
 
 /**
  * An SS58-encoded Substrate address (e.g. `5GrwvaEF...`). The brand marks strings

--- a/product-sdk/packages/individuality/src/airdrop-decode.ts
+++ b/product-sdk/packages/individuality/src/airdrop-decode.ts
@@ -1,0 +1,364 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Raw `Airdrop` storage values → domain shapes. An unknown enum variant throws
+ * rather than map to something plausible: a new lifecycle state must not render as
+ * the wrong phase.
+ *
+ * Two traps the compiler cannot see. `Status` carries its counters in some variants
+ * and not others (`AirdropEvent` has the table), so `?? 0` is a lie; and the `u64`
+ * timestamps throw rather than round, because a rounded one looks real.
+ */
+import { IndividualityDecodeError } from "./errors.js";
+import type {
+    AirdropAssetId,
+    AirdropEvent,
+    AirdropPhase,
+    AirdropPrize,
+    AirdropRegistrant,
+    AirdropStatusTag,
+} from "./airdrop-types.js";
+
+/** The raw `AirdropPrize`, narrowed to the fields the domain carries. */
+export interface RawAirdropPrize {
+    asset_id: AirdropAssetId;
+    asset_amount: bigint;
+    max_winners: number;
+    winner_cap: number;
+}
+
+/** The raw `EventInfo`. Every timestamp is a `u64` of Unix **seconds**. */
+export interface RawAirdropEventInfo {
+    prize: RawAirdropPrize;
+    registration_starts: bigint;
+    draw_time: bigint;
+    end_time: bigint;
+}
+
+/**
+ * The raw `Status` enum. The payload is loose on purpose: enumerating eight
+ * variants' field sets would duplicate the descriptor and catch nothing the
+ * availability rules above miss.
+ */
+export interface RawAirdropStatus {
+    type: string;
+    value?: {
+        total_participants?: number;
+        effective_winners?: number;
+        claimed?: number;
+    };
+}
+
+/**
+ * The raw `Airdrop.Events` value, narrowed to what the domain reads.
+ *
+ * Extra fields on the actual value are accepted — this is a structural type, not
+ * an exhaustive record of the storage entry.
+ */
+export interface RawActiveEvent {
+    id: string;
+    info: RawAirdropEventInfo;
+    status: RawAirdropStatus;
+    source?: string | undefined;
+}
+
+/** The raw `RegistrationEntry` enum, the key `Winners` is addressed by. */
+export type RawRegistrationEntry =
+    | { type: "Alias"; value: { alias: string } }
+    | { type: "Account"; value: { account_id: string } };
+
+/**
+ * `Status` collapsed to the phase a product renders. A lookup rather than a
+ * `switch` so a new {@link AirdropStatusTag} fails to compile here — classifying it
+ * is the one decision that must not be skippable.
+ */
+const PHASE_OF_STATUS: Record<AirdropStatusTag, AirdropPhase> = {
+    Scheduled: "Upcoming",
+    Registering: "Registering",
+    // Both are "closed, winners not final". The chain distinguishes waiting for
+    // randomness from assigning winners; a product does not.
+    AwaitingEntropy: "Drawing",
+    DrawWinners: "Drawing",
+    Claiming: "Claiming",
+    // All three clean-up states are over-and-nothing-to-do. Claims closed at
+    // `endTime`, which is what moved the draw out of `Claiming`.
+    ClearingRegistrations: "Settling",
+    ClearingWinners: "Settling",
+    Finalizing: "Settling",
+};
+
+/**
+ * Validate a raw `Status` variant name.
+ *
+ * The domain tags match the chain's variant names exactly, so this narrows
+ * rather than translates.
+ */
+function statusTag(type: string): AirdropStatusTag {
+    if (type in PHASE_OF_STATUS) {
+        return type as AirdropStatusTag;
+    }
+    // Fixed message: never echo chain data. Same rule at every throw here.
+    throw new IndividualityDecodeError("unknown airdrop status variant");
+}
+
+export function airdropPhase(status: AirdropStatusTag): AirdropPhase {
+    return PHASE_OF_STATUS[status];
+}
+
+/**
+ * Narrow a `u64` of Unix seconds, rejecting anything a JS number cannot hold
+ * exactly — a rounded timestamp is indistinguishable from a real one.
+ */
+function toUnixSeconds(value: bigint): number {
+    const seconds = Number(value);
+    if (!Number.isSafeInteger(seconds)) {
+        throw new IndividualityDecodeError("airdrop timestamp is out of range");
+    }
+    return seconds;
+}
+
+/** Exported for `game-decode.ts`: a game schedule carries this same shape per draw. */
+export function toAirdropPrize(raw: RawAirdropPrize): AirdropPrize {
+    return {
+        assetId: raw.asset_id,
+        assetAmount: raw.asset_amount,
+        maxWinners: raw.max_winners,
+        winnerCapPermill: raw.winner_cap,
+    };
+}
+
+/**
+ * @param eventId - the key the row was read under, rather than `raw.id`; the two
+ *   agreeing is asserted below, not assumed.
+ * @throws IndividualityDecodeError on an unknown status variant, an out-of-range
+ *   timestamp, or an `id` that disagrees with the key.
+ */
+export function toAirdropEvent(eventId: string, raw: RawActiveEvent): AirdropEvent {
+    // The id is stored in the value as well as the key, so a mismatch means a
+    // misaddressed read or a wrong descriptor — both worth failing on.
+    if (raw.id.toLowerCase() !== eventId.toLowerCase()) {
+        throw new IndividualityDecodeError(
+            "airdrop event id does not match the key it was read under",
+        );
+    }
+
+    const status = statusTag(raw.status.type);
+    // Undefined in every state that has not computed the figure yet, and
+    // `undefined` is not `0`: see trap 1 in the module doc.
+    const counters = raw.status.value;
+
+    return {
+        eventId,
+        status,
+        phase: airdropPhase(status),
+        prize: toAirdropPrize(raw.info.prize),
+        registrationStarts: toUnixSeconds(raw.info.registration_starts),
+        drawTime: toUnixSeconds(raw.info.draw_time),
+        endTime: toUnixSeconds(raw.info.end_time),
+        totalParticipants: counters?.total_participants ?? null,
+        effectiveWinners: counters?.effective_winners ?? null,
+        claimed: counters?.claimed ?? null,
+        source: raw.source ?? null,
+    };
+}
+
+/** A domain registrant as the `Winners` key wants it. */
+export function toRawRegistrationEntry(registrant: AirdropRegistrant): RawRegistrationEntry {
+    return registrant.tag === "Alias"
+        ? { type: "Alias", value: { alias: registrant.alias } }
+        : { type: "Account", value: { account_id: registrant.accountAddress } };
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    const EVENT_ID = `0x${"11".repeat(32)}`;
+
+    const rawPrize = (overrides: Partial<RawAirdropPrize> = {}): RawAirdropPrize => ({
+        asset_id: { parents: 1, interior: { type: "Here", value: undefined } },
+        asset_amount: 1_000_000_000_000n,
+        max_winners: 500,
+        winner_cap: 25_000,
+        ...overrides,
+    });
+
+    const rawEvent = (overrides: Partial<RawActiveEvent> = {}): RawActiveEvent => ({
+        id: EVENT_ID,
+        info: {
+            prize: rawPrize(),
+            registration_starts: 1_770_000_000n,
+            draw_time: 1_770_003_600n,
+            end_time: 1_770_090_000n,
+        },
+        status: {
+            type: "Claiming",
+            value: { total_participants: 40, effective_winners: 10, claimed: 3 },
+        },
+        source: undefined,
+        ...overrides,
+    });
+
+    describe("airdropPhase", () => {
+        test.each([
+            ["Scheduled", "Upcoming"],
+            ["Registering", "Registering"],
+            ["AwaitingEntropy", "Drawing"],
+            ["DrawWinners", "Drawing"],
+            ["Claiming", "Claiming"],
+            ["ClearingRegistrations", "Settling"],
+            ["ClearingWinners", "Settling"],
+            ["Finalizing", "Settling"],
+        ] as Array<[AirdropStatusTag, AirdropPhase]>)("maps %s to %s", (status, phase) => {
+            expect(airdropPhase(status)).toBe(phase);
+        });
+
+        test("covers all eight chain variants", () => {
+            // A ninth variant added to the union without a phase would fail the
+            // Record's type check, but a variant *removed* from the mapping
+            // would not — this pins the count.
+            expect(Object.keys(PHASE_OF_STATUS)).toHaveLength(8);
+        });
+    });
+
+    describe("toAirdropEvent", () => {
+        test("maps every field of a representative event", () => {
+            expect(toAirdropEvent(EVENT_ID, rawEvent())).toEqual({
+                eventId: EVENT_ID,
+                status: "Claiming",
+                phase: "Claiming",
+                prize: {
+                    assetId: { parents: 1, interior: { type: "Here", value: undefined } },
+                    assetAmount: 1_000_000_000_000n,
+                    maxWinners: 500,
+                    winnerCapPermill: 25_000,
+                },
+                registrationStarts: 1_770_000_000,
+                drawTime: 1_770_003_600,
+                endTime: 1_770_090_000,
+                totalParticipants: 40,
+                effectiveWinners: 10,
+                claimed: 3,
+                source: null,
+            });
+        });
+
+        test("carries the funding source when the event has one", () => {
+            const account = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+            expect(toAirdropEvent(EVENT_ID, rawEvent({ source: account })).source).toBe(account);
+        });
+
+        // The availability rules, one test per absent field. Each of these is a
+        // state a normal draw passes through, so `?? 0` here would be wrong in
+        // production rather than in a corner case.
+        test("Scheduled carries no counters at all", () => {
+            const event = toAirdropEvent(EVENT_ID, rawEvent({ status: { type: "Scheduled" } }));
+            expect(event.totalParticipants).toBeNull();
+            expect(event.effectiveWinners).toBeNull();
+            expect(event.claimed).toBeNull();
+        });
+
+        test("Registering carries participants but no winners and no claims", () => {
+            const event = toAirdropEvent(
+                EVENT_ID,
+                rawEvent({ status: { type: "Registering", value: { total_participants: 12 } } }),
+            );
+            expect(event.totalParticipants).toBe(12);
+            expect(event.effectiveWinners).toBeNull();
+            expect(event.claimed).toBeNull();
+        });
+
+        test("DrawWinners carries both counts but no claims yet", () => {
+            const event = toAirdropEvent(
+                EVENT_ID,
+                rawEvent({
+                    status: {
+                        type: "DrawWinners",
+                        value: { total_participants: 12, effective_winners: 4 },
+                    },
+                }),
+            );
+            expect(event.totalParticipants).toBe(12);
+            expect(event.effectiveWinners).toBe(4);
+            expect(event.claimed).toBeNull();
+        });
+
+        test("Finalizing drops the participant count but keeps winners and claims", () => {
+            const event = toAirdropEvent(
+                EVENT_ID,
+                rawEvent({
+                    status: { type: "Finalizing", value: { effective_winners: 4, claimed: 2 } },
+                }),
+            );
+            // Not zero: the draw had participants, the chain stopped carrying
+            // the figure.
+            expect(event.totalParticipants).toBeNull();
+            expect(event.effectiveWinners).toBe(4);
+            expect(event.claimed).toBe(2);
+        });
+
+        test("keeps a zero counter distinct from an absent one", () => {
+            const event = toAirdropEvent(
+                EVENT_ID,
+                rawEvent({ status: { type: "Registering", value: { total_participants: 0 } } }),
+            );
+            expect(event.totalParticipants).toBe(0);
+        });
+
+        test("throws on an unknown status variant", () => {
+            expect(() =>
+                toAirdropEvent(EVENT_ID, rawEvent({ status: { type: "Reconciling" } })),
+            ).toThrow(IndividualityDecodeError);
+        });
+
+        test("never interpolates chain data into a decode error message", () => {
+            expect(() =>
+                toAirdropEvent(
+                    EVENT_ID,
+                    rawEvent({ status: { type: "Reconciling", value: { claimed: 99 } } }),
+                ),
+            ).toThrow(/^unknown airdrop status variant$/);
+        });
+
+        test("throws when the row's own id disagrees with the key", () => {
+            expect(() =>
+                toAirdropEvent(EVENT_ID, rawEvent({ id: `0x${"22".repeat(32)}` })),
+            ).toThrow(IndividualityDecodeError);
+        });
+
+        test("accepts an id that differs only in hex case", () => {
+            expect(() =>
+                toAirdropEvent(EVENT_ID.toUpperCase().replace("0X", "0x"), rawEvent()),
+            ).not.toThrow();
+        });
+
+        test("throws on a timestamp beyond safe-integer range", () => {
+            const raw = rawEvent();
+            raw.info.draw_time = 2n ** 63n;
+            expect(() => toAirdropEvent(EVENT_ID, raw)).toThrow(IndividualityDecodeError);
+        });
+
+        test("accepts a zero timestamp, which is a real chain value", () => {
+            const raw = rawEvent();
+            raw.info.registration_starts = 0n;
+            expect(toAirdropEvent(EVENT_ID, raw).registrationStarts).toBe(0);
+        });
+    });
+
+    describe("toRawRegistrationEntry", () => {
+        test("maps an alias registrant to the Alias variant", () => {
+            const alias = `0x${"ab".repeat(32)}`;
+            expect(toRawRegistrationEntry({ tag: "Alias", alias })).toEqual({
+                type: "Alias",
+                value: { alias },
+            });
+        });
+
+        test("maps an account registrant to the Account variant", () => {
+            const accountAddress = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+            expect(toRawRegistrationEntry({ tag: "Account", accountAddress })).toEqual({
+                type: "Account",
+                value: { account_id: accountAddress },
+            });
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/airdrop-decode.ts
+++ b/product-sdk/packages/individuality/src/airdrop-decode.ts
@@ -88,12 +88,13 @@ const PHASE_OF_STATUS: Record<AirdropStatusTag, AirdropPhase> = {
 };
 
 /**
- * Validate a raw `Status` variant name.
+ * Validate a raw `Status` variant name. Exported so a read that only needs the
+ * variant, not the whole event, still fails loudly on an unknown one.
  *
  * The domain tags match the chain's variant names exactly, so this narrows
  * rather than translates.
  */
-function statusTag(type: string): AirdropStatusTag {
+export function statusTag(type: string): AirdropStatusTag {
     if (type in PHASE_OF_STATUS) {
         return type as AirdropStatusTag;
     }

--- a/product-sdk/packages/individuality/src/airdrop-ids.ts
+++ b/product-sdk/packages/individuality/src/airdrop-ids.ts
@@ -1,0 +1,432 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Prize-draw event ids, derived offline. No storage entry lists them, so this is
+ * the entry point to every read in `airdrop-read.ts`.
+ *
+ * ```
+ * Game:            base(27) ‖ airdrop_index(u8) ‖ game_index(u32 BE)
+ * PeopleAirdrops:  base(24) ‖ draw_index(u64 BE)
+ * ```
+ *
+ * `Game`'s base is a runtime constant; `PeopleAirdrops`' never reaches metadata, so
+ * it is hardcoded and the pinned vectors are its only guard.
+ *
+ * **This layout is paseo's.** Devnet's base is 28 bytes — one draw per game, so no
+ * airdrop-index byte. `SizedHex<N>` erases `N`, so nothing typechecks that: the
+ * length check in {@link gameAirdropEventId} is the whole guard.
+ */
+import { ProductIndividualityError } from "./errors.js";
+
+/**
+ * `Game::airdrop_event_id_base()` — 27 bytes, the ten trailing spaces included as
+ * part of the value. The pinned expectation; production reads the chain's copy.
+ */
+export const GAME_AIRDROP_EVENT_ID_BASE = "pop:game:airdrop:          ";
+
+/**
+ * `indiv_pallet_people_airdrops::EVENT_ID_BASE` — 24 bytes, four trailing spaces
+ * included. Hardcoded because it never reaches metadata, unlike `Game`'s; if it
+ * ever gains an `extra_constants` entry, read that and delete this.
+ */
+export const PEOPLE_AIRDROPS_EVENT_ID_BASE = "pop:people-airdrops:    ";
+
+/** `Game`'s `MAX_GAME_AIRDROPS`: a game schedules at most this many draws. */
+export const MAX_GAME_AIRDROPS = 16;
+
+/** Every event id is 32 bytes, both layouts. */
+const EVENT_ID_BYTES = 32;
+
+const GAME_BASE_BYTES = 27;
+const PEOPLE_AIRDROPS_BASE_BYTES = 24;
+
+const U8_MAX = 0xff;
+const U32_MAX = 0xff_ff_ff_ff;
+const U64_MAX = 0xff_ff_ff_ff_ff_ff_ff_ffn;
+
+/** `0x`-prefixed lower-case hex, the form every PAPI storage key here takes. */
+function toEventId(bytes: Uint8Array): string {
+    let hex = "";
+    for (const byte of bytes) {
+        hex += byte.toString(16).padStart(2, "0");
+    }
+    return `0x${hex}`;
+}
+
+/**
+ * A base as bytes, from `0x` hex (the chain constant) or ASCII (the pinned ones).
+ * A wrong length is a chain-versus-client disagreement, so it throws rather than
+ * pad or truncate into something plausible.
+ */
+function baseBytes(base: string | Uint8Array, expectedLength: number): Uint8Array {
+    const bytes = typeof base === "string" ? decodeBase(base) : base;
+    if (bytes.length !== expectedLength) {
+        throw new ProductIndividualityError("airdrop event id base has the wrong length");
+    }
+    return bytes;
+}
+
+/** Hex if it is `0x`-prefixed, UTF-8 otherwise. */
+function decodeBase(base: string): Uint8Array {
+    if (!base.startsWith("0x")) {
+        return new TextEncoder().encode(base);
+    }
+    const digits = base.slice(2);
+    if (digits.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(digits)) {
+        throw new ProductIndividualityError("airdrop event id base is not valid hex");
+    }
+    const bytes = new Uint8Array(digits.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = Number.parseInt(digits.slice(i * 2, i * 2 + 2), 16);
+    }
+    return bytes;
+}
+
+function checkIndex(value: number, max: number, what: string): number {
+    if (!Number.isInteger(value) || value < 0 || value > max) {
+        throw new ProductIndividualityError(`airdrop ${what} is out of range`);
+    }
+    return value;
+}
+
+/**
+ * Mirrors `Game::airdrop_event_id`, a plain `impl` method, so only its base reaches
+ * metadata and the pinned vectors below keep this honest.
+ *
+ * @param options.base - pass the chain constant, not
+ *   {@link GAME_AIRDROP_EVENT_ID_BASE}, so a base change cannot desync this.
+ * @throws ProductIndividualityError on a malformed base, or an index wider than its
+ *   chain type (`u32` game, `u8` airdrop).
+ */
+export function gameAirdropEventId(options: {
+    base: string | Uint8Array;
+    gameIndex: number;
+    airdropIndex: number;
+}): string {
+    const base = baseBytes(options.base, GAME_BASE_BYTES);
+    // A u8 on chain. Not capped at MAX_GAME_AIRDROPS: `claim_airdrop` takes the
+    // full width, and capping here would make a legitimate id underivable.
+    const airdropIndex = checkIndex(options.airdropIndex, U8_MAX, "index");
+    const gameIndex = checkIndex(options.gameIndex, U32_MAX, "game index");
+
+    const id = new Uint8Array(EVENT_ID_BYTES);
+    id.set(base, 0);
+    id[GAME_BASE_BYTES] = airdropIndex;
+    // u32, big-endian. `>>>` keeps the shift unsigned; a signed `>>` would be
+    // wrong for indices above 2^31.
+    id[28] = (gameIndex >>> 24) & U8_MAX;
+    id[29] = (gameIndex >>> 16) & U8_MAX;
+    id[30] = (gameIndex >>> 8) & U8_MAX;
+    id[31] = gameIndex & U8_MAX;
+    return toEventId(id);
+}
+
+/**
+ * Derive a `PeopleAirdrops` draw's event id, mirroring
+ * `PeopleAirdrops::draw_event_id`. The `u64` index takes a `bigint` or a
+ * safe-integer `number`: anything above `MAX_SAFE_INTEGER` would round before
+ * reaching the encoder and address a draw nobody scheduled, so it throws.
+ */
+export function peopleAirdropsEventId(drawIndex: number | bigint): string {
+    let index: bigint;
+    if (typeof drawIndex === "bigint") {
+        index = drawIndex;
+    } else {
+        if (!Number.isSafeInteger(drawIndex)) {
+            throw new ProductIndividualityError("airdrop draw index is out of range");
+        }
+        index = BigInt(drawIndex);
+    }
+    if (index < 0n || index > U64_MAX) {
+        throw new ProductIndividualityError("airdrop draw index is out of range");
+    }
+
+    const base = baseBytes(PEOPLE_AIRDROPS_EVENT_ID_BASE, PEOPLE_AIRDROPS_BASE_BYTES);
+    const id = new Uint8Array(EVENT_ID_BYTES);
+    id.set(base, 0);
+    // u64, big-endian: fill the last eight bytes from the low end up.
+    for (let i = 0; i < 8; i++) {
+        id[31 - i] = Number((index >> BigInt(i * 8)) & 0xffn);
+    }
+    return toEventId(id);
+}
+
+/**
+ * Every draw id of one game, in airdrop-index order. `airdropsScheduled` only
+ * exists while that game is current, so a past game's count must have been
+ * captured — probing cannot tell a cleaned-up draw from one never scheduled.
+ */
+export function gameAirdropEventIds(options: {
+    base: string | Uint8Array;
+    gameIndex: number;
+    airdropsScheduled: number;
+}): string[] {
+    const count = checkIndex(options.airdropsScheduled, MAX_GAME_AIRDROPS, "draw count");
+    return Array.from({ length: count }, (_, airdropIndex) =>
+        gameAirdropEventId({
+            base: options.base,
+            gameIndex: options.gameIndex,
+            airdropIndex,
+        }),
+    );
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    /**
+     * Hex of an ASCII string, computed here rather than with the module's own
+     * helper: a vector that shares its encoder with the code under test pins
+     * nothing.
+     */
+    const asciiHex = (text: string): string =>
+        [...new TextEncoder().encode(text)].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+    describe("the pinned bases", () => {
+        test("Game's base is 27 bytes with its padding intact", () => {
+            expect(new TextEncoder().encode(GAME_AIRDROP_EVENT_ID_BASE)).toHaveLength(27);
+            expect(GAME_AIRDROP_EVENT_ID_BASE).toBe("pop:game:airdrop:          ");
+        });
+
+        test("PeopleAirdrops' base is 24 bytes with its padding intact", () => {
+            expect(new TextEncoder().encode(PEOPLE_AIRDROPS_EVENT_ID_BASE)).toHaveLength(24);
+            expect(PEOPLE_AIRDROPS_EVENT_ID_BASE).toBe("pop:people-airdrops:    ");
+        });
+    });
+
+    describe("gameAirdropEventId", () => {
+        test("lays out base ++ airdrop_index ++ game_index big-endian", () => {
+            expect(
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 1,
+                    airdropIndex: 0,
+                }),
+            ).toBe(`0x${asciiHex("pop:game:airdrop:          ")}0000000001`);
+        });
+
+        test("pins a multi-byte game index and a non-zero airdrop index", () => {
+            expect(
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 0x01_02_03_04,
+                    airdropIndex: 0x0f,
+                }),
+            ).toBe(`0x${asciiHex("pop:game:airdrop:          ")}0f01020304`);
+        });
+
+        test("keeps a game index above 2^31 unsigned", () => {
+            // A signed shift would produce ff… here. This is the case a `>>`
+            // typo passes every other test with.
+            expect(
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 0x80_00_00_01,
+                    airdropIndex: 0,
+                }),
+            ).toBe(`0x${asciiHex("pop:game:airdrop:          ")}0080000001`);
+        });
+
+        test("accepts the base as chain hex, identically to the ASCII literal", () => {
+            const fromHex = gameAirdropEventId({
+                base: `0x${asciiHex(GAME_AIRDROP_EVENT_ID_BASE)}`,
+                gameIndex: 7,
+                airdropIndex: 2,
+            });
+            const fromAscii = gameAirdropEventId({
+                base: GAME_AIRDROP_EVENT_ID_BASE,
+                gameIndex: 7,
+                airdropIndex: 2,
+            });
+            expect(fromHex).toBe(fromAscii);
+        });
+
+        test("accepts the base as bytes", () => {
+            expect(
+                gameAirdropEventId({
+                    base: new TextEncoder().encode(GAME_AIRDROP_EVENT_ID_BASE),
+                    gameIndex: 7,
+                    airdropIndex: 2,
+                }),
+            ).toBe(
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 7,
+                    airdropIndex: 2,
+                }),
+            );
+        });
+
+        test("is always 32 bytes", () => {
+            const id = gameAirdropEventId({
+                base: GAME_AIRDROP_EVENT_ID_BASE,
+                gameIndex: 0,
+                airdropIndex: 0,
+            });
+            expect(id).toHaveLength(2 + 64);
+        });
+
+        test("distinct (game, airdrop) pairs give distinct ids", () => {
+            const id = (gameIndex: number, airdropIndex: number) =>
+                gameAirdropEventId({ base: GAME_AIRDROP_EVENT_ID_BASE, gameIndex, airdropIndex });
+            expect(new Set([id(1, 0), id(0, 1), id(1, 1), id(0, 0)]).size).toBe(4);
+        });
+
+        test.each([
+            [26, "one byte short"],
+            [28, "one byte long"],
+        ])("rejects a %i-byte base (%s)", (length) => {
+            expect(() =>
+                gameAirdropEventId({
+                    base: new Uint8Array(length),
+                    gameIndex: 0,
+                    airdropIndex: 0,
+                }),
+            ).toThrow(ProductIndividualityError);
+        });
+
+        test("rejects a malformed hex base", () => {
+            expect(() =>
+                gameAirdropEventId({ base: "0xzz", gameIndex: 0, airdropIndex: 0 }),
+            ).toThrow(ProductIndividualityError);
+        });
+
+        test.each([
+            [-1, 0, "negative game index"],
+            [1.5, 0, "fractional game index"],
+            [U32_MAX + 1, 0, "game index above u32"],
+            [0, -1, "negative airdrop index"],
+            [0, 256, "airdrop index above u8"],
+            [Number.NaN, 0, "NaN"],
+        ])("rejects gameIndex %s / airdropIndex %s (%s)", (gameIndex, airdropIndex) => {
+            expect(() =>
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex,
+                    airdropIndex,
+                }),
+            ).toThrow(ProductIndividualityError);
+        });
+
+        test("allows an airdrop index above MAX_GAME_AIRDROPS", () => {
+            // `claim_airdrop` takes a full u8, so capping the derivation at the
+            // scheduling limit would make a legitimate id underivable.
+            expect(() =>
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 0,
+                    airdropIndex: MAX_GAME_AIRDROPS + 1,
+                }),
+            ).not.toThrow();
+        });
+    });
+
+    describe("peopleAirdropsEventId", () => {
+        test("lays out base ++ draw_index as a big-endian u64", () => {
+            expect(peopleAirdropsEventId(0)).toBe(
+                `0x${asciiHex("pop:people-airdrops:    ")}0000000000000000`,
+            );
+            expect(peopleAirdropsEventId(1)).toBe(
+                `0x${asciiHex("pop:people-airdrops:    ")}0000000000000001`,
+            );
+        });
+
+        test("pins a draw index using all eight bytes", () => {
+            expect(peopleAirdropsEventId(0x01_02_03_04_05_06_07_08n)).toBe(
+                `0x${asciiHex("pop:people-airdrops:    ")}0102030405060708`,
+            );
+        });
+
+        test("pins the u64 maximum", () => {
+            expect(peopleAirdropsEventId(U64_MAX)).toBe(
+                `0x${asciiHex("pop:people-airdrops:    ")}ffffffffffffffff`,
+            );
+        });
+
+        test("a number and the same bigint agree", () => {
+            expect(peopleAirdropsEventId(4_294_967_296)).toBe(
+                peopleAirdropsEventId(4_294_967_296n),
+            );
+        });
+
+        test("is always 32 bytes", () => {
+            expect(peopleAirdropsEventId(0)).toHaveLength(2 + 64);
+        });
+
+        test("never collides with a Game id", () => {
+            // Different bases, so this is really a check that the bases differ
+            // in their first 24 bytes — which is what makes the two schedulers'
+            // id spaces disjoint.
+            expect(peopleAirdropsEventId(0)).not.toBe(
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 0,
+                    airdropIndex: 0,
+                }),
+            );
+        });
+
+        test.each([
+            [-1n, "negative"],
+            [U64_MAX + 1n, "above u64"],
+        ])("rejects %s (%s)", (drawIndex) => {
+            expect(() => peopleAirdropsEventId(drawIndex)).toThrow(ProductIndividualityError);
+        });
+
+        test.each([
+            [-1, "negative"],
+            [1.5, "fractional"],
+            [Number.NaN, "NaN"],
+            [Number.MAX_SAFE_INTEGER + 1, "beyond safe-integer range"],
+        ])("rejects the number %s (%s)", (drawIndex) => {
+            expect(() => peopleAirdropsEventId(drawIndex)).toThrow(ProductIndividualityError);
+        });
+    });
+
+    describe("gameAirdropEventIds", () => {
+        test("returns one id per scheduled draw, in index order", () => {
+            const ids = gameAirdropEventIds({
+                base: GAME_AIRDROP_EVENT_ID_BASE,
+                gameIndex: 3,
+                airdropsScheduled: 3,
+            });
+            expect(ids).toEqual([
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 3,
+                    airdropIndex: 0,
+                }),
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 3,
+                    airdropIndex: 1,
+                }),
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 3,
+                    airdropIndex: 2,
+                }),
+            ]);
+        });
+
+        test("a game with no draws yields no ids", () => {
+            expect(
+                gameAirdropEventIds({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 3,
+                    airdropsScheduled: 0,
+                }),
+            ).toEqual([]);
+        });
+
+        test("rejects a count above MAX_GAME_AIRDROPS", () => {
+            expect(() =>
+                gameAirdropEventIds({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 3,
+                    airdropsScheduled: MAX_GAME_AIRDROPS + 1,
+                }),
+            ).toThrow(ProductIndividualityError);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/airdrop-read.ts
+++ b/product-sdk/packages/individuality/src/airdrop-read.ts
@@ -12,6 +12,7 @@
  * entropy slot with the entry as its value, so "am I registered" means scanning the
  * event's whole prefix — unbounded client-side, and no business in a polled status.
  */
+import { AccountId } from "polkadot-api";
 import { err, normalizeError, ok, type Result } from "@parity/result";
 import {
     toAirdropEvent,
@@ -19,8 +20,13 @@ import {
     type RawActiveEvent,
     type RawRegistrationEntry,
 } from "./airdrop-decode.js";
-import { gameAirdropEventIds } from "./airdrop-ids.js";
-import type { AirdropDraw, AirdropOutcome, AirdropRegistrant } from "./airdrop-types.js";
+import { gameAirdropEventId, gameAirdropEventIds } from "./airdrop-ids.js";
+import type {
+    AirdropAssetId,
+    AirdropDraw,
+    AirdropOutcome,
+    AirdropRegistrant,
+} from "./airdrop-types.js";
 import { ProductIndividualityError } from "./errors.js";
 import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
 import type { FinalizedSnapshot } from "./types.js";
@@ -70,6 +76,15 @@ export interface AirdropChain extends PinnedChain {
                         eventId: string,
                         options: ReadAt,
                     ): Promise<Array<{ keyArgs: [string, string]; value: RawRegistrationEntry }>>;
+                };
+                /**
+                 * Present only for assets a draw may pay in. `do_claim` rejects a
+                 * claim whose prize asset was disabled, so a claim check that skips
+                 * this can green-light one the chain will refuse, and a refused
+                 * claim pays a fee.
+                 */
+                SupportedAssets: {
+                    getValue(assetId: AirdropAssetId, options: ReadAt): Promise<bigint | undefined>;
                 };
             };
         };
@@ -200,12 +215,11 @@ export async function readDrawRegistration(
             readAt(snapshot, signal),
         );
 
-        const wanted = toRawRegistrationEntry(registrant);
-        const match = entries.find(
-            (entry) =>
-                entry.value.type === wanted.type &&
-                identityOf(entry.value).toLowerCase() === identityOf(wanted).toLowerCase(),
-        );
+        // Built before the scan, not per entry: the scan runs over every
+        // participant, and re-encoding the caller's own address each time doubled
+        // the work on a large draw.
+        const matches = matcherFor(toRawRegistrationEntry(registrant));
+        const match = entries.find(matches);
 
         return ok({
             at: snapshot,
@@ -219,8 +233,48 @@ export async function readDrawRegistration(
     }
 }
 
-function identityOf(entry: RawRegistrationEntry): string {
-    return entry.type === "Alias" ? entry.value.alias : entry.value.account_id;
+/**
+ * A predicate matching registration entries against one identity.
+ *
+ * Accounts are compared as **public keys, not SS58 strings**: one key encodes to a
+ * different string under every network prefix, so a caller holding the generic
+ * form would not match a chain returning the network form and would read as not
+ * registered. Base58 is also case-significant, so lowercasing an address breaks
+ * its checksum rather than normalising it. Aliases are 32-byte hex, where case
+ * genuinely does not matter.
+ *
+ * The caller's address is encoded here, once, which also makes a malformed one
+ * fail the same way every time. Encoding inside the scan instead made the failure
+ * depend on the draw's contents: a bad address threw only if some entry happened
+ * to be account-shaped, and answered "not registered" otherwise.
+ */
+function matcherFor(
+    wanted: RawRegistrationEntry,
+): (entry: { value: RawRegistrationEntry }) => boolean {
+    if (wanted.type === "Alias") {
+        const alias = wanted.value.alias.toLowerCase();
+        return ({ value }) => value.type === "Alias" && value.value.alias.toLowerCase() === alias;
+    }
+    const codec = AccountId();
+    const key = codec.enc(wanted.value.account_id);
+    return ({ value }) => {
+        if (value.type !== "Account") return false;
+        const other = codec.enc(value.value.account_id);
+        return other.length === key.length && other.every((byte, i) => byte === key[i]);
+    };
+}
+
+/**
+ * One draw's event id, with the base read from the chain rather than assumed.
+ * Internal, so the claim and prize-status reads share it instead of each repeating
+ * the read-then-derive pair.
+ */
+export async function readAirdropEventId(
+    chain: AirdropChain,
+    options: { gameIndex: number; airdropIndex: number },
+): Promise<string> {
+    const base = await chain.individuality.constants.Game.airdrop_event_id_base();
+    return gameAirdropEventId({ base, ...options });
 }
 
 /** Options for {@link readGameAirdropEventIds}. */
@@ -294,6 +348,7 @@ if (import.meta.vitest) {
         winners?: Record<string, string>;
         entropy?: string;
         base?: string;
+        assetDisabled?: boolean;
         /** `Registrations` rows under the event, as the prefix scan sees them. */
         registrations?: Array<{ keyArgs: [string, string]; value: RawRegistrationEntry }>;
         failOn?: "Events" | "Winners" | "EventEntropy" | "Registrations" | "constant" | "block";
@@ -352,6 +407,12 @@ if (import.meta.vitest) {
                                 boom("Registrations");
                                 record("Registrations", eventId, options);
                                 return state.registrations ?? [];
+                            },
+                        },
+                        SupportedAssets: {
+                            getValue: async (assetId, options) => {
+                                record("SupportedAssets", assetId, options);
+                                return state.assetDisabled ? undefined : 1n;
                             },
                         },
                     },
@@ -638,19 +699,56 @@ if (import.meta.vitest) {
             expect(registration.entriesScanned).toBe(1);
         });
 
-        test("does not match an alias against an account carrying the same bytes", async () => {
-            // The two variants are distinct identities even where the payload
-            // collides, so the variant has to be compared as well as the value.
+        test("matches an account across SS58 network prefixes", async () => {
+            // The two encodings below are one account. A string compare misses it.
+            const { AccountId } = await import("polkadot-api");
+            const otherPrefix = AccountId(0).dec(AccountId().enc(ALICE));
+            expect(otherPrefix).not.toBe(ALICE);
+
+            const { chain } = fakeChain({
+                registrations: rows({ type: "Account", value: { account_id: otherPrefix } }),
+            });
+            const registration = unwrapOk(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(registration.slot).toBe(SLOT);
+        });
+
+        test("does not match an alias entry against an account registrant", async () => {
+            // The two variants are distinct identities, so the variant is compared
+            // as well as the value.
             const { chain } = fakeChain({
                 registrations: rows({ type: "Alias", value: { alias: ALIAS } }),
             });
             const registration = unwrapOk(
                 await readDrawRegistration(chain, {
                     eventId: EVENT_ID,
-                    registrant: { tag: "Account", accountAddress: ALIAS },
+                    registrant: { tag: "Account", accountAddress: ALICE },
                 }),
             );
             expect(registration.slot).toBeNull();
+        });
+
+        test("a malformed account address fails, whatever the draw contains", async () => {
+            // Deterministic across draw shapes, which is the point: see `matcherFor`.
+            for (const registrations of [
+                rows({ type: "Alias", value: { alias: ALIAS } }),
+                rows({ type: "Account", value: { account_id: ALICE } }),
+                [],
+            ]) {
+                const { chain } = fakeChain({ registrations });
+                const error = unwrapErr(
+                    await readDrawRegistration(chain, {
+                        eventId: EVENT_ID,
+                        // An alias hex is not an address, and never was.
+                        registrant: { tag: "Account", accountAddress: ALIAS },
+                    }),
+                );
+                expect(error).toBeInstanceOf(ProductIndividualityError);
+            }
         });
 
         test("picks the caller's row out of several", async () => {

--- a/product-sdk/packages/individuality/src/airdrop-read.ts
+++ b/product-sdk/packages/individuality/src/airdrop-read.ts
@@ -1,0 +1,717 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The pinned prize-draw read: one event id in, one {@link AirdropDraw} out. Ids come
+ * from `airdrop-ids.ts`, or from {@link readGameAirdropEventIds}.
+ *
+ * **Every read shares one finalized block.** A draw's phase and its winner set move
+ * together, so reading them a block apart can report a draw as still `Registering`
+ * while it already holds its winners.
+ *
+ * `Registrations` is read only by {@link readDrawRegistration}: it is keyed by the
+ * entropy slot with the entry as its value, so "am I registered" means scanning the
+ * event's whole prefix — unbounded client-side, and no business in a polled status.
+ */
+import { err, normalizeError, ok, type Result } from "@parity/result";
+import {
+    toAirdropEvent,
+    toRawRegistrationEntry,
+    type RawActiveEvent,
+    type RawRegistrationEntry,
+} from "./airdrop-decode.js";
+import { gameAirdropEventIds } from "./airdrop-ids.js";
+import type { AirdropDraw, AirdropOutcome, AirdropRegistrant } from "./airdrop-types.js";
+import { ProductIndividualityError } from "./errors.js";
+import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
+import type { FinalizedSnapshot } from "./types.js";
+
+/**
+ * Structural, so a test double satisfies it. See `IndividualityChain` in `read.ts`
+ * for the conventions and where the fidelity guard lives.
+ *
+ * Matched by hand against the paseo descriptors on 2026-08-20:
+ *
+ * ```
+ * Game.airdrop_event_id_base: PlainDescriptor<SizedHex<27>>
+ * Airdrop.Events:             StorageDescriptor<[Key: SizedHex<32>], ActiveEvent, true, never>
+ * Airdrop.Winners:            StorageDescriptor<[SizedHex<32>, RegistrationEntry], SizedHex<32>, true, never>
+ * Airdrop.EventEntropy:       StorageDescriptor<[Key: SizedHex<32>], SizedHex<32>, true, never>
+ * ```
+ */
+export interface AirdropChain extends PinnedChain {
+    individuality: {
+        constants: {
+            Game: {
+                /** 27-byte base, `0x`-prefixed hex. */
+                airdrop_event_id_base(): Promise<string>;
+            };
+        };
+        query: {
+            Airdrop: {
+                Events: {
+                    getValue(eventId: string, options: ReadAt): Promise<RawActiveEvent | undefined>;
+                };
+                Winners: {
+                    getValue(
+                        eventId: string,
+                        entry: RawRegistrationEntry,
+                        options: ReadAt,
+                    ): Promise<string | undefined>;
+                };
+                EventEntropy: {
+                    getValue(eventId: string, options: ReadAt): Promise<string | undefined>;
+                };
+                /**
+                 * Keyed by the entropy slot with the entry as its value, so only
+                 * a prefix scan can answer "is this identity registered".
+                 */
+                Registrations: {
+                    getEntries(
+                        eventId: string,
+                        options: ReadAt,
+                    ): Promise<Array<{ keyArgs: [string, string]; value: RawRegistrationEntry }>>;
+                };
+            };
+        };
+    };
+}
+
+/** Options for {@link readAirdropDraw}. */
+export interface ReadAirdropDrawOptions {
+    /**
+     * The 32-byte event id, `0x`-prefixed. Derive it with `gameAirdropEventId`
+     * or `peopleAirdropsEventId` — no storage entry lists it.
+     */
+    eventId: string;
+    /**
+     * Whose outcome to look up. Omit it to read the draw itself without asking
+     * about anyone, which returns `outcome: { tag: "Unchecked" }` rather than a
+     * `false` that would read as "did not win".
+     */
+    registrant?: AirdropRegistrant;
+    /**
+     * Forwarded into every underlying pull, so an aborted caller stops the whole
+     * batch. No deadline is applied here — that belongs to the caller.
+     */
+    signal?: AbortSignal;
+}
+
+/**
+ * **A draw that is not in storage is not a failure**, it is `phase: "Gone"` — the
+ * steady state for every past draw. Not evidence the draw existed either: an id
+ * that was never scheduled answers identically.
+ */
+export async function readAirdropDraw(
+    chain: AirdropChain,
+    options: ReadAirdropDrawOptions,
+): Promise<Result<AirdropDraw, ProductIndividualityError>> {
+    try {
+        return ok(await runDrawRead(chain, options));
+    } catch (cause) {
+        // normalizeError passes an existing package error through unchanged, so
+        // callers can still narrow with isErrorOf.
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+/**
+ * The read itself. Throws; {@link readAirdropDraw} owns the `Result` boundary.
+ *
+ * Exported so `prize-status.ts` can run it against a block it already pinned.
+ */
+export async function runDrawRead(
+    chain: AirdropChain,
+    options: ReadAirdropDrawOptions,
+    pinned?: FinalizedSnapshot,
+): Promise<AirdropDraw> {
+    const { eventId, registrant, signal } = options;
+    const query = chain.individuality.query.Airdrop;
+
+    const snapshot = await pinBlock(chain, signal, pinned);
+    const at: ReadAt = readAt(snapshot, signal);
+
+    // One round trip, three entries, one block. The winner lookup is a point
+    // read rather than a scan because `Winners` hashes the registration entry —
+    // which is why an identity is all it takes.
+    const [rawEvent, ticket, entropy] = await Promise.all([
+        query.Events.getValue(eventId, at),
+        registrant === undefined
+            ? Promise.resolve(undefined)
+            : query.Winners.getValue(eventId, toRawRegistrationEntry(registrant), at),
+        query.EventEntropy.getValue(eventId, at),
+    ]);
+
+    const event = rawEvent === undefined ? null : toAirdropEvent(eventId, rawEvent);
+
+    return {
+        at: snapshot,
+        eventId,
+        // "Gone" is the absence of the row, not a status the chain reports.
+        phase: event?.phase ?? "Gone",
+        event,
+        outcome: toOutcome(registrant, ticket),
+        entropy: entropy ?? null,
+    };
+}
+
+function toOutcome(
+    registrant: AirdropRegistrant | undefined,
+    ticket: string | undefined,
+): AirdropOutcome {
+    if (registrant === undefined) {
+        return { tag: "Unchecked" };
+    }
+    return ticket === undefined ? { tag: "NotWon" } : { tag: "Won", ticket };
+}
+
+/** One draw's registration for one identity. */
+export interface DrawRegistration {
+    at: FinalizedSnapshot;
+    eventId: string;
+    /**
+     * The entropy slot the registration is stored under, or `null` when this
+     * identity has none. The slot is also the draw ticket.
+     */
+    slot: string | null;
+    /**
+     * Entries the scan walked. Reported because it is the cost of the call, and
+     * nothing bounds it below the draw's participant count.
+     */
+    entriesScanned: number;
+}
+
+/**
+ * Whether an identity entered a draw, which {@link readAirdropDraw} cannot say: an
+ * absent `Winners` entry before the draw means "not drawn yet", not "did not enter".
+ *
+ * **A prefix scan, hence a separate call** — the cost grows with the participant
+ * count, so this is for "you are in tonight's draw", not for every status poll. The
+ * personhood path could point-read it, but is gated on the `PeopleAirdrops` blockers.
+ */
+export async function readDrawRegistration(
+    chain: AirdropChain,
+    options: { eventId: string; registrant: AirdropRegistrant; signal?: AbortSignal },
+): Promise<Result<DrawRegistration, ProductIndividualityError>> {
+    try {
+        const { eventId, registrant, signal } = options;
+        const snapshot = await pinBlock(chain, signal);
+        const entries = await chain.individuality.query.Airdrop.Registrations.getEntries(
+            eventId,
+            readAt(snapshot, signal),
+        );
+
+        const wanted = toRawRegistrationEntry(registrant);
+        const match = entries.find(
+            (entry) =>
+                entry.value.type === wanted.type &&
+                identityOf(entry.value).toLowerCase() === identityOf(wanted).toLowerCase(),
+        );
+
+        return ok({
+            at: snapshot,
+            eventId,
+            // keyArgs is [eventId, slot], so the slot is the second key.
+            slot: match?.keyArgs[1] ?? null,
+            entriesScanned: entries.length,
+        });
+    } catch (cause) {
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+function identityOf(entry: RawRegistrationEntry): string {
+    return entry.type === "Alias" ? entry.value.alias : entry.value.account_id;
+}
+
+/** Options for {@link readGameAirdropEventIds}. */
+export interface ReadGameAirdropEventIdsOptions {
+    /** The game the draws belong to. */
+    gameIndex: number;
+    /**
+     * `Game.Game.airdrops_scheduled`, **readable only while the game is current** —
+     * capture it then, because a past game's count is unrecoverable. Probing ids
+     * upward cannot tell a cleaned-up draw from one never scheduled.
+     */
+    airdropsScheduled: number;
+}
+
+/**
+ * Every event id of one game's draws, with the base read from the chain rather
+ * than assumed. That is the point of it: a hardcoded copy would go on deriving ids
+ * for draws that do not exist if the base ever moved.
+ */
+export async function readGameAirdropEventIds(
+    chain: AirdropChain,
+    options: ReadGameAirdropEventIdsOptions,
+): Promise<Result<string[], ProductIndividualityError>> {
+    try {
+        const base = await chain.individuality.constants.Game.airdrop_event_id_base();
+        return ok(
+            gameAirdropEventIds({
+                base,
+                gameIndex: options.gameIndex,
+                airdropsScheduled: options.airdropsScheduled,
+            }),
+        );
+    } catch (cause) {
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test } = import.meta.vitest;
+    const { unwrapOk, unwrapErr, isErrorOf } = await import("@parity/result");
+    const { IndividualityDecodeError } = await import("./errors.js");
+    const { GAME_AIRDROP_EVENT_ID_BASE, gameAirdropEventId } = await import("./airdrop-ids.js");
+
+    const EVENT_ID = `0x${"11".repeat(32)}`;
+    const TICKET = `0x${"ee".repeat(32)}`;
+    const ENTROPY = `0x${"77".repeat(32)}`;
+    const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const ALIAS = `0x${"ab".repeat(32)}`;
+    const BLOCK = { hash: `0x${"33".repeat(32)}`, number: 9_100 };
+
+    const rawEvent = (overrides: Partial<RawActiveEvent> = {}): RawActiveEvent => ({
+        id: EVENT_ID,
+        info: {
+            prize: {
+                asset_id: { parents: 1, interior: { type: "Here", value: undefined } },
+                asset_amount: 500n,
+                max_winners: 10,
+                winner_cap: 100_000,
+            },
+            registration_starts: 1_770_000_000n,
+            draw_time: 1_770_003_600n,
+            end_time: 1_770_090_000n,
+        },
+        status: { type: "Registering", value: { total_participants: 6 } },
+        ...overrides,
+    });
+
+    interface FakeState {
+        event?: RawActiveEvent;
+        /** Winning tickets, keyed by the JSON of the raw registration entry. */
+        winners?: Record<string, string>;
+        entropy?: string;
+        base?: string;
+        /** `Registrations` rows under the event, as the prefix scan sees them. */
+        registrations?: Array<{ keyArgs: [string, string]; value: RawRegistrationEntry }>;
+        failOn?: "Events" | "Winners" | "EventEntropy" | "Registrations" | "constant" | "block";
+    }
+
+    /**
+     * Records each read's key and options: a read addressed with the wrong event id,
+     * or a winner lookup with the wrong entry shape, satisfies every other
+     * assertion here.
+     */
+    function fakeChain(state: FakeState) {
+        const calls: Array<{ entry: string; key: unknown; at: string | undefined }> = [];
+        const boom = (entry: FakeState["failOn"]) => {
+            if (state.failOn === entry) throw new Error(`${entry} unreachable`);
+        };
+        const record = (entry: string, key: unknown, options: ReadAt) => {
+            options.signal?.throwIfAborted();
+            calls.push({ entry, key, at: options.at });
+        };
+
+        const chain: AirdropChain = {
+            individuality: {
+                constants: {
+                    Game: {
+                        airdrop_event_id_base: async () => {
+                            boom("constant");
+                            return state.base ?? GAME_AIRDROP_EVENT_ID_BASE;
+                        },
+                    },
+                },
+                query: {
+                    Airdrop: {
+                        Events: {
+                            getValue: async (eventId, options) => {
+                                boom("Events");
+                                record("Events", eventId, options);
+                                return state.event;
+                            },
+                        },
+                        Winners: {
+                            getValue: async (eventId, entry, options) => {
+                                boom("Winners");
+                                record("Winners", [eventId, entry], options);
+                                return state.winners?.[JSON.stringify(entry)];
+                            },
+                        },
+                        EventEntropy: {
+                            getValue: async (eventId, options) => {
+                                boom("EventEntropy");
+                                record("EventEntropy", eventId, options);
+                                return state.entropy;
+                            },
+                        },
+                        Registrations: {
+                            getEntries: async (eventId, options) => {
+                                boom("Registrations");
+                                record("Registrations", eventId, options);
+                                return state.registrations ?? [];
+                            },
+                        },
+                    },
+                },
+            },
+            raw: {
+                individuality: {
+                    getFinalizedBlock: async () => {
+                        boom("block");
+                        return BLOCK;
+                    },
+                },
+            },
+        };
+        return { chain, calls };
+    }
+
+    describe("readAirdropDraw", () => {
+        test("returns the decoded event with its phase", async () => {
+            const { chain } = fakeChain({ event: rawEvent() });
+            const draw = unwrapOk(await readAirdropDraw(chain, { eventId: EVENT_ID }));
+
+            expect(draw.eventId).toBe(EVENT_ID);
+            expect(draw.phase).toBe("Registering");
+            expect(draw.event?.status).toBe("Registering");
+            expect(draw.event?.totalParticipants).toBe(6);
+        });
+
+        test("reports the pinned block, and reads every entry at it", async () => {
+            const { chain, calls } = fakeChain({ event: rawEvent(), entropy: ENTROPY });
+            const draw = unwrapOk(
+                await readAirdropDraw(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+
+            expect(draw.at).toEqual({ blockHash: BLOCK.hash, blockNumber: BLOCK.number });
+            expect(calls).toHaveLength(3);
+            // The whole reason the block is pinned: three entries, one block.
+            expect(new Set(calls.map((call) => call.at))).toEqual(new Set([BLOCK.hash]));
+        });
+
+        test("addresses every read with the event id it was given", async () => {
+            const { chain, calls } = fakeChain({ event: rawEvent() });
+            await readAirdropDraw(chain, {
+                eventId: EVENT_ID,
+                registrant: { tag: "Alias", alias: ALIAS },
+            });
+
+            expect(calls.find((call) => call.entry === "Events")?.key).toBe(EVENT_ID);
+            expect(calls.find((call) => call.entry === "EventEntropy")?.key).toBe(EVENT_ID);
+            expect(calls.find((call) => call.entry === "Winners")?.key).toEqual([
+                EVENT_ID,
+                { type: "Alias", value: { alias: ALIAS } },
+            ]);
+        });
+
+        test("looks a winner up by the account entry for an account registrant", async () => {
+            const entry = { type: "Account", value: { account_id: ALICE } };
+            const { chain } = fakeChain({
+                event: rawEvent(),
+                winners: { [JSON.stringify(entry)]: TICKET },
+            });
+
+            const draw = unwrapOk(
+                await readAirdropDraw(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(draw.outcome).toEqual({ tag: "Won", ticket: TICKET });
+        });
+
+        test("looks a winner up by the alias entry for an alias registrant", async () => {
+            const entry = { type: "Alias", value: { alias: ALIAS } };
+            const { chain } = fakeChain({
+                event: rawEvent(),
+                winners: { [JSON.stringify(entry)]: TICKET },
+            });
+
+            const draw = unwrapOk(
+                await readAirdropDraw(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Alias", alias: ALIAS },
+                }),
+            );
+            expect(draw.outcome).toEqual({ tag: "Won", ticket: TICKET });
+        });
+
+        test("a registrant with no winning entry is NotWon", async () => {
+            const { chain } = fakeChain({ event: rawEvent() });
+            const draw = unwrapOk(
+                await readAirdropDraw(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(draw.outcome).toEqual({ tag: "NotWon" });
+        });
+
+        test("no registrant means Unchecked, and no winner read at all", async () => {
+            const { chain, calls } = fakeChain({ event: rawEvent() });
+            const draw = unwrapOk(await readAirdropDraw(chain, { eventId: EVENT_ID }));
+
+            // Unchecked rather than NotWon: the question was never asked, and a
+            // `false` here would be a claim the read never made.
+            expect(draw.outcome).toEqual({ tag: "Unchecked" });
+            expect(calls.some((call) => call.entry === "Winners")).toBe(false);
+        });
+
+        test("a missing event row is Gone, on the ok channel", async () => {
+            const { chain } = fakeChain({});
+            const draw = unwrapOk(await readAirdropDraw(chain, { eventId: EVENT_ID }));
+
+            // The steady state for every past draw, and indistinguishable from
+            // an id that was never scheduled.
+            expect(draw.phase).toBe("Gone");
+            expect(draw.event).toBeNull();
+        });
+
+        test("a win still reads after the event row is gone", async () => {
+            const entry = { type: "Account", value: { account_id: ALICE } };
+            const { chain } = fakeChain({ winners: { [JSON.stringify(entry)]: TICKET } });
+
+            const draw = unwrapOk(
+                await readAirdropDraw(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(draw.phase).toBe("Gone");
+            expect(draw.outcome).toEqual({ tag: "Won", ticket: TICKET });
+        });
+
+        test("carries the entropy when the draw has run, and null before", async () => {
+            const withEntropy = fakeChain({ event: rawEvent(), entropy: ENTROPY });
+            expect(
+                unwrapOk(await readAirdropDraw(withEntropy.chain, { eventId: EVENT_ID })).entropy,
+            ).toBe(ENTROPY);
+
+            const without = fakeChain({ event: rawEvent() });
+            expect(
+                unwrapOk(await readAirdropDraw(without.chain, { eventId: EVENT_ID })).entropy,
+            ).toBeNull();
+        });
+
+        test("an unknown status variant arrives as a decode error", async () => {
+            const { chain } = fakeChain({ event: rawEvent({ status: { type: "Reconciling" } }) });
+            const error = unwrapErr(await readAirdropDraw(chain, { eventId: EVENT_ID }));
+
+            expect(isErrorOf(error, IndividualityDecodeError)).toBe(true);
+        });
+
+        test("a transport failure arrives on the err channel with its cause", async () => {
+            const { chain } = fakeChain({ failOn: "Events" });
+            const error = unwrapErr(await readAirdropDraw(chain, { eventId: EVENT_ID }));
+
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+            expect((error.cause as Error).message).toBe("Events unreachable");
+        });
+
+        test("an already-aborted signal costs no round trip", async () => {
+            const { chain, calls } = fakeChain({ event: rawEvent() });
+            const controller = new AbortController();
+            controller.abort();
+
+            const error = unwrapErr(
+                await readAirdropDraw(chain, { eventId: EVENT_ID, signal: controller.signal }),
+            );
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+            expect(calls).toHaveLength(0);
+        });
+    });
+
+    describe("readGameAirdropEventIds", () => {
+        test("derives one id per scheduled draw from the chain's own base", async () => {
+            const { chain } = fakeChain({});
+            const ids = unwrapOk(
+                await readGameAirdropEventIds(chain, { gameIndex: 4, airdropsScheduled: 2 }),
+            );
+
+            expect(ids).toEqual([
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 4,
+                    airdropIndex: 0,
+                }),
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 4,
+                    airdropIndex: 1,
+                }),
+            ]);
+        });
+
+        test("uses the base the chain reports, not the pinned constant", async () => {
+            // A base the chain could plausibly move to. If the pinned constant
+            // were used instead, this test would pass with the wrong ids.
+            const base = `0x${"5f".repeat(27)}`;
+            const { chain } = fakeChain({ base });
+            const ids = unwrapOk(
+                await readGameAirdropEventIds(chain, { gameIndex: 1, airdropsScheduled: 1 }),
+            );
+
+            expect(ids).toEqual([gameAirdropEventId({ base, gameIndex: 1, airdropIndex: 0 })]);
+            expect(ids[0]).not.toBe(
+                gameAirdropEventId({
+                    base: GAME_AIRDROP_EVENT_ID_BASE,
+                    gameIndex: 1,
+                    airdropIndex: 0,
+                }),
+            );
+        });
+
+        test("a failure reading the constant arrives on the err channel", async () => {
+            const { chain } = fakeChain({ failOn: "constant" });
+            const error = unwrapErr(
+                await readGameAirdropEventIds(chain, { gameIndex: 1, airdropsScheduled: 1 }),
+            );
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+        });
+
+        test("a count above MAX_GAME_AIRDROPS arrives on the err channel, not as a throw", async () => {
+            const { chain } = fakeChain({});
+            const error = unwrapErr(
+                await readGameAirdropEventIds(chain, { gameIndex: 1, airdropsScheduled: 17 }),
+            );
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+        });
+    });
+
+    describe("readDrawRegistration", () => {
+        const SLOT = `0x${"a1".repeat(32)}`;
+        const OTHER = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+        const rows = (
+            ...entries: RawRegistrationEntry[]
+        ): Array<{ keyArgs: [string, string]; value: RawRegistrationEntry }> =>
+            entries.map((value, index) => ({
+                keyArgs: [EVENT_ID, index === 0 ? SLOT : `0x${String(index).repeat(64)}`],
+                value,
+            }));
+
+        test("finds an account registrant and returns its slot", async () => {
+            const { chain } = fakeChain({
+                registrations: rows({ type: "Account", value: { account_id: ALICE } }),
+            });
+            const registration = unwrapOk(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+
+            expect(registration.slot).toBe(SLOT);
+            expect(registration.entriesScanned).toBe(1);
+        });
+
+        test("finds an alias registrant and returns its slot", async () => {
+            const { chain } = fakeChain({
+                registrations: rows({ type: "Alias", value: { alias: ALIAS } }),
+            });
+            const registration = unwrapOk(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Alias", alias: ALIAS },
+                }),
+            );
+            expect(registration.slot).toBe(SLOT);
+        });
+
+        test("an identity with no entry is null, not the first row's slot", async () => {
+            const { chain } = fakeChain({
+                registrations: rows({ type: "Account", value: { account_id: OTHER } }),
+            });
+            const registration = unwrapOk(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(registration.slot).toBeNull();
+            expect(registration.entriesScanned).toBe(1);
+        });
+
+        test("does not match an alias against an account carrying the same bytes", async () => {
+            // The two variants are distinct identities even where the payload
+            // collides, so the variant has to be compared as well as the value.
+            const { chain } = fakeChain({
+                registrations: rows({ type: "Alias", value: { alias: ALIAS } }),
+            });
+            const registration = unwrapOk(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALIAS },
+                }),
+            );
+            expect(registration.slot).toBeNull();
+        });
+
+        test("picks the caller's row out of several", async () => {
+            const { chain } = fakeChain({
+                registrations: rows(
+                    { type: "Account", value: { account_id: ALICE } },
+                    { type: "Account", value: { account_id: OTHER } },
+                    { type: "Alias", value: { alias: ALIAS } },
+                ),
+            });
+            const registration = unwrapOk(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(registration.slot).toBe(SLOT);
+            // Reported so the cost of the scan is visible to the caller.
+            expect(registration.entriesScanned).toBe(3);
+        });
+
+        test("an empty draw scans nothing and answers null", async () => {
+            const { chain } = fakeChain({});
+            const registration = unwrapOk(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(registration).toEqual({
+                at: { blockHash: BLOCK.hash, blockNumber: BLOCK.number },
+                eventId: EVENT_ID,
+                slot: null,
+                entriesScanned: 0,
+            });
+        });
+
+        test("a transport failure arrives on the err channel", async () => {
+            const { chain } = fakeChain({ failOn: "Registrations" });
+            const error = unwrapErr(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+        });
+
+        test("an already-aborted signal costs no round trip", async () => {
+            const { chain, calls } = fakeChain({});
+            const controller = new AbortController();
+            controller.abort();
+            const error = unwrapErr(
+                await readDrawRegistration(chain, {
+                    eventId: EVENT_ID,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                    signal: controller.signal,
+                }),
+            );
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+            expect(calls).toHaveLength(0);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/airdrop-types.ts
+++ b/product-sdk/packages/individuality/src/airdrop-types.ts
@@ -1,0 +1,157 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * One draw is one `Airdrop` event, addressed by a derived id (`airdrop-ids.ts`).
+ * `Game` and `PeopleAirdrops` schedule through the same mechanism, so everything
+ * here is keyed by event id and knows nothing about which one did.
+ */
+import type { FinalizedSnapshot } from "./types.js";
+
+/**
+ * The chain's own `Status`, kept alongside {@link AirdropPhase} because the
+ * collapse is lossy: a product renders one spinner for `AwaitingEntropy` and
+ * `DrawWinners`, but someone debugging a stalled draw needs to know which.
+ */
+export type AirdropStatusTag =
+    | "Scheduled"
+    | "Registering"
+    | "AwaitingEntropy"
+    | "DrawWinners"
+    | "Claiming"
+    | "ClearingRegistrations"
+    | "ClearingWinners"
+    | "Finalizing";
+
+/**
+ * The phase a product renders. `Gone` is not a chain status but the row's absence
+ * — the steady state for every past draw. It is **not** proof a draw happened: an id
+ * that was never scheduled answers identically, and the chain cannot tell them
+ * apart.
+ */
+export type AirdropPhase =
+    /** `Scheduled` — announced, registration not open yet. */
+    | "Upcoming"
+    /** `Registering` — entries are being taken until `drawTime`. */
+    | "Registering"
+    /** `AwaitingEntropy` or `DrawWinners` — closed, winners not final yet. */
+    | "Drawing"
+    /** `Claiming` — winners are settled and claims are open until `endTime`. */
+    | "Claiming"
+    /** Any of the three clean-up states: over, with nothing left to do. */
+    | "Settling"
+    /** No `Events` row at all — finalized and cleaned up, or never scheduled. */
+    | "Gone";
+
+/**
+ * The prize asset, as an XCM location. Opaque on purpose — this package does not
+ * model XCM; it is the key an `Assets.Metadata` read takes.
+ */
+export interface AirdropAssetId {
+    parents: number;
+    interior: unknown;
+}
+
+/** The prize a draw pays out, from `AirdropPrize` on chain. */
+export interface AirdropPrize {
+    /**
+     * **Not the chain's native token.** Prizes are paid in a foreign asset, so
+     * formatting `assetAmount` with the chain's `tokenDecimals` is wrong. Read
+     * `Assets.Metadata` for this id and use its `decimals`.
+     */
+    assetId: AirdropAssetId;
+    /** Total amount paid across all winners, in the prize asset's smallest unit. */
+    assetAmount: bigint;
+    /** Hard cap on winners, whatever the participant count. */
+    maxWinners: number;
+    /**
+     * The share of participants that may win, as a **Permill** — parts per
+     * million, not a count and not a percentage. `10_000` is one percent.
+     * Named for the unit because rendering it as a count is the mistake the
+     * plain chain name (`winner_cap`) invites.
+     */
+    winnerCapPermill: number;
+}
+
+/**
+ * The counters are `null` where the `Status` variant does not carry them — **not
+ * zero**: a `Finalizing` draw did have participants, the chain stopped reporting it.
+ *
+ * | Field | Absent in |
+ * |---|---|
+ * | `totalParticipants` | `Scheduled`, `Finalizing` |
+ * | `effectiveWinners` | `Scheduled`, `Registering` |
+ * | `claimed` | `Scheduled`, `Registering`, `AwaitingEntropy`, `DrawWinners` |
+ */
+export interface AirdropEvent {
+    /** The 32-byte event id, `0x`-prefixed, as the draw is addressed by. */
+    eventId: string;
+    status: AirdropStatusTag;
+    phase: AirdropPhase;
+    prize: AirdropPrize;
+    /**
+     * Unix timestamp in **seconds**, when registration opens.
+     *
+     * All three timestamps are `u64` seconds on chain, not block numbers and
+     * not milliseconds. Multiply by 1000 before handing one to `Date`.
+     */
+    registrationStarts: number;
+    /** Unix seconds: registration closes and the draw is performed. */
+    drawTime: number;
+    /** Unix seconds: claiming closes and clean-up starts. */
+    endTime: number;
+    totalParticipants: number | null;
+    effectiveWinners: number | null;
+    claimed: number | null;
+    /**
+     * The account funding this event, for source-funded draws. `null` for
+     * pre-funded ones, whose released funds stay in the pallet's pot.
+     */
+    source: string | null;
+}
+
+/**
+ * Which identity entered a draw. Not the player's choice on the game path: the
+ * chain picks `Alias` for a recognized person and `Account` for everyone else.
+ */
+export type AirdropRegistrant =
+    /** An SS58 account address. */
+    | { tag: "Account"; accountAddress: string }
+    /** A 32-byte contextual People alias, `0x`-prefixed. */
+    | { tag: "Alias"; alias: string };
+
+/**
+ * Whether a registrant won. `Unchecked` exists so "we did not ask" cannot be
+ * mistaken for "did not win" — a `false` there would be a claim the read never
+ * made.
+ */
+export type AirdropOutcome =
+    /** No registrant was supplied, so no winner lookup happened. */
+    | { tag: "Unchecked" }
+    /**
+     * No winning entry. Before the draw that means "not drawn yet" and after it
+     * "did not win" — the same storage answer, so read {@link AirdropEvent.phase}
+     * to tell them apart.
+     */
+    | { tag: "NotWon" }
+    /** Won. `ticket` is the 32-byte entropy slot the win is recorded under. */
+    | { tag: "Won"; ticket: string };
+
+/**
+ * One draw at one pinned block. `event` is `null` exactly when `phase` is `"Gone"`,
+ * but the outcome survives that: `Winners` is cleared in its own lifecycle state,
+ * so a win can outlive the event row or be swept before it.
+ */
+export interface AirdropDraw {
+    /** The finalized block every read in this row was pinned to. */
+    at: FinalizedSnapshot;
+    eventId: string;
+    phase: AirdropPhase;
+    event: AirdropEvent | null;
+    outcome: AirdropOutcome;
+    /**
+     * The draw's entropy seed, present from `DrawWinners` onwards and `null`
+     * before it. Only useful for verifying a draw independently; a product
+     * rendering a result does not need it.
+     */
+    entropy: string | null;
+}

--- a/product-sdk/packages/individuality/src/airdrop-types.ts
+++ b/product-sdk/packages/individuality/src/airdrop-types.ts
@@ -128,9 +128,10 @@ export type AirdropOutcome =
     /** No registrant was supplied, so no winner lookup happened. */
     | { tag: "Unchecked" }
     /**
-     * No winning entry. Before the draw that means "not drawn yet" and after it
-     * "did not win" — the same storage answer, so read {@link AirdropEvent.phase}
-     * to tell them apart.
+     * No winning entry, which is **three** situations sharing one storage answer:
+     * not drawn yet, did not win, or won and already claimed — a successful claim
+     * removes the row. `phase` separates the first from the rest; only a kept
+     * ticket or the `PrizeClaimed` event separates the last two.
      */
     | { tag: "NotWon" }
     /** Won. `ticket` is the 32-byte entropy slot the win is recorded under. */

--- a/product-sdk/packages/individuality/src/claim-derive.ts
+++ b/product-sdk/packages/individuality/src/claim-derive.ts
@@ -36,21 +36,27 @@ export interface ClaimInputs {
 }
 
 /**
- * Recognition and `reachedPersonhood` are independent routes through this gate.
- * Testing the flag before the variant wrongly blocks an externally-recognized
- * player whose flag is unset.
+ * Recognition and `reachedPersonhood` are independent routes through this gate,
+ * mirroring the pallet: `claim_airdrop` admits `p.recognition.is_recognized() ||
+ * p.reached_personhood`. `is_recognized()` is false for `Suspended`, but the
+ * `reached_personhood` route still rescues a suspended player — so the combined
+ * check has to run *before* we single out `Suspended`, or we block a claimant
+ * the runtime would accept.
  */
 function personhoodBlocker(participant: PersonhoodParticipant | null): ClaimBlocker | null {
     if (participant === null) {
         return { tag: "NotAParticipant" };
     }
-    if (participant.recognition === "Suspended") {
-        return { tag: "Suspended" };
-    }
     const recognized =
         participant.recognition === "Recognized" ||
         participant.recognition === "ExternallyRecognized";
-    return recognized || participant.reachedPersonhood ? null : { tag: "NotRecognized" };
+    if (recognized || participant.reachedPersonhood) {
+        return null;
+    }
+    // Neither route passes: report the specific recognition state as the reason.
+    return participant.recognition === "Suspended"
+        ? { tag: "Suspended" }
+        : { tag: "NotRecognized" };
 }
 
 /** Decide whether one prize can be claimed. Never throws. */
@@ -206,17 +212,23 @@ if (import.meta.vitest) {
         });
 
         test("suspended is its own blocker, not NotRecognized", () => {
-            const result = check({ participant: participant({ recognition: "Suspended" }) });
+            // Isolate the Suspended tag: personhood is off, so neither route
+            // passes and the specific recognition state is the reported reason.
+            const result = check({
+                participant: participant({ recognition: "Suspended", reachedPersonhood: false }),
+            });
             expect(result.blockers).toEqual([{ tag: "Suspended" }]);
         });
 
-        test("suspended blocks even with the personhood flag set", () => {
-            // The runtime's `is_recognized()` is false for Suspended, and the
-            // `||` cannot rescue it, so neither can this.
+        test("personhood rescues a suspended player, matching the runtime's ||", () => {
+            // `is_recognized()` is false for Suspended, but `claim_airdrop` admits
+            // `is_recognized() || reached_personhood`, so the personhood route
+            // still clears the gate.
             const result = check({
                 participant: participant({ recognition: "Suspended", reachedPersonhood: true }),
             });
-            expect(result.claimable).toBe(false);
+            expect(result.claimable).toBe(true);
+            expect(result.blockers).toEqual([]);
         });
 
         test("neither recognized nor at personhood", () => {

--- a/product-sdk/packages/individuality/src/claim-derive.ts
+++ b/product-sdk/packages/individuality/src/claim-derive.ts
@@ -18,6 +18,16 @@ export interface ClaimInputs {
     /** `null` when `Score.Participants` holds no record for the claimant. */
     participant: PersonhoodParticipant | null;
     /**
+     * Whether the prize asset is still enabled for airdrops, from
+     * `Airdrop.SupportedAssets`. `false` blocks the claim on chain, so leaving it
+     * out would let a `claimable: true` cost the player a fee.
+     *
+     * `null` means nothing to check: the draw's event row is gone and carries no
+     * asset id. Not the same as disabled, and reporting it as such would name a
+     * cause that is not true on top of the `DrawNotClaiming` that already fires.
+     */
+    prizeAssetEnabled: boolean | null;
+    /**
      * Unix **seconds**, against the draw's `end_time`. An input rather than the
      * clock so a caller can pass the block's own time: a device clock minutes fast
      * will call a live window closed.
@@ -57,7 +67,7 @@ export function deriveClaimEligibility(inputs: ClaimInputs): ClaimEligibility {
     // repeating it as an attendance failure would double-count one cause.
     if (participant !== null && participant.lastAttendedGame !== gameIndex) {
         blockers.push({
-            tag: "AttendedALaterGame",
+            tag: "DidNotAttendThisGame",
             lastAttendedGame: participant.lastAttendedGame,
         });
     }
@@ -71,6 +81,12 @@ export function deriveClaimEligibility(inputs: ClaimInputs): ClaimEligibility {
     // covers that, so the window is only checkable when there is an event.
     if (draw.event !== null && now >= draw.event.endTime) {
         blockers.push({ tag: "ClaimWindowClosed", endTime: draw.event.endTime });
+    }
+
+    // Only an explicit `false` blocks. `null` is "not checkable", which
+    // `DrawNotClaiming` already covers.
+    if (inputs.prizeAssetEnabled === false) {
+        blockers.push({ tag: "PrizeAssetDisabled" });
     }
 
     if (draw.outcome.tag === "Unchecked") {
@@ -138,6 +154,7 @@ if (import.meta.vitest) {
             gameIndex: 41,
             draw: draw(),
             participant: participant(),
+            prizeAssetEnabled: true,
             now: NOW,
             ...overrides,
         });
@@ -216,20 +233,24 @@ if (import.meta.vitest) {
     describe("the attendance gate", () => {
         test("a later game closed the claim", () => {
             const result = check({ participant: participant({ lastAttendedGame: 42 }) });
-            expect(result.blockers).toEqual([{ tag: "AttendedALaterGame", lastAttendedGame: 42 }]);
+            expect(result.blockers).toEqual([
+                { tag: "DidNotAttendThisGame", lastAttendedGame: 42 },
+            ]);
         });
 
         test("an earlier game also fails, because the chain compares for equality", () => {
             // Not a "too old" check: the runtime tests `==`, so any mismatch
             // fails in either direction.
             const result = check({ participant: participant({ lastAttendedGame: 40 }) });
-            expect(result.blockers).toEqual([{ tag: "AttendedALaterGame", lastAttendedGame: 40 }]);
+            expect(result.blockers).toEqual([
+                { tag: "DidNotAttendThisGame", lastAttendedGame: 40 },
+            ]);
         });
 
         test("never having attended fails too", () => {
             const result = check({ participant: participant({ lastAttendedGame: null }) });
             expect(result.blockers).toEqual([
-                { tag: "AttendedALaterGame", lastAttendedGame: null },
+                { tag: "DidNotAttendThisGame", lastAttendedGame: null },
             ]);
         });
     });
@@ -276,6 +297,28 @@ if (import.meta.vitest) {
         });
     });
 
+    describe("the prize-asset gate", () => {
+        test("a disabled prize asset blocks the claim", () => {
+            // Blocks locally because a refused claim pays a fee.
+            const result = check({ prizeAssetEnabled: false });
+            expect(result.claimable).toBe(false);
+            expect(result.blockers).toEqual([{ tag: "PrizeAssetDisabled" }]);
+        });
+
+        test("an enabled asset adds no blocker", () => {
+            expect(check({ prizeAssetEnabled: true }).claimable).toBe(true);
+        });
+
+        test("nothing to check is not the same as disabled", () => {
+            // A gone draw carries no asset id, so the gate is not applicable.
+            const result = check({
+                draw: draw({ phase: "Gone", event: null }),
+                prizeAssetEnabled: null,
+            });
+            expect(result.blockers.map((b) => b.tag)).toEqual(["DrawNotClaiming"]);
+        });
+    });
+
     describe("several blockers at once", () => {
         test("collects every independent cause", () => {
             const result = check({
@@ -288,8 +331,8 @@ if (import.meta.vitest) {
                 now: END + 1,
             });
             expect(result.blockers.map((b) => b.tag).sort()).toEqual([
-                "AttendedALaterGame",
                 "ClaimWindowClosed",
+                "DidNotAttendThisGame",
                 "DrawNotClaiming",
                 "NoPrize",
                 "NotRecognized",

--- a/product-sdk/packages/individuality/src/claim-derive.ts
+++ b/product-sdk/packages/individuality/src/claim-derive.ts
@@ -1,0 +1,303 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The claim predicate, pure, so a caller already holding a draw and a participant
+ * need not re-fetch them. Also the one place the `last_attended_game` comparison
+ * lives, which matters because the runtime may relax it.
+ */
+import type { AirdropDraw } from "./airdrop-types.js";
+import type { ClaimBlocker, ClaimEligibility, ClaimWindow } from "./claim-types.js";
+import type { PersonhoodParticipant } from "./types.js";
+
+/** Everything the predicate needs, all from one pinned block. */
+export interface ClaimInputs {
+    /** The game the prize belongs to, which the chain compares attendance against. */
+    gameIndex: number;
+    /** The draw, as `readAirdropDraw` or `readPrizeStatus` returned it. */
+    draw: AirdropDraw;
+    /** `null` when `Score.Participants` holds no record for the claimant. */
+    participant: PersonhoodParticipant | null;
+    /**
+     * Unix **seconds**, against the draw's `end_time`. An input rather than the
+     * clock so a caller can pass the block's own time: a device clock minutes fast
+     * will call a live window closed.
+     */
+    now: number;
+}
+
+/**
+ * Recognition and `reachedPersonhood` are independent routes through this gate.
+ * Testing the flag before the variant wrongly blocks an externally-recognized
+ * player whose flag is unset.
+ */
+function personhoodBlocker(participant: PersonhoodParticipant | null): ClaimBlocker | null {
+    if (participant === null) {
+        return { tag: "NotAParticipant" };
+    }
+    if (participant.recognition === "Suspended") {
+        return { tag: "Suspended" };
+    }
+    const recognized =
+        participant.recognition === "Recognized" ||
+        participant.recognition === "ExternallyRecognized";
+    return recognized || participant.reachedPersonhood ? null : { tag: "NotRecognized" };
+}
+
+/** Decide whether one prize can be claimed. Never throws. */
+export function deriveClaimEligibility(inputs: ClaimInputs): ClaimEligibility {
+    const { gameIndex, draw, participant, now } = inputs;
+    const blockers: ClaimBlocker[] = [];
+
+    const personhood = personhoodBlocker(participant);
+    if (personhood !== null) {
+        blockers.push(personhood);
+    }
+
+    // The attendance gate. A `null` record already produced NotAParticipant, and
+    // repeating it as an attendance failure would double-count one cause.
+    if (participant !== null && participant.lastAttendedGame !== gameIndex) {
+        blockers.push({
+            tag: "AttendedALaterGame",
+            lastAttendedGame: participant.lastAttendedGame,
+        });
+    }
+
+    // Only `Claiming` takes claims. Every other phase, including `Gone`, fails.
+    if (draw.phase !== "Claiming") {
+        blockers.push({ tag: "DrawNotClaiming", phase: draw.phase });
+    }
+
+    // `event` is null exactly when the row is gone, and DrawNotClaiming already
+    // covers that, so the window is only checkable when there is an event.
+    if (draw.event !== null && now >= draw.event.endTime) {
+        blockers.push({ tag: "ClaimWindowClosed", endTime: draw.event.endTime });
+    }
+
+    if (draw.outcome.tag === "Unchecked") {
+        blockers.push({ tag: "OutcomeUnchecked" });
+    } else if (draw.outcome.tag === "NotWon") {
+        blockers.push({ tag: "NoPrize" });
+    }
+
+    const ticket = draw.outcome.tag === "Won" ? draw.outcome.ticket : null;
+    const window: ClaimWindow | null =
+        draw.event === null ? null : { endTime: draw.event.endTime, closesOnNextAttendance: true };
+
+    return { claimable: blockers.length === 0, blockers, ticket, window };
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test } = import.meta.vitest;
+
+    const EVENT_ID = `0x${"11".repeat(32)}`;
+    const TICKET = `0x${"ee".repeat(32)}`;
+    const END = 1_800_000_000;
+    const NOW = END - 3_600;
+
+    const participant = (
+        overrides: Partial<PersonhoodParticipant> = {},
+    ): PersonhoodParticipant => ({
+        score: 10,
+        streak: { tag: "Attended", count: 3 },
+        attendanceHistory: 0xff,
+        reachedPersonhood: true,
+        recognition: "Recognized",
+        lastAttendedGame: 41,
+        ...overrides,
+    });
+
+    const draw = (overrides: Partial<AirdropDraw> = {}): AirdropDraw => ({
+        at: { blockHash: `0x${"22".repeat(32)}`, blockNumber: 1 },
+        eventId: EVENT_ID,
+        phase: "Claiming",
+        event: {
+            eventId: EVENT_ID,
+            status: "Claiming",
+            phase: "Claiming",
+            prize: {
+                assetId: { parents: 1, interior: { type: "Here", value: undefined } },
+                assetAmount: 100n,
+                maxWinners: 5,
+                winnerCapPermill: 10_000,
+            },
+            registrationStarts: END - 86_400,
+            drawTime: END - 7_200,
+            endTime: END,
+            totalParticipants: 9,
+            effectiveWinners: 2,
+            claimed: 0,
+            source: null,
+        },
+        outcome: { tag: "Won", ticket: TICKET },
+        entropy: null,
+        ...overrides,
+    });
+
+    const check = (overrides: Partial<ClaimInputs> = {}) =>
+        deriveClaimEligibility({
+            gameIndex: 41,
+            draw: draw(),
+            participant: participant(),
+            now: NOW,
+            ...overrides,
+        });
+
+    describe("the claimable case", () => {
+        test("a recognized winner inside the window can claim", () => {
+            const result = check();
+            expect(result.claimable).toBe(true);
+            expect(result.blockers).toEqual([]);
+            expect(result.ticket).toBe(TICKET);
+        });
+
+        test("personhood alone clears the first gate without recognition", () => {
+            // The two routes are independent: `reached_personhood` passes on its
+            // own, which is what the runtime's `||` says.
+            const result = check({
+                participant: participant({ recognition: "NotRecognized", reachedPersonhood: true }),
+            });
+            expect(result.claimable).toBe(true);
+        });
+
+        test("external recognition passes even with the personhood flag unset", () => {
+            // Testing the flag before the variant gets this wrong, and it is the
+            // one combination where the order of the two checks is observable.
+            const result = check({
+                participant: participant({
+                    recognition: "ExternallyRecognized",
+                    reachedPersonhood: false,
+                }),
+            });
+            expect(result.claimable).toBe(true);
+        });
+
+        test("reports the window, including that playing again ends it", () => {
+            expect(check().window).toEqual({ endTime: END, closesOnNextAttendance: true });
+        });
+    });
+
+    describe("the personhood gate", () => {
+        test("no participant record", () => {
+            const result = check({ participant: null });
+            expect(result.claimable).toBe(false);
+            expect(result.blockers).toEqual([{ tag: "NotAParticipant" }]);
+        });
+
+        test("a missing record is not also reported as an attendance failure", () => {
+            // One cause, one blocker. Listing both would send a UI two ways.
+            expect(check({ participant: null }).blockers).toHaveLength(1);
+        });
+
+        test("suspended is its own blocker, not NotRecognized", () => {
+            const result = check({ participant: participant({ recognition: "Suspended" }) });
+            expect(result.blockers).toEqual([{ tag: "Suspended" }]);
+        });
+
+        test("suspended blocks even with the personhood flag set", () => {
+            // The runtime's `is_recognized()` is false for Suspended, and the
+            // `||` cannot rescue it, so neither can this.
+            const result = check({
+                participant: participant({ recognition: "Suspended", reachedPersonhood: true }),
+            });
+            expect(result.claimable).toBe(false);
+        });
+
+        test("neither recognized nor at personhood", () => {
+            const result = check({
+                participant: participant({
+                    recognition: "NotRecognized",
+                    reachedPersonhood: false,
+                }),
+            });
+            expect(result.blockers).toEqual([{ tag: "NotRecognized" }]);
+        });
+    });
+
+    describe("the attendance gate", () => {
+        test("a later game closed the claim", () => {
+            const result = check({ participant: participant({ lastAttendedGame: 42 }) });
+            expect(result.blockers).toEqual([{ tag: "AttendedALaterGame", lastAttendedGame: 42 }]);
+        });
+
+        test("an earlier game also fails, because the chain compares for equality", () => {
+            // Not a "too old" check: the runtime tests `==`, so any mismatch
+            // fails in either direction.
+            const result = check({ participant: participant({ lastAttendedGame: 40 }) });
+            expect(result.blockers).toEqual([{ tag: "AttendedALaterGame", lastAttendedGame: 40 }]);
+        });
+
+        test("never having attended fails too", () => {
+            const result = check({ participant: participant({ lastAttendedGame: null }) });
+            expect(result.blockers).toEqual([
+                { tag: "AttendedALaterGame", lastAttendedGame: null },
+            ]);
+        });
+    });
+
+    describe("the draw gates", () => {
+        test.each(["Upcoming", "Registering", "Drawing", "Settling", "Gone"] as const)(
+            "phase %s does not take claims",
+            (phase) => {
+                const result = check({ draw: draw({ phase }) });
+                expect(result.blockers).toContainEqual({ tag: "DrawNotClaiming", phase });
+            },
+        );
+
+        test("a gone draw reports the phase but no window", () => {
+            const result = check({ draw: draw({ phase: "Gone", event: null }) });
+            expect(result.window).toBeNull();
+            expect(result.blockers).toContainEqual({ tag: "DrawNotClaiming", phase: "Gone" });
+            // And no ClaimWindowClosed: with no event there is no end_time to be
+            // past, and inventing one would double-report the same cause.
+            expect(result.blockers.some((b) => b.tag === "ClaimWindowClosed")).toBe(false);
+        });
+
+        test("past end_time closes the window", () => {
+            const result = check({ now: END });
+            expect(result.blockers).toContainEqual({ tag: "ClaimWindowClosed", endTime: END });
+        });
+
+        test("the boundary is exclusive, matching the chain's `<`", () => {
+            expect(check({ now: END - 1 }).claimable).toBe(true);
+            expect(check({ now: END }).claimable).toBe(false);
+        });
+
+        test("no winning entry", () => {
+            const result = check({ draw: draw({ outcome: { tag: "NotWon" } }) });
+            expect(result.blockers).toEqual([{ tag: "NoPrize" }]);
+            expect(result.ticket).toBeNull();
+        });
+
+        test("an unchecked draw is its own blocker, not NoPrize", () => {
+            // The read never asked, so claiming that there is no prize would be a
+            // claim it never made.
+            const result = check({ draw: draw({ outcome: { tag: "Unchecked" } }) });
+            expect(result.blockers).toEqual([{ tag: "OutcomeUnchecked" }]);
+        });
+    });
+
+    describe("several blockers at once", () => {
+        test("collects every independent cause", () => {
+            const result = check({
+                participant: participant({
+                    recognition: "NotRecognized",
+                    reachedPersonhood: false,
+                    lastAttendedGame: 42,
+                }),
+                draw: draw({ phase: "Settling", outcome: { tag: "NotWon" } }),
+                now: END + 1,
+            });
+            expect(result.blockers.map((b) => b.tag).sort()).toEqual([
+                "AttendedALaterGame",
+                "ClaimWindowClosed",
+                "DrawNotClaiming",
+                "NoPrize",
+                "NotRecognized",
+            ]);
+        });
+
+        test("claimable is false whenever anything blocks", () => {
+            expect(check({ now: END }).claimable).toBe(false);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/claim-types.ts
+++ b/product-sdk/packages/individuality/src/claim-types.ts
@@ -1,8 +1,10 @@
 // Copyright 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * `Game.claim_airdrop` has **five** gates and only two are about personhood, so a
- * caller checking recognition alone still gets errors it cannot explain.
+ * `Game.claim_airdrop` has **six** gates and only two are about personhood, so a
+ * caller checking recognition alone still gets errors it cannot explain. A refused
+ * claim pays a fee, since `Pays::No` applies only on success, so every gate that
+ * can be read is read.
  *
  * | Gate | On-chain error |
  * |---|---|
@@ -10,6 +12,7 @@
  * | `last_attended_game == game_index` | `Game.NotEligibleForAirdrop` |
  * | the draw's status is `Claiming` | `Airdrop.NotClaiming` |
  * | now is before the draw's `end_time` | `Airdrop.ClaimingWindowClosed` |
+ * | the prize asset is still enabled | `Airdrop.AssetNotEnabled` |
  * | a `Winners` entry for this identity | `Airdrop.NoSuchWinner` |
  */
 import type { AirdropPhase } from "./airdrop-types.js";
@@ -29,11 +32,12 @@ export type ClaimBlocker =
     /** Recognition is `Suspended` — distinct from never having had it. */
     | { tag: "Suspended" }
     /**
-     * The player attended a game after this one, which **overwrote**
-     * `last_attended_game` and closed this claim for good. Not a timing problem:
-     * playing again is what ended it.
+     * `last_attended_game` is not this game, so the chain's equality check fails.
+     * Covers three situations: the player never attended it, attended an earlier
+     * one, or has since played again, which overwrites the field and closes the
+     * claim for good. Compare `lastAttendedGame` to the game index to tell which.
      */
-    | { tag: "AttendedALaterGame"; lastAttendedGame: number | null }
+    | { tag: "DidNotAttendThisGame"; lastAttendedGame: number | null }
     /**
      * The draw is not taking claims. Before `Claiming` the winners are not
      * settled; after it the window has closed and the prize is being released.
@@ -41,6 +45,11 @@ export type ClaimBlocker =
     | { tag: "DrawNotClaiming"; phase: AirdropPhase }
     /** Past the draw's `end_time`. The chain checks this itself, late OCW or not. */
     | { tag: "ClaimWindowClosed"; endTime: number }
+    /**
+     * The prize asset was disabled for airdrops, so the payout cannot be
+     * released. Nothing the player can do about it.
+     */
+    | { tag: "PrizeAssetDisabled" }
     /**
      * No winning entry — which includes "already claimed", since claiming removes
      * the row. See {@link AirdropOutcome} for why storage cannot separate the two.
@@ -76,7 +85,12 @@ export interface ClaimEligibility {
      * removed the `Winners` row.
      */
     ticket: string | null;
-    /** `null` when there is nothing claimable to bound. */
+    /**
+     * The draw's deadlines whenever the draw exists, independent of whether this
+     * caller can claim, so a product can show the window to someone who did not
+     * win. `null` only when the event row is gone. Read `claimable` for whether
+     * there is anything to do before it.
+     */
     window: ClaimWindow | null;
 }
 

--- a/product-sdk/packages/individuality/src/claim-types.ts
+++ b/product-sdk/packages/individuality/src/claim-types.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * `Game.claim_airdrop` has **five** gates and only two are about personhood, so a
+ * caller checking recognition alone still gets errors it cannot explain.
+ *
+ * | Gate | On-chain error |
+ * |---|---|
+ * | recognized, or reached personhood | `Game.NotEligibleForAirdrop` |
+ * | `last_attended_game == game_index` | `Game.NotEligibleForAirdrop` |
+ * | the draw's status is `Claiming` | `Airdrop.NotClaiming` |
+ * | now is before the draw's `end_time` | `Airdrop.ClaimingWindowClosed` |
+ * | a `Winners` entry for this identity | `Airdrop.NoSuchWinner` |
+ */
+import type { AirdropPhase } from "./airdrop-types.js";
+import type { FinalizedSnapshot } from "./types.js";
+
+/**
+ * Why a prize cannot be claimed. Several can hold at once, so
+ * {@link ClaimEligibility} carries a list rather than the first one found — a UI
+ * that says "not recognized" while the window has also closed sends the player
+ * to fix the wrong thing.
+ */
+export type ClaimBlocker =
+    /** No `Score.Participants` record at all. */
+    | { tag: "NotAParticipant" }
+    /** Neither recognized nor over the personhood threshold. */
+    | { tag: "NotRecognized" }
+    /** Recognition is `Suspended` — distinct from never having had it. */
+    | { tag: "Suspended" }
+    /**
+     * The player attended a game after this one, which **overwrote**
+     * `last_attended_game` and closed this claim for good. Not a timing problem:
+     * playing again is what ended it.
+     */
+    | { tag: "AttendedALaterGame"; lastAttendedGame: number | null }
+    /**
+     * The draw is not taking claims. Before `Claiming` the winners are not
+     * settled; after it the window has closed and the prize is being released.
+     */
+    | { tag: "DrawNotClaiming"; phase: AirdropPhase }
+    /** Past the draw's `end_time`. The chain checks this itself, late OCW or not. */
+    | { tag: "ClaimWindowClosed"; endTime: number }
+    /**
+     * No winning entry — which includes "already claimed", since claiming removes
+     * the row. See {@link AirdropOutcome} for why storage cannot separate the two.
+     */
+    | { tag: "NoPrize" }
+    /** The draw was read without a registrant, so winning was never checked. */
+    | { tag: "OutcomeUnchecked" };
+
+/**
+ * When a claim stops being possible. Two deadlines apply and only one is a clock —
+ * the other has no timestamp at all.
+ */
+export interface ClaimWindow {
+    /** Unix seconds. The draw's `end_time`. */
+    endTime: number;
+    /**
+     * Always `true` on the game path, and the reason a countdown alone misleads:
+     * attending the next game moves `last_attended_game` and closes the claim,
+     * usually well before `endTime`. The runtime contemplates relaxing `==` to
+     * `>=`, which would make this `false`.
+     */
+    closesOnNextAttendance: boolean;
+}
+
+/** Whether a specific prize can be claimed, and what stops it if not. */
+export interface ClaimEligibility {
+    claimable: boolean;
+    /** Empty exactly when `claimable` is true. */
+    blockers: ClaimBlocker[];
+    /**
+     * The winning ticket, when there is one. Worth keeping: it is the only local
+     * evidence that distinguishes "claimed" from "never won" once the chain has
+     * removed the `Winners` row.
+     */
+    ticket: string | null;
+    /** `null` when there is nothing claimable to bound. */
+    window: ClaimWindow | null;
+}
+
+/** The result of checking a claim against the chain. */
+export interface ClaimEligibilityResult extends ClaimEligibility {
+    at: FinalizedSnapshot;
+    gameIndex: number;
+    airdropIndex: number;
+    eventId: string;
+}
+
+/**
+ * Whether a submitted claim reached the chain, re-read rather than watched. A
+ * successful claim removes the `Winners` row, so the absence of a ticket that was
+ * there before **is** the confirmation — recoverable after a reload, which a
+ * subscription is not.
+ */
+export type ClaimOutcome =
+    /** The ticket is gone: the claim landed. */
+    | { tag: "Claimed"; at: FinalizedSnapshot }
+    /** The ticket is still there, so the claim has not taken effect yet. */
+    | { tag: "Pending"; at: FinalizedSnapshot; ticket: string }
+    /**
+     * The ticket is gone but the draw has also left `Claiming`, so the row could
+     * have been swept by the lifecycle rather than by a claim. Indistinguishable
+     * from here — the `PrizeClaimed` event log is the only way to be sure.
+     */
+    | { tag: "Unknown"; at: FinalizedSnapshot; phase: AirdropPhase };

--- a/product-sdk/packages/individuality/src/claim.ts
+++ b/product-sdk/packages/individuality/src/claim.ts
@@ -20,12 +20,11 @@
  * evidence separating "claimed" from "never won" ({@link confirmClaim}).
  */
 import { err, normalizeError, ok, type Result } from "@parity/result";
-import { runDrawRead, type AirdropChain } from "./airdrop-read.js";
-import { gameAirdropEventId } from "./airdrop-ids.js";
+import { readAirdropEventId, runDrawRead, type AirdropChain } from "./airdrop-read.js";
 import type { AirdropRegistrant } from "./airdrop-types.js";
 import { deriveClaimEligibility } from "./claim-derive.js";
 import type { ClaimEligibilityResult, ClaimOutcome } from "./claim-types.js";
-import { toRawRegistrationEntry } from "./airdrop-decode.js";
+import { airdropPhase, statusTag, toRawRegistrationEntry } from "./airdrop-decode.js";
 import { toPersonhoodParticipant, type RawParticipant } from "./decode.js";
 import { ProductIndividualityError } from "./errors.js";
 import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
@@ -35,7 +34,7 @@ import type { PersonhoodParticipant } from "./types.js";
  * The `Game.claim_airdrop` call, plus the `Score.Participants` read the check
  * needs. Composed with `AirdropChain`, which supplies the draw.
  */
-export interface ClaimChain extends PinnedChain {
+export interface ClaimChain<Tx = unknown> extends PinnedChain {
     individuality: {
         constants: { Game: { airdrop_event_id_base(): Promise<string> } };
         query: {
@@ -54,7 +53,7 @@ export interface ClaimChain extends PinnedChain {
                     game_index: number;
                     airdrop_index: number;
                     beneficiary: string;
-                }): unknown;
+                }): Tx;
             };
         };
     };
@@ -90,9 +89,9 @@ function participantKey(registrant: AirdropRegistrant): { type: string; value: u
 }
 
 /**
- * Check whether one prize can be claimed, from one pinned finalized block — the
- * five gates span the draw and the score record, so reading them apart is exactly
- * the inconsistency pinning prevents.
+ * Check whether one prize can be claimed, from one pinned finalized block. The six
+ * gates span the draw, the score record and the asset list, so reading them apart
+ * is exactly the inconsistency pinning prevents.
  */
 export async function readClaimEligibility(
     chain: AirdropChain & ClaimChain,
@@ -103,8 +102,7 @@ export async function readClaimEligibility(
         const snapshot = await pinBlock(chain, signal);
         const at = readAt(snapshot, signal);
 
-        const base = await chain.individuality.constants.Game.airdrop_event_id_base();
-        const eventId = gameAirdropEventId({ base, gameIndex, airdropIndex });
+        const eventId = await readAirdropEventId(chain, { gameIndex, airdropIndex });
 
         const [draw, rawParticipant] = await Promise.all([
             runDrawRead(chain, { eventId, registrant, signal }, snapshot),
@@ -113,6 +111,16 @@ export async function readClaimEligibility(
 
         const participant: PersonhoodParticipant | null =
             rawParticipant === undefined ? null : toPersonhoodParticipant(rawParticipant);
+
+        // The sixth gate. Sequential because the asset id comes out of the draw,
+        // so it cannot join the batch above.
+        const prizeAssetEnabled =
+            draw.event === null
+                ? null
+                : (await chain.individuality.query.Airdrop.SupportedAssets.getValue(
+                      draw.event.prize.assetId,
+                      at,
+                  )) !== undefined;
 
         return ok({
             at: snapshot,
@@ -123,6 +131,7 @@ export async function readClaimEligibility(
                 gameIndex,
                 draw,
                 participant,
+                prizeAssetEnabled,
                 // Seconds, not milliseconds: every timestamp on these two pallets
                 // is a Unix second.
                 now: options.now ?? Math.floor(Date.now() / 1000),
@@ -140,15 +149,15 @@ export async function readClaimEligibility(
  * @param options.beneficiary - need not be the claimant; the chain takes any
  *   account, which is what gives an alias claimant somewhere to be paid.
  */
-export function claimPrizeTx<T = unknown>(
-    chain: ClaimChain,
+export function claimPrizeTx<Tx>(
+    chain: ClaimChain<Tx>,
     options: { gameIndex: number; airdropIndex: number; beneficiary: string },
-): T {
+): Tx {
     return chain.individuality.tx.Game.claim_airdrop({
         game_index: options.gameIndex,
         airdrop_index: options.airdropIndex,
         beneficiary: options.beneficiary,
-    }) as T;
+    });
 }
 
 /** Options for {@link confirmClaim}. */
@@ -170,8 +179,7 @@ export async function confirmClaim(
         const snapshot = await pinBlock(chain, signal);
         const at = readAt(snapshot, signal);
 
-        const base = await chain.individuality.constants.Game.airdrop_event_id_base();
-        const eventId = gameAirdropEventId({ base, gameIndex, airdropIndex });
+        const eventId = await readAirdropEventId(chain, { gameIndex, airdropIndex });
 
         const [ticket, rawEvent] = await Promise.all([
             chain.individuality.query.Airdrop.Winners.getValue(
@@ -186,18 +194,19 @@ export async function confirmClaim(
             return ok({ tag: "Pending", at: snapshot, ticket });
         }
 
-        // No ticket. Only a draw still taking claims makes that unambiguous —
-        // `ClearingWinners` drains the same rows, and a finalized draw has none.
-        const phase = rawEvent?.status.type;
-        return ok(
-            phase === "Claiming"
-                ? { tag: "Claimed", at: snapshot }
-                : {
-                      tag: "Unknown",
-                      at: snapshot,
-                      phase: phase === undefined ? "Gone" : "Settling",
-                  },
-        );
+        // No ticket. Only a draw still taking claims makes that unambiguous:
+        // `ClearingWinners` drains the same rows and a finalized draw has none. The
+        // variant goes through `statusTag`, so an unrecognised one throws instead of
+        // being reported as some other phase.
+        const status = rawEvent === undefined ? null : statusTag(rawEvent.status.type);
+        if (status === "Claiming") {
+            return ok({ tag: "Claimed", at: snapshot });
+        }
+        return ok({
+            tag: "Unknown",
+            at: snapshot,
+            phase: status === null ? "Gone" : airdropPhase(status),
+        });
     } catch (cause) {
         return err(normalizeError(cause, ProductIndividualityError));
     }
@@ -233,6 +242,7 @@ if (import.meta.vitest) {
 
     interface FakeState {
         participant?: RawParticipant;
+        assetDisabled?: boolean;
         ticket?: string;
         status?: string;
         eventMissing?: boolean;
@@ -297,6 +307,9 @@ if (import.meta.vitest) {
                         },
                         EventEntropy: { getValue: async () => undefined },
                         Registrations: { getEntries: async () => [] },
+                        SupportedAssets: {
+                            getValue: async () => (state.assetDisabled ? undefined : 1n),
+                        },
                     },
                 },
                 tx: {
@@ -380,6 +393,38 @@ if (import.meta.vitest) {
             expect(result.blockers).toEqual([{ tag: "NotAParticipant" }]);
         });
 
+        test("a disabled prize asset blocks the claim", async () => {
+            const { chain } = fakeChain({
+                participant: rawParticipant(),
+                ticket: TICKET,
+                assetDisabled: true,
+            });
+            const result = unwrapOk(
+                await readClaimEligibility(chain, {
+                    gameIndex: 41,
+                    airdropIndex: 0,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                    now: END - 60,
+                }),
+            );
+            expect(result.claimable).toBe(false);
+            expect(result.blockers).toEqual([{ tag: "PrizeAssetDisabled" }]);
+        });
+
+        test("a gone draw is not reported as having a disabled asset", async () => {
+            // Not applicable rather than failed: see `ClaimInputs.prizeAssetEnabled`.
+            const { chain } = fakeChain({ participant: rawParticipant(), eventMissing: true });
+            const result = unwrapOk(
+                await readClaimEligibility(chain, {
+                    gameIndex: 41,
+                    airdropIndex: 0,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                    now: END - 60,
+                }),
+            );
+            expect(result.blockers.some((b) => b.tag === "PrizeAssetDisabled")).toBe(false);
+        });
+
         test("a claimed or unwon prize blocks with NoPrize", async () => {
             const { chain } = fakeChain({ participant: rawParticipant() });
             const result = unwrapOk(
@@ -443,15 +488,16 @@ if (import.meta.vitest) {
             });
         });
 
-        test("returns whatever the chain's tx builder returned", async () => {
+        test("returns whatever the chain's tx builder returned, typed", async () => {
+            // The transaction type comes from the chain, not from a type argument
+            // at the call site. That is what lets the result go straight into
+            // `submitAndWatch` without a cast.
             const { chain } = fakeChain({});
-            expect(
-                claimPrizeTx<{ call: string }>(chain, {
-                    gameIndex: 1,
-                    airdropIndex: 0,
-                    beneficiary: ALICE,
-                }).call,
-            ).toBe("Game.claim_airdrop");
+            const built: { call: string } = claimPrizeTx(
+                chain as unknown as ClaimChain<{ call: string }>,
+                { gameIndex: 1, airdropIndex: 0, beneficiary: ALICE },
+            );
+            expect(built.call).toBe("Game.claim_airdrop");
         });
     });
 
@@ -486,6 +532,26 @@ if (import.meta.vitest) {
                 at: expect.anything(),
                 phase: "Settling",
             });
+        });
+
+        test("reports the draw's real phase, not a two-value guess", async () => {
+            // A draw still assigning winners is `Drawing`. Collapsing every
+            // non-claiming status to `Settling` would say the window is over.
+            const { chain } = fakeChain({ status: "DrawWinners" });
+            const outcome = unwrapOk(await confirmClaim(chain, target));
+            expect(outcome).toEqual({
+                tag: "Unknown",
+                at: expect.anything(),
+                phase: "Drawing",
+            });
+        });
+
+        test("an unknown status variant fails rather than reporting a phase", async () => {
+            // Matches every other decode in the package: a state added by a
+            // runtime upgrade must not render as some existing phase.
+            const { chain } = fakeChain({ status: "Reconciling" });
+            const error = unwrapErr(await confirmClaim(chain, target));
+            expect(error).toBeInstanceOf(ProductIndividualityError);
         });
 
         test("a vanished event is Unknown with phase Gone", async () => {

--- a/product-sdk/packages/individuality/src/claim.ts
+++ b/product-sdk/packages/individuality/src/claim.ts
@@ -1,0 +1,506 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Claiming a prize: check it, build the call, confirm it landed.
+ *
+ * **Submission is not here.** `claimPrizeTx` returns a PAPI transaction, so
+ * signing and watching stay with `@parity/product-sdk-tx` — the same split
+ * `withAsPerson` uses, and retries, batching and fee estimation come free of it.
+ *
+ * ```ts
+ * const tx = claimPrizeTx(chain, { gameIndex, airdropIndex, beneficiary });
+ * await submitAndWatch(tx, signer, { waitFor: "finalized" });
+ * ```
+ *
+ * The call is identical under a person origin — `claim_airdrop` accepts both and
+ * derives the registration entry from whichever it got — so wrap the signer with
+ * `withAsPerson` and change nothing else.
+ *
+ * **Persist the ticket when you claim.** Once the row is gone it is the only local
+ * evidence separating "claimed" from "never won" ({@link confirmClaim}).
+ */
+import { err, normalizeError, ok, type Result } from "@parity/result";
+import { runDrawRead, type AirdropChain } from "./airdrop-read.js";
+import { gameAirdropEventId } from "./airdrop-ids.js";
+import type { AirdropRegistrant } from "./airdrop-types.js";
+import { deriveClaimEligibility } from "./claim-derive.js";
+import type { ClaimEligibilityResult, ClaimOutcome } from "./claim-types.js";
+import { toRawRegistrationEntry } from "./airdrop-decode.js";
+import { toPersonhoodParticipant, type RawParticipant } from "./decode.js";
+import { ProductIndividualityError } from "./errors.js";
+import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
+import type { PersonhoodParticipant } from "./types.js";
+
+/**
+ * The `Game.claim_airdrop` call, plus the `Score.Participants` read the check
+ * needs. Composed with `AirdropChain`, which supplies the draw.
+ */
+export interface ClaimChain extends PinnedChain {
+    individuality: {
+        constants: { Game: { airdrop_event_id_base(): Promise<string> } };
+        query: {
+            Score: {
+                Participants: {
+                    getValue(
+                        key: { type: string; value: unknown },
+                        options: ReadAt,
+                    ): Promise<RawParticipant | undefined>;
+                };
+            };
+        };
+        tx: {
+            Game: {
+                claim_airdrop(args: {
+                    game_index: number;
+                    airdrop_index: number;
+                    beneficiary: string;
+                }): unknown;
+            };
+        };
+    };
+}
+
+/** Everything a claim addresses. */
+export interface ClaimTarget {
+    gameIndex: number;
+    airdropIndex: number;
+    /**
+     * Who is claiming. Decides both the `Score.Participants` key and the
+     * `Winners` key, and must match the identity that entered the draw — a
+     * player who signed up with an alias cannot claim as an account.
+     */
+    registrant: AirdropRegistrant;
+}
+
+/** Options for {@link readClaimEligibility}. */
+export interface ReadClaimEligibilityOptions extends ClaimTarget {
+    /** Unix **seconds**; defaults to the device clock. See {@link ClaimInputs.now}. */
+    now?: number;
+    signal?: AbortSignal;
+}
+
+/** The `Score.Participants` key for a registrant. */
+function participantKey(registrant: AirdropRegistrant): { type: string; value: unknown } {
+    // `AccountOrPerson` names the account variant `Account` and the alias one
+    // `Person`, where `Airdrop`'s registration entry calls the second `Alias`.
+    // Same identity, two spellings, and the wrong one silently reads nothing.
+    return registrant.tag === "Account"
+        ? { type: "Account", value: registrant.accountAddress }
+        : { type: "Person", value: registrant.alias };
+}
+
+/**
+ * Check whether one prize can be claimed, from one pinned finalized block — the
+ * five gates span the draw and the score record, so reading them apart is exactly
+ * the inconsistency pinning prevents.
+ */
+export async function readClaimEligibility(
+    chain: AirdropChain & ClaimChain,
+    options: ReadClaimEligibilityOptions,
+): Promise<Result<ClaimEligibilityResult, ProductIndividualityError>> {
+    try {
+        const { gameIndex, airdropIndex, registrant, signal } = options;
+        const snapshot = await pinBlock(chain, signal);
+        const at = readAt(snapshot, signal);
+
+        const base = await chain.individuality.constants.Game.airdrop_event_id_base();
+        const eventId = gameAirdropEventId({ base, gameIndex, airdropIndex });
+
+        const [draw, rawParticipant] = await Promise.all([
+            runDrawRead(chain, { eventId, registrant, signal }, snapshot),
+            chain.individuality.query.Score.Participants.getValue(participantKey(registrant), at),
+        ]);
+
+        const participant: PersonhoodParticipant | null =
+            rawParticipant === undefined ? null : toPersonhoodParticipant(rawParticipant);
+
+        return ok({
+            at: snapshot,
+            gameIndex,
+            airdropIndex,
+            eventId,
+            ...deriveClaimEligibility({
+                gameIndex,
+                draw,
+                participant,
+                // Seconds, not milliseconds: every timestamp on these two pallets
+                // is a Unix second.
+                now: options.now ?? Math.floor(Date.now() / 1000),
+            }),
+        });
+    } catch (cause) {
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+/**
+ * Build the `Game.claim_airdrop` call, unsigned. `Pays::No` on success, so only a
+ * rejected claim costs a fee.
+ *
+ * @param options.beneficiary - need not be the claimant; the chain takes any
+ *   account, which is what gives an alias claimant somewhere to be paid.
+ */
+export function claimPrizeTx<T = unknown>(
+    chain: ClaimChain,
+    options: { gameIndex: number; airdropIndex: number; beneficiary: string },
+): T {
+    return chain.individuality.tx.Game.claim_airdrop({
+        game_index: options.gameIndex,
+        airdrop_index: options.airdropIndex,
+        beneficiary: options.beneficiary,
+    }) as T;
+}
+
+/** Options for {@link confirmClaim}. */
+export interface ConfirmClaimOptions extends ClaimTarget {
+    signal?: AbortSignal;
+}
+
+/**
+ * Did a submitted claim take effect? Re-reads the row rather than watching, so it
+ * answers after a reload. Absence means it landed — *unless* the draw has left
+ * `Claiming`, where the lifecycle may have swept the row instead.
+ */
+export async function confirmClaim(
+    chain: AirdropChain & ClaimChain,
+    options: ConfirmClaimOptions,
+): Promise<Result<ClaimOutcome, ProductIndividualityError>> {
+    try {
+        const { gameIndex, airdropIndex, registrant, signal } = options;
+        const snapshot = await pinBlock(chain, signal);
+        const at = readAt(snapshot, signal);
+
+        const base = await chain.individuality.constants.Game.airdrop_event_id_base();
+        const eventId = gameAirdropEventId({ base, gameIndex, airdropIndex });
+
+        const [ticket, rawEvent] = await Promise.all([
+            chain.individuality.query.Airdrop.Winners.getValue(
+                eventId,
+                toRawRegistrationEntry(registrant),
+                at,
+            ),
+            chain.individuality.query.Airdrop.Events.getValue(eventId, at),
+        ]);
+
+        if (ticket !== undefined) {
+            return ok({ tag: "Pending", at: snapshot, ticket });
+        }
+
+        // No ticket. Only a draw still taking claims makes that unambiguous —
+        // `ClearingWinners` drains the same rows, and a finalized draw has none.
+        const phase = rawEvent?.status.type;
+        return ok(
+            phase === "Claiming"
+                ? { tag: "Claimed", at: snapshot }
+                : {
+                      tag: "Unknown",
+                      at: snapshot,
+                      phase: phase === undefined ? "Gone" : "Settling",
+                  },
+        );
+    } catch (cause) {
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test } = import.meta.vitest;
+    const { unwrapOk, unwrapErr } = await import("@parity/result");
+    const { GAME_AIRDROP_EVENT_ID_BASE, gameAirdropEventId: eventIdOf } = await import(
+        "./airdrop-ids.js"
+    );
+
+    const BLOCK = { hash: `0x${"88".repeat(32)}`, number: 5_150 };
+    const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const ALIAS = `0x${"ab".repeat(32)}`;
+    const TICKET = `0x${"ee".repeat(32)}`;
+    const END = 1_800_000_000;
+    const EVENT_ID = eventIdOf({
+        base: GAME_AIRDROP_EVENT_ID_BASE,
+        gameIndex: 41,
+        airdropIndex: 0,
+    });
+
+    const rawParticipant = (overrides: Partial<RawParticipant> = {}): RawParticipant => ({
+        score: 10,
+        streak: { type: "Attended", value: 3 },
+        attendance_history: 0xff,
+        reached_personhood: true,
+        recognition: { type: "Recognized", value: 1n },
+        last_attended_game: 41,
+        ...overrides,
+    });
+
+    interface FakeState {
+        participant?: RawParticipant;
+        ticket?: string;
+        status?: string;
+        eventMissing?: boolean;
+    }
+
+    /** Records the keys every read was addressed with, and the built call. */
+    function fakeChain(state: FakeState) {
+        const keys: Array<{ entry: string; key: unknown }> = [];
+        let built: unknown = null;
+        const chain = {
+            individuality: {
+                constants: {
+                    Game: { airdrop_event_id_base: async () => GAME_AIRDROP_EVENT_ID_BASE },
+                },
+                query: {
+                    Score: {
+                        Participants: {
+                            getValue: async (key: unknown) => {
+                                keys.push({ entry: "Participants", key });
+                                return state.participant;
+                            },
+                        },
+                    },
+                    Airdrop: {
+                        Events: {
+                            getValue: async (id: string) => {
+                                keys.push({ entry: "Events", key: id });
+                                return state.eventMissing
+                                    ? undefined
+                                    : {
+                                          id,
+                                          info: {
+                                              prize: {
+                                                  asset_id: {
+                                                      parents: 1,
+                                                      interior: { type: "Here", value: undefined },
+                                                  },
+                                                  asset_amount: 100n,
+                                                  max_winners: 5,
+                                                  winner_cap: 10_000,
+                                              },
+                                              registration_starts: BigInt(END - 86_400),
+                                              draw_time: BigInt(END - 7_200),
+                                              end_time: BigInt(END),
+                                          },
+                                          status: {
+                                              type: state.status ?? "Claiming",
+                                              value: {
+                                                  total_participants: 9,
+                                                  effective_winners: 2,
+                                                  claimed: 0,
+                                              },
+                                          },
+                                      };
+                            },
+                        },
+                        Winners: {
+                            getValue: async (id: string, entry: unknown) => {
+                                keys.push({ entry: "Winners", key: [id, entry] });
+                                return state.ticket;
+                            },
+                        },
+                        EventEntropy: { getValue: async () => undefined },
+                        Registrations: { getEntries: async () => [] },
+                    },
+                },
+                tx: {
+                    Game: {
+                        claim_airdrop: (args: unknown) => {
+                            built = args;
+                            return { call: "Game.claim_airdrop", args };
+                        },
+                    },
+                },
+            },
+            raw: { individuality: { getFinalizedBlock: async () => BLOCK } },
+        } as unknown as AirdropChain & ClaimChain;
+        return { chain, keys: () => keys, built: () => built };
+    }
+
+    describe("readClaimEligibility", () => {
+        test("a recognized winner inside the window is claimable", async () => {
+            const { chain } = fakeChain({ participant: rawParticipant(), ticket: TICKET });
+            const result = unwrapOk(
+                await readClaimEligibility(chain, {
+                    gameIndex: 41,
+                    airdropIndex: 0,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                    now: END - 60,
+                }),
+            );
+
+            expect(result.claimable).toBe(true);
+            expect(result.ticket).toBe(TICKET);
+            expect(result.eventId).toBe(EVENT_ID);
+            expect(result.at).toEqual({ blockHash: BLOCK.hash, blockNumber: BLOCK.number });
+        });
+
+        test("keys the score read by Account for an account registrant", async () => {
+            const { chain, keys } = fakeChain({ participant: rawParticipant(), ticket: TICKET });
+            await readClaimEligibility(chain, {
+                gameIndex: 41,
+                airdropIndex: 0,
+                registrant: { tag: "Account", accountAddress: ALICE },
+                now: END - 60,
+            });
+            expect(keys().find((k) => k.entry === "Participants")?.key).toEqual({
+                type: "Account",
+                value: ALICE,
+            });
+        });
+
+        test("keys the score read by Person for an alias registrant", async () => {
+            // `AccountOrPerson` spells the alias variant `Person` while the
+            // airdrop entry spells it `Alias`. Reading with the wrong spelling
+            // finds nothing and looks like a missing record.
+            const { chain, keys } = fakeChain({ participant: rawParticipant(), ticket: TICKET });
+            await readClaimEligibility(chain, {
+                gameIndex: 41,
+                airdropIndex: 0,
+                registrant: { tag: "Alias", alias: ALIAS },
+                now: END - 60,
+            });
+            expect(keys().find((k) => k.entry === "Participants")?.key).toEqual({
+                type: "Person",
+                value: ALIAS,
+            });
+            expect(keys().find((k) => k.entry === "Winners")?.key).toEqual([
+                EVENT_ID,
+                { type: "Alias", value: { alias: ALIAS } },
+            ]);
+        });
+
+        test("no score record blocks the claim", async () => {
+            const { chain } = fakeChain({ ticket: TICKET });
+            const result = unwrapOk(
+                await readClaimEligibility(chain, {
+                    gameIndex: 41,
+                    airdropIndex: 0,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                    now: END - 60,
+                }),
+            );
+            expect(result.claimable).toBe(false);
+            expect(result.blockers).toEqual([{ tag: "NotAParticipant" }]);
+        });
+
+        test("a claimed or unwon prize blocks with NoPrize", async () => {
+            const { chain } = fakeChain({ participant: rawParticipant() });
+            const result = unwrapOk(
+                await readClaimEligibility(chain, {
+                    gameIndex: 41,
+                    airdropIndex: 0,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                    now: END - 60,
+                }),
+            );
+            expect(result.blockers).toEqual([{ tag: "NoPrize" }]);
+        });
+
+        test("defaults `now` to the device clock", async () => {
+            // The draw's end_time is in 2027, so the default must be treated as
+            // inside the window rather than ignored.
+            const { chain } = fakeChain({ participant: rawParticipant(), ticket: TICKET });
+            const result = unwrapOk(
+                await readClaimEligibility(chain, {
+                    gameIndex: 41,
+                    airdropIndex: 0,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(result.blockers.some((b) => b.tag === "ClaimWindowClosed")).toBe(false);
+        });
+
+        test("a transport failure arrives on the err channel", async () => {
+            const { chain } = fakeChain({});
+            const broken = {
+                ...chain,
+                raw: {
+                    individuality: {
+                        getFinalizedBlock: async () => {
+                            throw new Error("node down");
+                        },
+                    },
+                },
+            } as AirdropChain & ClaimChain;
+            const error = unwrapErr(
+                await readClaimEligibility(broken, {
+                    gameIndex: 41,
+                    airdropIndex: 0,
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+        });
+    });
+
+    describe("claimPrizeTx", () => {
+        test("builds the call with the chain's own argument names", async () => {
+            // snake_case, and the beneficiary is an SS58 string. PAPI encodes
+            // whatever it is given, so a renamed field would encode as undefined.
+            const { chain, built } = fakeChain({});
+            claimPrizeTx(chain, { gameIndex: 41, airdropIndex: 2, beneficiary: ALICE });
+            expect(built()).toEqual({
+                game_index: 41,
+                airdrop_index: 2,
+                beneficiary: ALICE,
+            });
+        });
+
+        test("returns whatever the chain's tx builder returned", async () => {
+            const { chain } = fakeChain({});
+            expect(
+                claimPrizeTx<{ call: string }>(chain, {
+                    gameIndex: 1,
+                    airdropIndex: 0,
+                    beneficiary: ALICE,
+                }).call,
+            ).toBe("Game.claim_airdrop");
+        });
+    });
+
+    describe("confirmClaim", () => {
+        const target = {
+            gameIndex: 41,
+            airdropIndex: 0,
+            registrant: { tag: "Account", accountAddress: ALICE },
+        } as const;
+
+        test("a ticket still present means the claim has not landed", async () => {
+            const { chain } = fakeChain({ ticket: TICKET });
+            const outcome = unwrapOk(await confirmClaim(chain, target));
+            expect(outcome).toEqual({ tag: "Pending", at: expect.anything(), ticket: TICKET });
+        });
+
+        test("the ticket gone while still Claiming means it landed", async () => {
+            // The whole resume story: a successful claim removes the row, so its
+            // absence is the confirmation.
+            const { chain } = fakeChain({});
+            const outcome = unwrapOk(await confirmClaim(chain, target));
+            expect(outcome.tag).toBe("Claimed");
+        });
+
+        test("the ticket gone after Claiming is Unknown, not Claimed", async () => {
+            // `ClearingWinners` drains the same rows, so absence no longer proves
+            // a claim.
+            const { chain } = fakeChain({ status: "ClearingWinners" });
+            const outcome = unwrapOk(await confirmClaim(chain, target));
+            expect(outcome).toEqual({
+                tag: "Unknown",
+                at: expect.anything(),
+                phase: "Settling",
+            });
+        });
+
+        test("a vanished event is Unknown with phase Gone", async () => {
+            const { chain } = fakeChain({ eventMissing: true });
+            const outcome = unwrapOk(await confirmClaim(chain, target));
+            expect(outcome).toEqual({ tag: "Unknown", at: expect.anything(), phase: "Gone" });
+        });
+
+        test("addresses the winner lookup with the derived event id", async () => {
+            const { chain, keys } = fakeChain({ ticket: TICKET });
+            await confirmClaim(chain, target);
+            expect(keys().find((k) => k.entry === "Winners")?.key).toEqual([
+                EVENT_ID,
+                { type: "Account", value: { account_id: ALICE } },
+            ]);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/game-decode.ts
+++ b/product-sdk/packages/individuality/src/game-decode.ts
@@ -1,0 +1,434 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Raw `Game` storage values → domain shapes, plus the phase-boundary arithmetic.
+ *
+ * **These timestamps are `u32` seconds where `Airdrop`'s are `u64`.** The pallets
+ * genuinely disagree, so these need no narrowing check and the airdrop ones do —
+ * not an oversight to normalize away. {@link gameTimeline} reimplements a runtime
+ * formula and the pinned tests below are what would catch it drifting.
+ */
+import { toAirdropPrize } from "./airdrop-decode.js";
+import type { RawAirdropPrize } from "./airdrop-decode.js";
+import { IndividualityDecodeError } from "./errors.js";
+import type {
+    CurrentGame,
+    GamePhase,
+    GamePhaseDurations,
+    GameSchedulePreview,
+    GameScheduledAirdrop,
+    GameTimeline,
+} from "./game-types.js";
+
+/** `u32` bounds, for the saturating arithmetic the runtime uses. */
+const U32_MAX = 0xff_ff_ff_ff;
+
+/** The raw `PhaseDurationValues`, from storage or from the runtime constant. */
+export interface RawPhaseDurations {
+    registration: number;
+    shuffle: number;
+    post_shuffle_margin: number;
+    reporting: number;
+    player_process: number;
+}
+
+/** The raw `GameState` enum. Its payloads are not read — see {@link GamePhase}. */
+export interface RawGameState {
+    type: string;
+}
+
+/** The raw `Game.Game` value, narrowed to the fields the domain carries. */
+export interface RawGameInfo {
+    index: number;
+    registration_ends: number;
+    shuffle_deadline: number;
+    game_date: number;
+    report_ends: number;
+    state: RawGameState;
+    max_group_size: number;
+    rounds: number;
+    pending_attendance: number;
+    airdrops_scheduled: number;
+}
+
+/** One raw `GameAirdrop` from a schedule. */
+export interface RawGameAirdrop {
+    draw_offset: number;
+    claim_window: number;
+    prize: RawAirdropPrize;
+}
+
+/** One raw `GameSchedule` from the `Game.GameSchedules` list. */
+export interface RawGameSchedule {
+    game_play_time: number;
+    rounds: number;
+    max_group_size: number;
+    airdrops: RawGameAirdrop[];
+}
+
+/**
+ * The boundary each phase runs to, `null` where it ends on work. A lookup rather
+ * than a `switch` so a new {@link GamePhase} fails to compile here — classifying it
+ * must not be skippable.
+ */
+const DEADLINE_FIELD: Record<GamePhase, keyof RawGameInfo | null> = {
+    Registration: "registration_ends",
+    Shuffle: "shuffle_deadline",
+    Reporting: "report_ends",
+    // Both run until their sub-steps finish. `game_date` and `report_ends` are
+    // already behind them, and the chain stores no boundary for either.
+    PlayerProcess: null,
+    Cancelling: null,
+};
+
+/** Validate a raw `GameState` variant name. The domain tags match it exactly. */
+function gamePhase(type: string): GamePhase {
+    if (type in DEADLINE_FIELD) {
+        return type as GamePhase;
+    }
+    throw new IndividualityDecodeError("unknown game state variant");
+}
+
+/** Clamp to `u32`, matching the runtime's saturating arithmetic. */
+function saturate(value: number): number {
+    if (value < 0) return 0;
+    return value > U32_MAX ? U32_MAX : value;
+}
+
+/** Map the raw phase durations, from either source. */
+export function toGamePhaseDurations(raw: RawPhaseDurations): GamePhaseDurations {
+    return {
+        registration: raw.registration,
+        shuffle: raw.shuffle,
+        postShuffleMargin: raw.post_shuffle_margin,
+        reporting: raw.reporting,
+        playerProcess: raw.player_process,
+    };
+}
+
+/**
+ * A line-for-line mirror of the runtime's `GameTimes` trait, including
+ * `saturating_sub` clamping at zero — reachable for a play time earlier than the
+ * phases before it.
+ *
+ * ```text
+ * registrationStarts = play - shuffle - postShuffleMargin - registration
+ * registrationEnds   = play - shuffle - postShuffleMargin
+ * shuffleDeadline    = play - postShuffleMargin
+ * reportingEnds      = play + reporting
+ * playerProcessEnds  = play + reporting + playerProcess
+ * ```
+ *
+ * Only correct for a game that does not exist yet — a created game stores its own.
+ */
+export function gameTimeline(gamePlayTime: number, durations: GamePhaseDurations): GameTimeline {
+    const beforeShuffle = saturate(gamePlayTime - durations.shuffle - durations.postShuffleMargin);
+    return {
+        registrationStarts: saturate(beforeShuffle - durations.registration),
+        registrationEnds: beforeShuffle,
+        shuffleDeadline: saturate(gamePlayTime - durations.postShuffleMargin),
+        gamePlayTime,
+        reportingEnds: saturate(gamePlayTime + durations.reporting),
+        playerProcessEnds: saturate(gamePlayTime + durations.reporting + durations.playerProcess),
+    };
+}
+
+/**
+ * Map the raw running game, selecting the deadline that belongs to its phase.
+ *
+ * @throws IndividualityDecodeError on a `GameState` variant this package does not
+ *   know.
+ */
+export function toCurrentGame(raw: RawGameInfo): CurrentGame {
+    const phase = gamePhase(raw.state.type);
+    const field = DEADLINE_FIELD[phase];
+
+    return {
+        index: raw.index,
+        phase,
+        // Read from the field the phase names, so a phase whose boundary has
+        // already passed still reports that boundary rather than the next one.
+        nextDeadline: field === null ? null : (raw[field] as number),
+        registrationEnds: raw.registration_ends,
+        shuffleDeadline: raw.shuffle_deadline,
+        gamePlayTime: raw.game_date,
+        reportingEnds: raw.report_ends,
+        maxGroupSize: raw.max_group_size,
+        rounds: raw.rounds,
+        pendingAttendance: raw.pending_attendance,
+        airdropsScheduled: raw.airdrops_scheduled,
+    };
+}
+
+/** Map one scheduled draw. The prize shape is the airdrop pallet's own. */
+function toScheduledAirdrop(raw: RawGameAirdrop): GameScheduledAirdrop {
+    return {
+        drawOffset: raw.draw_offset,
+        claimWindow: raw.claim_window,
+        prize: toAirdropPrize(raw.prize),
+    };
+}
+
+/**
+ * Map one upcoming schedule, deriving its timeline from the given durations.
+ *
+ * The durations must come from the same block as the schedule, or the projection
+ * describes a game under rules that were never in force together.
+ */
+export function toGameSchedulePreview(
+    raw: RawGameSchedule,
+    durations: GamePhaseDurations,
+): GameSchedulePreview {
+    return {
+        gamePlayTime: raw.game_play_time,
+        rounds: raw.rounds,
+        maxGroupSize: raw.max_group_size,
+        airdrops: raw.airdrops.map(toScheduledAirdrop),
+        timeline: gameTimeline(raw.game_play_time, durations),
+    };
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    const DURATIONS: GamePhaseDurations = {
+        registration: 3_600,
+        shuffle: 600,
+        postShuffleMargin: 300,
+        reporting: 1_800,
+        playerProcess: 900,
+    };
+
+    /** A round play time, so every boundary below is checkable by eye. */
+    const PLAY_TIME = 1_800_000_000;
+
+    const rawPrize = (): RawAirdropPrize => ({
+        asset_id: { parents: 1, interior: { type: "Here", value: undefined } },
+        asset_amount: 7_000n,
+        max_winners: 20,
+        winner_cap: 50_000,
+    });
+
+    const rawGame = (overrides: Partial<RawGameInfo> = {}): RawGameInfo => ({
+        index: 41,
+        registration_ends: PLAY_TIME - 900,
+        shuffle_deadline: PLAY_TIME - 300,
+        game_date: PLAY_TIME,
+        report_ends: PLAY_TIME + 1_800,
+        state: { type: "Registration" },
+        max_group_size: 5,
+        rounds: 3,
+        pending_attendance: 0,
+        airdrops_scheduled: 2,
+        ...overrides,
+    });
+
+    describe("toGamePhaseDurations", () => {
+        test("renames post_shuffle_margin and player_process", () => {
+            expect(
+                toGamePhaseDurations({
+                    registration: 1,
+                    shuffle: 2,
+                    post_shuffle_margin: 3,
+                    reporting: 4,
+                    player_process: 5,
+                }),
+            ).toEqual({
+                registration: 1,
+                shuffle: 2,
+                postShuffleMargin: 3,
+                reporting: 4,
+                playerProcess: 5,
+            });
+        });
+    });
+
+    describe("gameTimeline", () => {
+        test("derives every boundary from the play time", () => {
+            // Written out rather than computed from the durations, so a formula
+            // change here fails instead of moving with the code.
+            expect(gameTimeline(PLAY_TIME, DURATIONS)).toEqual({
+                registrationStarts: PLAY_TIME - 600 - 300 - 3_600,
+                registrationEnds: PLAY_TIME - 600 - 300,
+                shuffleDeadline: PLAY_TIME - 300,
+                gamePlayTime: PLAY_TIME,
+                reportingEnds: PLAY_TIME + 1_800,
+                playerProcessEnds: PLAY_TIME + 1_800 + 900,
+            });
+        });
+
+        test("the boundaries stay in chronological order", () => {
+            const t = gameTimeline(PLAY_TIME, DURATIONS);
+            const order = [
+                t.registrationStarts,
+                t.registrationEnds,
+                t.shuffleDeadline,
+                t.gamePlayTime,
+                t.reportingEnds,
+                t.playerProcessEnds,
+            ];
+            expect([...order].sort((a, b) => a - b)).toEqual(order);
+        });
+
+        test("clamps at zero rather than going negative, like saturating_sub", () => {
+            // A play time inside the pre-game phases. Reachable, and a negative
+            // timestamp here would render as 1969.
+            const t = gameTimeline(60, DURATIONS);
+            expect(t.registrationStarts).toBe(0);
+            expect(t.registrationEnds).toBe(0);
+            expect(t.shuffleDeadline).toBe(0);
+            expect(t.gamePlayTime).toBe(60);
+        });
+
+        test("clamps at u32 rather than overflowing, like saturating_add", () => {
+            const t = gameTimeline(U32_MAX, DURATIONS);
+            expect(t.reportingEnds).toBe(U32_MAX);
+            expect(t.playerProcessEnds).toBe(U32_MAX);
+        });
+
+        test("zero durations collapse every boundary onto the play time", () => {
+            const zero: GamePhaseDurations = {
+                registration: 0,
+                shuffle: 0,
+                postShuffleMargin: 0,
+                reporting: 0,
+                playerProcess: 0,
+            };
+            const t = gameTimeline(PLAY_TIME, zero);
+            expect(new Set(Object.values(t))).toEqual(new Set([PLAY_TIME]));
+        });
+    });
+
+    describe("toCurrentGame", () => {
+        test("maps every field of a representative game", () => {
+            expect(toCurrentGame(rawGame())).toEqual({
+                index: 41,
+                phase: "Registration",
+                nextDeadline: PLAY_TIME - 900,
+                registrationEnds: PLAY_TIME - 900,
+                shuffleDeadline: PLAY_TIME - 300,
+                gamePlayTime: PLAY_TIME,
+                reportingEnds: PLAY_TIME + 1_800,
+                maxGroupSize: 5,
+                rounds: 3,
+                pendingAttendance: 0,
+                airdropsScheduled: 2,
+            });
+        });
+
+        test.each([
+            ["Registration", "registration_ends"],
+            ["Shuffle", "shuffle_deadline"],
+            ["Reporting", "report_ends"],
+        ] as Array<[GamePhase, keyof RawGameInfo]>)(
+            "%s takes its deadline from %s",
+            (phase, field) => {
+                const raw = rawGame({ state: { type: phase } });
+                expect(toCurrentGame(raw).nextDeadline).toBe(raw[field]);
+            },
+        );
+
+        test.each(["PlayerProcess", "Cancelling"])(
+            "%s has no deadline, because it ends on work",
+            (phase) => {
+                expect(toCurrentGame(rawGame({ state: { type: phase } })).nextDeadline).toBeNull();
+            },
+        );
+
+        test("reports a deadline that has already passed, rather than the next one", () => {
+            // The transition runs in an offchain worker's own time, so a phase
+            // outliving its boundary is normal. Skipping ahead here would report
+            // a phase the chain is not in.
+            const raw = rawGame({
+                state: { type: "Registration" },
+                registration_ends: 1_000,
+                shuffle_deadline: 2_000,
+            });
+            expect(toCurrentGame(raw).nextDeadline).toBe(1_000);
+        });
+
+        test("ignores the state payload entirely", () => {
+            // Payloads are offchain-worker bookkeeping. A step cursor changing
+            // must not change the decoded game.
+            const withPayload = rawGame({
+                state: { type: "Reporting", player_count: 9 } as RawGameState,
+            });
+            expect(toCurrentGame(withPayload)).toEqual(
+                toCurrentGame(rawGame({ state: { type: "Reporting" } })),
+            );
+        });
+
+        test("throws on an unknown state variant", () => {
+            expect(() => toCurrentGame(rawGame({ state: { type: "Reshuffling" } }))).toThrow(
+                IndividualityDecodeError,
+            );
+        });
+
+        test("never interpolates chain data into a decode error message", () => {
+            expect(() => toCurrentGame(rawGame({ state: { type: "Reshuffling" } }))).toThrow(
+                /^unknown game state variant$/,
+            );
+        });
+
+        test("covers all five chain phases", () => {
+            expect(Object.keys(DEADLINE_FIELD)).toHaveLength(5);
+        });
+    });
+
+    describe("toGameSchedulePreview", () => {
+        test("maps a schedule and derives its timeline", () => {
+            const preview = toGameSchedulePreview(
+                {
+                    game_play_time: PLAY_TIME,
+                    rounds: 4,
+                    max_group_size: 6,
+                    airdrops: [{ draw_offset: 3_600, claim_window: 7_200, prize: rawPrize() }],
+                },
+                DURATIONS,
+            );
+
+            expect(preview.gamePlayTime).toBe(PLAY_TIME);
+            expect(preview.rounds).toBe(4);
+            expect(preview.maxGroupSize).toBe(6);
+            expect(preview.timeline).toEqual(gameTimeline(PLAY_TIME, DURATIONS));
+            expect(preview.airdrops).toEqual([
+                {
+                    drawOffset: 3_600,
+                    claimWindow: 7_200,
+                    prize: {
+                        assetId: { parents: 1, interior: { type: "Here", value: undefined } },
+                        assetAmount: 7_000n,
+                        maxWinners: 20,
+                        winnerCapPermill: 50_000,
+                    },
+                },
+            ]);
+        });
+
+        test("a schedule with no draws yields an empty list, not a missing field", () => {
+            const preview = toGameSchedulePreview(
+                { game_play_time: PLAY_TIME, rounds: 1, max_group_size: 4, airdrops: [] },
+                DURATIONS,
+            );
+            expect(preview.airdrops).toEqual([]);
+        });
+
+        test("keeps the draws in the order the chain stores them", () => {
+            // The order is the airdrop index, so reordering here would mislabel
+            // every draw.
+            const preview = toGameSchedulePreview(
+                {
+                    game_play_time: PLAY_TIME,
+                    rounds: 1,
+                    max_group_size: 4,
+                    airdrops: [
+                        { draw_offset: 10, claim_window: 1, prize: rawPrize() },
+                        { draw_offset: 20, claim_window: 2, prize: rawPrize() },
+                    ],
+                },
+                DURATIONS,
+            );
+            expect(preview.airdrops.map((a) => a.drawOffset)).toEqual([10, 20]);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/game-read.ts
+++ b/product-sdk/packages/individuality/src/game-read.ts
@@ -1,0 +1,464 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The pinned current-game read: nothing in, one {@link CurrentGameResult} out.
+ *
+ * **Every read shares one finalized block.** A schedule's timeline is only
+ * meaningful against the durations in force with it, so reading them a block apart
+ * can describe a game under rules that never held together.
+ *
+ * One value escapes that: `Game.DefaultPhaseDurations` is a constant, and PAPI
+ * serves constants from the client's runtime, not from a block. It is read only when
+ * `StoredPhaseDurations` is empty, and can only disagree across an upgrade mid-read.
+ */
+import { err, normalizeError, ok, type Result } from "@parity/result";
+import {
+    toCurrentGame,
+    toGamePhaseDurations,
+    toGameSchedulePreview,
+    type RawGameInfo,
+    type RawGameSchedule,
+    type RawPhaseDurations,
+} from "./game-decode.js";
+import type { CurrentGameResult, GamePhaseDurations } from "./game-types.js";
+import { ProductIndividualityError } from "./errors.js";
+import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
+import type { FinalizedSnapshot } from "./types.js";
+
+/**
+ * Structural, so a test double satisfies it. Separate from `AirdropChain` because a
+ * caller reading the game needs neither it nor the personhood entries;
+ * `PrizeStatusChain` is the intersection.
+ *
+ * Matched by hand against the paseo descriptors on 2026-08-20:
+ *
+ * ```
+ * Game.GameIndex:             StorageDescriptor<[], number, false, never>
+ * Game.Game:                  StorageDescriptor<[], GameInfo, true, never>
+ * Game.GameSchedules:         StorageDescriptor<[], Array<GameSchedule>, false, never>
+ * Game.StoredPhaseDurations:  StorageDescriptor<[], PhaseDurationValues, true, never>
+ * Game.DefaultPhaseDurations: PlainDescriptor<PhaseDurationValues>
+ * ```
+ */
+export interface GameChain extends PinnedChain {
+    individuality: {
+        constants: {
+            Game: {
+                /** The fallback durations, used when storage holds no override. */
+                DefaultPhaseDurations(): Promise<RawPhaseDurations>;
+            };
+        };
+        query: {
+            Game: {
+                /** `ValueQuery`: always answers, `0` before any game exists. */
+                GameIndex: {
+                    getValue(options: ReadAt): Promise<number>;
+                };
+                /** Absent between games, which is most of the time. */
+                Game: {
+                    getValue(options: ReadAt): Promise<RawGameInfo | undefined>;
+                };
+                /** `ValueQuery`: an empty list rather than absence. */
+                GameSchedules: {
+                    getValue(options: ReadAt): Promise<RawGameSchedule[]>;
+                };
+                /** The governance override, absent unless one has been set. */
+                StoredPhaseDurations: {
+                    getValue(options: ReadAt): Promise<RawPhaseDurations | undefined>;
+                };
+            };
+        };
+    };
+}
+
+/** Options for {@link readCurrentGame}. */
+export interface ReadCurrentGameOptions {
+    /**
+     * Forwarded into every underlying pull, so an aborted caller stops the whole
+     * batch. No deadline is applied here — that belongs to the caller.
+     */
+    signal?: AbortSignal;
+}
+
+/**
+ * **No game running is not a failure**, it is `BetweenGames` — the chain's normal
+ * state, since one game exists at a time and each is killed when it ends.
+ */
+export async function readCurrentGame(
+    chain: GameChain,
+    options: ReadCurrentGameOptions = {},
+): Promise<Result<CurrentGameResult, ProductIndividualityError>> {
+    try {
+        return ok(await runGameRead(chain, options));
+    } catch (cause) {
+        // normalizeError passes an existing package error through unchanged.
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+/**
+ * The read itself. Throws; {@link readCurrentGame} owns the `Result` boundary.
+ *
+ * Exported so `prize-status.ts` can run it against a block it already pinned.
+ */
+export async function runGameRead(
+    chain: GameChain,
+    options: ReadCurrentGameOptions,
+    pinned?: FinalizedSnapshot,
+): Promise<CurrentGameResult> {
+    const { signal } = options;
+    const query = chain.individuality.query.Game;
+
+    const snapshot = await pinBlock(chain, signal, pinned);
+    const at: ReadAt = readAt(snapshot, signal);
+
+    const [gameIndex, rawGame, rawSchedules, storedDurations] = await Promise.all([
+        query.GameIndex.getValue(at),
+        query.Game.getValue(at),
+        query.GameSchedules.getValue(at),
+        query.StoredPhaseDurations.getValue(at),
+    ]);
+
+    // The constant is only needed when governance has set no override, so it is
+    // not fetched otherwise — which also keeps the un-pinned read out of the
+    // common path entirely.
+    const durations: GamePhaseDurations = toGamePhaseDurations(
+        storedDurations ?? (await chain.individuality.constants.Game.DefaultPhaseDurations()),
+    );
+
+    // Already chronological: the chain rejects a schedule that overlaps or
+    // precedes the last one, so no sort is needed and imposing one would hide a
+    // chain-side ordering bug rather than surface it.
+    const upcoming = rawSchedules.map((schedule) => toGameSchedulePreview(schedule, durations));
+
+    if (rawGame === undefined) {
+        return {
+            tag: "BetweenGames",
+            at: snapshot,
+            // The counter only moves when a game is created, so it still names
+            // the game that just ended. Games are numbered from 1, so 0 means
+            // none has ever been created.
+            lastGameIndex: gameIndex === 0 ? null : gameIndex,
+            upcoming,
+            durations,
+        };
+    }
+
+    return {
+        tag: "Running",
+        at: snapshot,
+        // Taken from the game itself, not from `GameIndex`. The two agree while a
+        // game runs, and the game's own copy is the one a prize claim is keyed
+        // by.
+        game: toCurrentGame(rawGame),
+        upcoming,
+        durations,
+    };
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test } = import.meta.vitest;
+    const { unwrapOk, unwrapErr, isErrorOf } = await import("@parity/result");
+    const { IndividualityDecodeError } = await import("./errors.js");
+    const { gameTimeline } = await import("./game-decode.js");
+
+    const BLOCK = { hash: `0x${"44".repeat(32)}`, number: 12_345 };
+    const PLAY_TIME = 1_800_000_000;
+
+    const STORED: RawPhaseDurations = {
+        registration: 3_600,
+        shuffle: 600,
+        post_shuffle_margin: 300,
+        reporting: 1_800,
+        player_process: 900,
+    };
+    /** Deliberately different from STORED, so which one was used is observable. */
+    const DEFAULT: RawPhaseDurations = {
+        registration: 7_200,
+        shuffle: 1_200,
+        post_shuffle_margin: 600,
+        reporting: 3_600,
+        player_process: 1_800,
+    };
+
+    const rawGame = (overrides: Partial<RawGameInfo> = {}): RawGameInfo => ({
+        index: 41,
+        registration_ends: PLAY_TIME - 900,
+        shuffle_deadline: PLAY_TIME - 300,
+        game_date: PLAY_TIME,
+        report_ends: PLAY_TIME + 1_800,
+        state: { type: "Reporting" },
+        max_group_size: 5,
+        rounds: 3,
+        pending_attendance: 2,
+        airdrops_scheduled: 2,
+        ...overrides,
+    });
+
+    const rawSchedule = (playTime: number): RawGameSchedule => ({
+        game_play_time: playTime,
+        rounds: 3,
+        max_group_size: 5,
+        airdrops: [],
+    });
+
+    interface FakeState {
+        gameIndex?: number;
+        game?: RawGameInfo;
+        schedules?: RawGameSchedule[];
+        stored?: RawPhaseDurations;
+        failOn?:
+            | "GameIndex"
+            | "Game"
+            | "GameSchedules"
+            | "StoredPhaseDurations"
+            | "constant"
+            | "block";
+    }
+
+    /**
+     * Records which entries were read and at which block — a read that silently
+     * used the best block instead of the pinned one satisfies every value
+     * assertion.
+     */
+    function fakeChain(state: FakeState) {
+        const calls: Array<{ entry: string; at: string | undefined }> = [];
+        const boom = (entry: FakeState["failOn"]) => {
+            if (state.failOn === entry) throw new Error(`${entry} unreachable`);
+        };
+        const record = (entry: string, options: ReadAt) => {
+            options.signal?.throwIfAborted();
+            calls.push({ entry, at: options.at });
+        };
+
+        const chain: GameChain = {
+            individuality: {
+                constants: {
+                    Game: {
+                        DefaultPhaseDurations: async () => {
+                            boom("constant");
+                            calls.push({ entry: "DefaultPhaseDurations", at: undefined });
+                            return DEFAULT;
+                        },
+                    },
+                },
+                query: {
+                    Game: {
+                        GameIndex: {
+                            getValue: async (options) => {
+                                boom("GameIndex");
+                                record("GameIndex", options);
+                                return state.gameIndex ?? 41;
+                            },
+                        },
+                        Game: {
+                            getValue: async (options) => {
+                                boom("Game");
+                                record("Game", options);
+                                return state.game;
+                            },
+                        },
+                        GameSchedules: {
+                            getValue: async (options) => {
+                                boom("GameSchedules");
+                                record("GameSchedules", options);
+                                return state.schedules ?? [];
+                            },
+                        },
+                        StoredPhaseDurations: {
+                            getValue: async (options) => {
+                                boom("StoredPhaseDurations");
+                                record("StoredPhaseDurations", options);
+                                return state.stored;
+                            },
+                        },
+                    },
+                },
+            },
+            raw: {
+                individuality: {
+                    getFinalizedBlock: async () => {
+                        boom("block");
+                        return BLOCK;
+                    },
+                },
+            },
+        };
+        return { chain, calls };
+    }
+
+    describe("readCurrentGame, with a game running", () => {
+        test("returns the running game with its phase and deadline", async () => {
+            const { chain } = fakeChain({ game: rawGame(), stored: STORED });
+            const result = unwrapOk(await readCurrentGame(chain));
+
+            expect(result.tag).toBe("Running");
+            if (result.tag !== "Running") return;
+            expect(result.game.index).toBe(41);
+            expect(result.game.phase).toBe("Reporting");
+            expect(result.game.nextDeadline).toBe(PLAY_TIME + 1_800);
+            expect(result.game.airdropsScheduled).toBe(2);
+        });
+
+        test("reports the pinned block, and reads every entry at it", async () => {
+            const { chain, calls } = fakeChain({ game: rawGame(), stored: STORED });
+            const result = unwrapOk(await readCurrentGame(chain));
+
+            expect(result.at).toEqual({ blockHash: BLOCK.hash, blockNumber: BLOCK.number });
+            expect(calls).toHaveLength(4);
+            expect(new Set(calls.map((call) => call.at))).toEqual(new Set([BLOCK.hash]));
+        });
+
+        test("takes the index from the game, not from the counter", async () => {
+            // They agree on chain while a game runs. This pins which one is read,
+            // because the game's own copy is what a prize claim is keyed by.
+            const { chain } = fakeChain({
+                game: rawGame({ index: 41 }),
+                gameIndex: 999,
+                stored: STORED,
+            });
+            const result = unwrapOk(await readCurrentGame(chain));
+            if (result.tag !== "Running") throw new Error("expected Running");
+            expect(result.game.index).toBe(41);
+        });
+    });
+
+    describe("readCurrentGame, between games", () => {
+        test("no game is a success value, not an error", async () => {
+            const { chain } = fakeChain({ gameIndex: 41, stored: STORED });
+            const result = unwrapOk(await readCurrentGame(chain));
+
+            expect(result.tag).toBe("BetweenGames");
+            if (result.tag !== "BetweenGames") return;
+            expect(result.lastGameIndex).toBe(41);
+        });
+
+        test("index 0 means no game has ever been created", async () => {
+            // Games are numbered from 1, so 0 is not a game that just ended.
+            const { chain } = fakeChain({ gameIndex: 0, stored: STORED });
+            const result = unwrapOk(await readCurrentGame(chain));
+            if (result.tag !== "BetweenGames") throw new Error("expected BetweenGames");
+            expect(result.lastGameIndex).toBeNull();
+        });
+
+        test("still answers when the next game is scheduled", async () => {
+            const { chain } = fakeChain({
+                gameIndex: 41,
+                stored: STORED,
+                schedules: [rawSchedule(PLAY_TIME)],
+            });
+            const result = unwrapOk(await readCurrentGame(chain));
+            if (result.tag !== "BetweenGames") throw new Error("expected BetweenGames");
+
+            expect(result.upcoming).toHaveLength(1);
+            expect(result.upcoming[0]?.timeline.registrationStarts).toBe(
+                PLAY_TIME - 600 - 300 - 3_600,
+            );
+        });
+    });
+
+    describe("the upcoming schedule", () => {
+        test("keeps the chain's chronological order rather than re-sorting", async () => {
+            // The chain enforces the order at `schedule_games`. Sorting here would
+            // hide a chain-side ordering bug instead of surfacing it.
+            const { chain } = fakeChain({
+                game: rawGame(),
+                stored: STORED,
+                schedules: [rawSchedule(PLAY_TIME), rawSchedule(PLAY_TIME + 86_400)],
+            });
+            const result = unwrapOk(await readCurrentGame(chain));
+
+            expect(result.upcoming.map((s) => s.gamePlayTime)).toEqual([
+                PLAY_TIME,
+                PLAY_TIME + 86_400,
+            ]);
+        });
+
+        test("an empty schedule list is empty, not absent", async () => {
+            const { chain } = fakeChain({ game: rawGame(), stored: STORED });
+            expect(unwrapOk(await readCurrentGame(chain)).upcoming).toEqual([]);
+        });
+
+        test("every timeline is derived with the durations the result reports", async () => {
+            const { chain } = fakeChain({
+                game: rawGame(),
+                stored: STORED,
+                schedules: [rawSchedule(PLAY_TIME)],
+            });
+            const result = unwrapOk(await readCurrentGame(chain));
+
+            expect(result.upcoming[0]?.timeline).toEqual(gameTimeline(PLAY_TIME, result.durations));
+        });
+    });
+
+    describe("the phase durations", () => {
+        test("prefers the stored override, and never reads the constant then", async () => {
+            const { chain, calls } = fakeChain({
+                game: rawGame(),
+                stored: STORED,
+                schedules: [rawSchedule(PLAY_TIME)],
+            });
+            const result = unwrapOk(await readCurrentGame(chain));
+
+            expect(result.durations.registration).toBe(3_600);
+            // The constant is the one value not pinned to the block, so staying
+            // off it whenever storage answers is deliberate, not incidental.
+            expect(calls.some((call) => call.entry === "DefaultPhaseDurations")).toBe(false);
+        });
+
+        test("falls back to the runtime constant when no override is set", async () => {
+            const { chain, calls } = fakeChain({
+                game: rawGame(),
+                schedules: [rawSchedule(PLAY_TIME)],
+            });
+            const result = unwrapOk(await readCurrentGame(chain));
+
+            expect(result.durations.registration).toBe(7_200);
+            expect(calls.some((call) => call.entry === "DefaultPhaseDurations")).toBe(true);
+            // And the fallback durations are the ones the projection used.
+            expect(result.upcoming[0]?.timeline.registrationStarts).toBe(
+                PLAY_TIME - 1_200 - 600 - 7_200,
+            );
+        });
+    });
+
+    describe("failures", () => {
+        test("an unknown game state arrives as a decode error", async () => {
+            const { chain } = fakeChain({
+                game: rawGame({ state: { type: "Reshuffling" } }),
+                stored: STORED,
+            });
+            const error = unwrapErr(await readCurrentGame(chain));
+            expect(isErrorOf(error, IndividualityDecodeError)).toBe(true);
+        });
+
+        test.each(["GameIndex", "Game", "GameSchedules", "StoredPhaseDurations", "block"] as const)(
+            "a transport failure on %s arrives on the err channel with its cause",
+            async (failOn) => {
+                const { chain } = fakeChain({ game: rawGame(), stored: STORED, failOn });
+                const error = unwrapErr(await readCurrentGame(chain));
+
+                expect(error).toBeInstanceOf(ProductIndividualityError);
+                expect((error.cause as Error).message).toBe(`${failOn} unreachable`);
+            },
+        );
+
+        test("a failure reading the fallback constant also arrives on the err channel", async () => {
+            // Only reachable when storage holds no override, which is why this
+            // case is separate from the table above.
+            const { chain } = fakeChain({ game: rawGame(), failOn: "constant" });
+            const error = unwrapErr(await readCurrentGame(chain));
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+        });
+
+        test("an already-aborted signal costs no round trip", async () => {
+            const { chain, calls } = fakeChain({ game: rawGame(), stored: STORED });
+            const controller = new AbortController();
+            controller.abort();
+
+            const error = unwrapErr(await readCurrentGame(chain, { signal: controller.signal }));
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+            expect(calls).toHaveLength(0);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/game-types.ts
+++ b/product-sdk/packages/individuality/src/game-types.ts
@@ -1,0 +1,169 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * One game exists at a time and `Game.Game` is empty between them, hence a two-arm
+ * union rather than a nullable game.
+ *
+ * **Stored boundaries and derived ones are not interchangeable.** A running game
+ * carries the boundaries it was created with, and governance can move the durations
+ * afterwards, so re-deriving would contradict storage. {@link GameTimeline} is
+ * therefore only on {@link GameSchedulePreview}, where play time is all there is.
+ *
+ * **Paseo only.** Devnet's metadata predates this work — one optional prize per
+ * schedule, no `airdrops_scheduled`, an extra `airdrop_claim_window` — so a devnet
+ * client fails `GameChain`, which the umbrella's contract test asserts deliberately.
+ */
+import type { AirdropPrize } from "./airdrop-types.js";
+import type { FinalizedSnapshot } from "./types.js";
+
+/**
+ * The phase a game is in, named as the chain's `GameState` variant. Their payloads
+ * are not decoded — offchain-worker cursors and sub-step markers, not anything a
+ * product renders; `pendingAttendance` is the progress signal that is.
+ */
+export type GamePhase =
+    /** Sign-ups are open until `registrationEnds`. */
+    | "Registration"
+    /** Registration closed; players are being grouped, until `shuffleDeadline`. */
+    | "Shuffle"
+    /** The game has been played; players report each other until `reportingEnds`. */
+    | "Reporting"
+    /** Reporting closed; results are being settled. Ends on work, not on a clock. */
+    | "PlayerProcess"
+    /**
+     * The game was abandoned and is cleaning up — too few players to group, or a
+     * missed shuffle deadline. No prizes, and the game is not replayed.
+     */
+    | "Cancelling";
+
+/**
+ * The phase durations in force, from `Game.StoredPhaseDurations` when governance
+ * has set one and `Game.DefaultPhaseDurations` otherwise. All in seconds.
+ */
+export interface GamePhaseDurations {
+    registration: number;
+    shuffle: number;
+    /** Slack between the shuffle deadline and the play time. */
+    postShuffleMargin: number;
+    reporting: number;
+    playerProcess: number;
+}
+
+/**
+ * A game's phase boundaries, Unix **seconds**. Mirrors the runtime's `GameTimes`
+ * trait (`pallets/game/src/types.rs:525`), and is only ever a projection, for a
+ * game that does not exist yet.
+ */
+export interface GameTimeline {
+    /** Earliest the game may open for sign-ups. */
+    registrationStarts: number;
+    registrationEnds: number;
+    /** Miss this and the game is cancelled rather than played. */
+    shuffleDeadline: number;
+    gamePlayTime: number;
+    reportingEnds: number;
+    /** End of the whole game. The chain schedules nothing else before it. */
+    playerProcessEnds: number;
+}
+
+/** One prize draw a schedule will set up, with its timing relative to play time. */
+export interface GameScheduledAirdrop {
+    /** Seconds after the play time at which winners are drawn. */
+    drawOffset: number;
+    /** Seconds the claim window stays open after the draw. */
+    claimWindow: number;
+    prize: AirdropPrize;
+}
+
+/** The game that is running now. */
+export interface CurrentGame {
+    /**
+     * The game index, which is also the `game_index` a prize claim takes.
+     *
+     * Games are numbered from 1: the counter is incremented when a game is
+     * created, so index 0 never names one.
+     */
+    index: number;
+    phase: GamePhase;
+    /**
+     * The boundary this phase runs to, `null` for `PlayerProcess` and `Cancelling`,
+     * which end on work rather than time. Taken from the boundary matching
+     * {@link phase}, never inferred from the clock: transitions run in an offchain
+     * worker's own time, so a boundary can be past while its phase is current.
+     */
+    nextDeadline: number | null;
+    /** Unix seconds. Stored on the game, not re-derived. */
+    registrationEnds: number;
+    shuffleDeadline: number;
+    gamePlayTime: number;
+    reportingEnds: number;
+    maxGroupSize: number;
+    rounds: number;
+    /**
+     * Registered players whose attendance is not settled yet. Reaches zero when
+     * every player has been resolved, which can end the reporting phase early.
+     */
+    pendingAttendance: number;
+    /**
+     * Draws actually scheduled, carrying airdrop indices `0..airdropsScheduled`.
+     *
+     * **Derive event ids from this, not the schedule's count.** Scheduling stops at
+     * the first failure, so a game can end up with fewer draws than it asked for.
+     */
+    airdropsScheduled: number;
+}
+
+/**
+ * A game not created yet. The chain keeps `Game.GameSchedules` chronological —
+ * `schedule_games` rejects anything overlapping or preceding the last one, and
+ * `remove_scheduled_game` binary-searches it — so the first entry is the next game.
+ */
+export interface GameSchedulePreview {
+    /** Unix seconds. The only time the chain stores for a scheduled game. */
+    gamePlayTime: number;
+    rounds: number;
+    maxGroupSize: number;
+    /**
+     * The draws this schedule asks for — an upper bound, since scheduling can fail
+     * per draw. For showing a prize before the game exists, never for deriving
+     * event ids.
+     */
+    airdrops: GameScheduledAirdrop[];
+    /**
+     * Boundaries derived from the durations at the same block — **a projection**.
+     * Governance can move them before this game is created, shifting everything
+     * here except `gamePlayTime`. Once it exists, read its stored boundaries.
+     */
+    timeline: GameTimeline;
+}
+
+/**
+ * The outcome of a current-game read.
+ *
+ * Between games is not a failure and not an empty result: the chain was asked
+ * and answered that no game is running, which is most of the time.
+ */
+export type CurrentGameResult =
+    /** A game exists in `Game.Game`. */
+    | {
+          tag: "Running";
+          at: FinalizedSnapshot;
+          game: CurrentGame;
+          /** Games after this one, chronologically. */
+          upcoming: GameSchedulePreview[];
+          /** The durations the {@link GameSchedulePreview} timelines were derived with. */
+          durations: GamePhaseDurations;
+      }
+    /** `Game.Game` is empty. */
+    | {
+          tag: "BetweenGames";
+          at: FinalizedSnapshot;
+          /**
+           * The game that just ended: the counter only moves at creation, so it
+           * still points there. `null` before any game existed. This is the index a
+           * prize from that game is claimed against.
+           */
+          lastGameIndex: number | null;
+          upcoming: GameSchedulePreview[];
+          durations: GamePhaseDurations;
+      };

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -203,6 +203,28 @@ export type {
 export { readCurrentGame } from "./game-read.js";
 export type { GameChain, ReadCurrentGameOptions } from "./game-read.js";
 
+// Claiming a prize. `claim_airdrop` has five gates and only two are about
+// personhood, so the predicate is exported separately from the read that feeds
+// it. Submission stays with `@parity/product-sdk-tx`: `claimPrizeTx` returns the
+// unsigned call. `confirmClaim` re-reads whether a claim landed, which is how the
+// flow survives a reload — a successful claim removes the `Winners` row.
+export type {
+    ClaimBlocker,
+    ClaimEligibility,
+    ClaimEligibilityResult,
+    ClaimOutcome,
+    ClaimWindow,
+} from "./claim-types.js";
+export { deriveClaimEligibility } from "./claim-derive.js";
+export type { ClaimInputs } from "./claim-derive.js";
+export { claimPrizeTx, confirmClaim, readClaimEligibility } from "./claim.js";
+export type {
+    ClaimChain,
+    ClaimTarget,
+    ConfirmClaimOptions,
+    ReadClaimEligibilityOptions,
+} from "./claim.js";
+
 // The write half: wrap a signer so the call runs under a person origin. Returns
 // a `PolkadotSigner`, so submission stays with `@parity/product-sdk-tx`.
 export { withAsPerson } from "./as-person-signer.js";

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -134,7 +134,12 @@ export {
 
 // Raw `Airdrop` storage values to domain shapes, for callers doing their own
 // reads. `airdropPhase` is the `Status`-to-UI-phase collapse on its own.
-export { airdropPhase, toAirdropEvent, toRawRegistrationEntry } from "./airdrop-decode.js";
+export {
+    airdropPhase,
+    statusTag,
+    toAirdropEvent,
+    toRawRegistrationEntry,
+} from "./airdrop-decode.js";
 export type {
     RawActiveEvent,
     RawAirdropEventInfo,
@@ -203,7 +208,7 @@ export type {
 export { readCurrentGame } from "./game-read.js";
 export type { GameChain, ReadCurrentGameOptions } from "./game-read.js";
 
-// Claiming a prize. `claim_airdrop` has five gates and only two are about
+// Claiming a prize. `claim_airdrop` has six gates and only two are about
 // personhood, so the predicate is exported separately from the read that feeds
 // it. Submission stays with `@parity/product-sdk-tx`: `claimPrizeTx` returns the
 // unsigned call. `confirmClaim` re-reads whether a claim landed, which is how the

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -72,6 +72,105 @@ export type { RawParticipant, RawRecognition, RawStreak } from "./decode.js";
 export { readPersonhoodState } from "./read.js";
 export type { IndividualityChain, RawAccountAlias, ReadPersonhoodStateOptions } from "./read.js";
 
+// The prize-draw half: derive a draw's event id, then read the draw at one
+// pinned block. Two pallets schedule draws through the same `Airdrop` mechanism,
+// so the reads are keyed by event id and know nothing about which one did.
+export type {
+    AirdropAssetId,
+    AirdropDraw,
+    AirdropEvent,
+    AirdropOutcome,
+    AirdropPhase,
+    AirdropPrize,
+    AirdropRegistrant,
+    AirdropStatusTag,
+} from "./airdrop-types.js";
+
+// The derivations. Pure, so they work against an index you already hold. Prefer
+// `readGameAirdropEventIds` over the pinned base: the chain exposes `Game`'s base
+// as a constant, and a hardcoded copy would derive ids for draws that do not
+// exist if it ever moved. `PeopleAirdrops`' base is not exposed, so that one is
+// pinned here and guarded by vectors.
+export {
+    GAME_AIRDROP_EVENT_ID_BASE,
+    MAX_GAME_AIRDROPS,
+    PEOPLE_AIRDROPS_EVENT_ID_BASE,
+    gameAirdropEventId,
+    gameAirdropEventIds,
+    peopleAirdropsEventId,
+} from "./airdrop-ids.js";
+
+// Raw `Airdrop` storage values to domain shapes, for callers doing their own
+// reads. `airdropPhase` is the `Status`-to-UI-phase collapse on its own.
+export { airdropPhase, toAirdropEvent, toRawRegistrationEntry } from "./airdrop-decode.js";
+export type {
+    RawActiveEvent,
+    RawAirdropEventInfo,
+    RawAirdropPrize,
+    RawAirdropStatus,
+    RawRegistrationEntry,
+} from "./airdrop-decode.js";
+
+// The pinned draw read. `readDrawRegistration` is the prefix scan that answers
+// "am I in this draw" before it runs — separate because its cost grows with the
+// draw's participant count, where everything else here is a point read.
+export {
+    readAirdropDraw,
+    readDrawRegistration,
+    readGameAirdropEventIds,
+} from "./airdrop-read.js";
+export type {
+    AirdropChain,
+    DrawRegistration,
+    ReadAirdropDrawOptions,
+    ReadGameAirdropEventIdsOptions,
+} from "./airdrop-read.js";
+
+// The composed read behind `getDailyPrizeStatus`: a game's draws and this
+// identity's outcome in each, all at one pinned block. A caller cannot assemble
+// this from the two reads above without pinning two blocks.
+export { readPrizeStatus } from "./prize-status.js";
+export type {
+    CapturedGame,
+    PrizeStatus,
+    PrizeStatusChain,
+    ReadPrizeStatusOptions,
+} from "./prize-status.js";
+
+// The game half: what game is running, what phase it is in, and what is
+// scheduled next. Between games is a success value, not an empty result.
+export type {
+    CurrentGame,
+    CurrentGameResult,
+    GamePhase,
+    GamePhaseDurations,
+    GameScheduledAirdrop,
+    GameSchedulePreview,
+    GameTimeline,
+} from "./game-types.js";
+
+// Raw `Game` storage values to domain shapes, plus the phase-boundary
+// arithmetic. `gameTimeline` mirrors the runtime's own `GameTimes` trait and is
+// only correct for a game that does not exist yet — a created game stores its
+// boundaries, and re-deriving them contradicts storage once the durations move.
+export {
+    gameTimeline,
+    toCurrentGame,
+    toGamePhaseDurations,
+    toGameSchedulePreview,
+} from "./game-decode.js";
+export type {
+    RawGameAirdrop,
+    RawGameInfo,
+    RawGameSchedule,
+    RawGameState,
+    RawPhaseDurations,
+} from "./game-decode.js";
+
+// The pinned current-game read.
+export { readCurrentGame } from "./game-read.js";
+export type { GameChain, ReadCurrentGameOptions } from "./game-read.js";
+
 // The write half: wrap a signer so the call runs under a person origin. Returns
 // a `PolkadotSigner`, so submission stays with `@parity/product-sdk-tx`.
 export { withAsPerson } from "./as-person-signer.js";

--- a/product-sdk/packages/individuality/src/pinned.ts
+++ b/product-sdk/packages/individuality/src/pinned.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Block pinning: entries read a block apart can return a state the chain was never
+ * in. Each public read pins its own, so two in sequence pin two — {@link pinBlock}
+ * lets a composing read pin once and hand the snapshot down.
+ */
+import type { FinalizedSnapshot } from "./types.js";
+
+/** Options every pinned storage read is given, so all of them agree on a block. */
+export interface ReadAt {
+    at: string;
+    signal?: AbortSignal;
+}
+
+/**
+ * The `getFinalizedBlock` escape hatch every read needs. `IndividualityChain` keeps
+ * its own copy rather than extending this — it shipped first, and rewiring a
+ * published interface buys no behaviour.
+ */
+export interface PinnedChain {
+    raw: {
+        individuality: {
+            getFinalizedBlock(): Promise<{ hash: string; number: number }>;
+        };
+    };
+}
+
+/**
+ * The abort check lives here because `getFinalizedBlock` takes no options and so
+ * cannot carry a signal itself — without it an already-cancelled read would still
+ * cost a round trip.
+ */
+export async function pinBlock(
+    chain: PinnedChain,
+    signal: AbortSignal | undefined,
+    snapshot?: FinalizedSnapshot,
+): Promise<FinalizedSnapshot> {
+    signal?.throwIfAborted();
+    if (snapshot !== undefined) {
+        return snapshot;
+    }
+    const block = await chain.raw.individuality.getFinalizedBlock();
+    return { blockHash: block.hash, blockNumber: block.number };
+}
+
+export function readAt(snapshot: FinalizedSnapshot, signal: AbortSignal | undefined): ReadAt {
+    return { at: snapshot.blockHash, signal };
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test } = import.meta.vitest;
+
+    const BLOCK = { hash: `0x${"55".repeat(32)}`, number: 77 };
+    const SNAPSHOT = { blockHash: `0x${"66".repeat(32)}`, blockNumber: 88 };
+
+    function fakeChain() {
+        let fetches = 0;
+        const chain: PinnedChain = {
+            raw: {
+                individuality: {
+                    getFinalizedBlock: async () => {
+                        fetches += 1;
+                        return BLOCK;
+                    },
+                },
+            },
+        };
+        return { chain, fetches: () => fetches };
+    }
+
+    describe("pinBlock", () => {
+        test("pins the finalized block when given no snapshot", async () => {
+            const { chain, fetches } = fakeChain();
+            expect(await pinBlock(chain, undefined)).toEqual({
+                blockHash: BLOCK.hash,
+                blockNumber: BLOCK.number,
+            });
+            expect(fetches()).toBe(1);
+        });
+
+        test("reuses a snapshot without a round trip", async () => {
+            // The whole point: a composing read pins once, and the inner reads
+            // must not each pin again.
+            const { chain, fetches } = fakeChain();
+            expect(await pinBlock(chain, undefined, SNAPSHOT)).toBe(SNAPSHOT);
+            expect(fetches()).toBe(0);
+        });
+
+        test("an aborted signal throws before any round trip", async () => {
+            const { chain, fetches } = fakeChain();
+            const controller = new AbortController();
+            controller.abort();
+            await expect(pinBlock(chain, controller.signal)).rejects.toThrow();
+            expect(fetches()).toBe(0);
+        });
+
+        test("an aborted signal throws even when a snapshot was supplied", async () => {
+            const controller = new AbortController();
+            controller.abort();
+            await expect(
+                pinBlock(fakeChain().chain, controller.signal, SNAPSHOT),
+            ).rejects.toThrow();
+        });
+    });
+
+    describe("readAt", () => {
+        test("addresses the snapshot's hash and carries the signal", () => {
+            const signal = new AbortController().signal;
+            expect(readAt(SNAPSHOT, signal)).toEqual({ at: SNAPSHOT.blockHash, signal });
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/prize-status.ts
+++ b/product-sdk/packages/individuality/src/prize-status.ts
@@ -1,0 +1,499 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * "Did I win anything, and can I still claim it" — the composed read behind
+ * `getDailyPrizeStatus`. The game gives an index and a draw count, the count gives
+ * the event ids, each id gives a draw.
+ *
+ * **One function because the pinning is:** the two inner reads each pin their own
+ * block when called alone, so composing them by hand reads two.
+ *
+ * **The draw count is the difficulty.** It lives on `Game.Game`, which holds only
+ * the running game, but a claim outlives its game — hence
+ * {@link ReadPrizeStatusOptions.game}, and no probe fallback: probing cannot tell a
+ * cleaned-up draw from one never scheduled, and a short answer reads as "you won
+ * nothing".
+ */
+import { err, normalizeError, ok, type Result } from "@parity/result";
+import { runDrawRead, type AirdropChain } from "./airdrop-read.js";
+import { gameAirdropEventIds } from "./airdrop-ids.js";
+import type { AirdropDraw, AirdropRegistrant } from "./airdrop-types.js";
+import { ProductIndividualityError } from "./errors.js";
+import { runGameRead, type GameChain } from "./game-read.js";
+import type { CurrentGame, GameSchedulePreview } from "./game-types.js";
+import { pinBlock } from "./pinned.js";
+import type { FinalizedSnapshot } from "./types.js";
+
+/** Both halves of the chain surface, since this read spans `Game` and `Airdrop`. */
+export type PrizeStatusChain = AirdropChain & GameChain;
+
+/** A game identified by the caller rather than read from the chain. */
+export interface CapturedGame {
+    index: number;
+    /**
+     * `airdrops_scheduled` as it was while the game ran. Capture it then: it is
+     * unreadable afterwards, and it is the count that actually got scheduled
+     * rather than what the schedule asked for.
+     */
+    airdropsScheduled: number;
+}
+
+/** Options for {@link readPrizeStatus}. */
+export interface ReadPrizeStatusOptions {
+    /**
+     * Whose outcome to report. Omit to read the draws without asking about
+     * anyone, which leaves every outcome `Unchecked`.
+     */
+    registrant?: AirdropRegistrant;
+    /**
+     * A game the caller already knows, for claiming after it ended. Supplying it
+     * **skips the game read** — four fewer reads, so `game` on the result is `null`
+     * even if this index is the running one.
+     */
+    game?: CapturedGame;
+    signal?: AbortSignal;
+}
+
+/** The outcome of a prize-status read. */
+export type PrizeStatus =
+    /**
+     * No game is running and the caller named none, so there are no draws to
+     * report. Carries the upcoming schedule, which is the useful answer here.
+     */
+    | { tag: "NoGame"; at: FinalizedSnapshot; upcoming: GameSchedulePreview[] }
+    /** A game's draws, in airdrop-index order. */
+    | {
+          tag: "Draws";
+          at: FinalizedSnapshot;
+          gameIndex: number;
+          /**
+           * Where the draw count came from. `"caller"` means the count was
+           * supplied and the chain was not asked to confirm it — a wrong count
+           * silently shortens or pads this list.
+           */
+          drawCountFrom: "chain" | "caller";
+          /**
+           * The running game, when these draws belong to it. `null` for a
+           * caller-supplied game, whose read is skipped.
+           */
+          game: CurrentGame | null;
+          /** One entry per scheduled draw. Empty when the game scheduled none. */
+          draws: AirdropDraw[];
+      };
+
+/**
+ * **Not an authorization oracle.** The chain re-checks eligibility on claim, and a
+ * backend trusting a `Won` here is trivially spoofed.
+ *
+ * `Game.airdrop_event_id_base` escapes the pinned block — PAPI serves constants from
+ * the client's runtime — so it can only disagree across an upgrade mid-read.
+ */
+export async function readPrizeStatus(
+    chain: PrizeStatusChain,
+    options: ReadPrizeStatusOptions = {},
+): Promise<Result<PrizeStatus, ProductIndividualityError>> {
+    try {
+        return ok(await runPrizeStatusRead(chain, options));
+    } catch (cause) {
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+/** Throws; {@link readPrizeStatus} owns the `Result` boundary. */
+async function runPrizeStatusRead(
+    chain: PrizeStatusChain,
+    options: ReadPrizeStatusOptions,
+): Promise<PrizeStatus> {
+    const { registrant, game: captured, signal } = options;
+
+    // Pinned once here and handed to every inner read, which is the only reason
+    // this composition is safe to make.
+    const snapshot = await pinBlock(chain, signal);
+
+    const resolved = await resolveGame(chain, captured, snapshot, signal);
+    if (resolved.tag === "NoGame") {
+        return { tag: "NoGame", at: snapshot, upcoming: resolved.upcoming };
+    }
+
+    const base = await chain.individuality.constants.Game.airdrop_event_id_base();
+    const eventIds = gameAirdropEventIds({
+        base,
+        gameIndex: resolved.index,
+        airdropsScheduled: resolved.airdropsScheduled,
+    });
+
+    // Fanned out rather than sequential: the draws are independent point reads
+    // against a block that is already pinned, so ordering buys nothing.
+    const draws = await Promise.all(
+        eventIds.map((eventId) => runDrawRead(chain, { eventId, registrant, signal }, snapshot)),
+    );
+
+    return {
+        tag: "Draws",
+        at: snapshot,
+        gameIndex: resolved.index,
+        drawCountFrom: resolved.drawCountFrom,
+        game: resolved.game,
+        draws,
+    };
+}
+
+/** Which game's draws to report, and where its count came from. */
+type ResolvedGame =
+    | { tag: "NoGame"; upcoming: GameSchedulePreview[] }
+    | {
+          tag: "Game";
+          index: number;
+          airdropsScheduled: number;
+          drawCountFrom: "chain" | "caller";
+          game: CurrentGame | null;
+      };
+
+async function resolveGame(
+    chain: PrizeStatusChain,
+    captured: CapturedGame | undefined,
+    snapshot: FinalizedSnapshot,
+    signal: AbortSignal | undefined,
+): Promise<ResolvedGame> {
+    if (captured !== undefined) {
+        // The caller knows the game, so the four game reads would tell us nothing
+        // we are going to use.
+        return {
+            tag: "Game",
+            index: captured.index,
+            airdropsScheduled: captured.airdropsScheduled,
+            drawCountFrom: "caller",
+            game: null,
+        };
+    }
+
+    const current = await runGameRead(chain, { signal }, snapshot);
+    if (current.tag === "BetweenGames") {
+        // `lastGameIndex` names the game that just ended, but not its draw count,
+        // so it cannot stand in for a captured game. Reporting no draws here is
+        // honest; guessing a count would not be.
+        return { tag: "NoGame", upcoming: current.upcoming };
+    }
+
+    return {
+        tag: "Game",
+        index: current.game.index,
+        airdropsScheduled: current.game.airdropsScheduled,
+        drawCountFrom: "chain",
+        game: current.game,
+    };
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test } = import.meta.vitest;
+    const { unwrapOk, unwrapErr } = await import("@parity/result");
+    const { GAME_AIRDROP_EVENT_ID_BASE, gameAirdropEventId } = await import("./airdrop-ids.js");
+
+    const BLOCK = { hash: `0x${"77".repeat(32)}`, number: 4_242 };
+    const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const PLAY_TIME = 1_800_000_000;
+    const TICKET = `0x${"ee".repeat(32)}`;
+
+    const eventId = (gameIndex: number, airdropIndex: number) =>
+        gameAirdropEventId({ base: GAME_AIRDROP_EVENT_ID_BASE, gameIndex, airdropIndex });
+
+    interface FakeState {
+        /** Omit to put the chain between games. */
+        game?: { index: number; airdropsScheduled: number };
+        /** Event ids that hold a winning entry for ALICE. */
+        wins?: string[];
+        schedules?: number[];
+    }
+
+    /**
+     * A double spanning both halves of the surface, recording every read's block.
+     *
+     * The block is what most of this suite is about: a composition that pins per
+     * inner read still satisfies every value assertion.
+     */
+    function fakeChain(state: FakeState) {
+        const blocks: string[] = [];
+        let pins = 0;
+        const seen = (options: { at: string; signal?: AbortSignal }) => {
+            options.signal?.throwIfAborted();
+            blocks.push(options.at);
+        };
+
+        const chain: PrizeStatusChain = {
+            individuality: {
+                constants: {
+                    Game: {
+                        airdrop_event_id_base: async () => GAME_AIRDROP_EVENT_ID_BASE,
+                        DefaultPhaseDurations: async () => ({
+                            registration: 3_600,
+                            shuffle: 600,
+                            post_shuffle_margin: 300,
+                            reporting: 1_800,
+                            player_process: 900,
+                        }),
+                    },
+                },
+                query: {
+                    Game: {
+                        GameIndex: {
+                            getValue: async (o) => {
+                                seen(o);
+                                return state.game?.index ?? 40;
+                            },
+                        },
+                        Game: {
+                            getValue: async (o) => {
+                                seen(o);
+                                return state.game === undefined
+                                    ? undefined
+                                    : {
+                                          index: state.game.index,
+                                          registration_ends: PLAY_TIME - 900,
+                                          shuffle_deadline: PLAY_TIME - 300,
+                                          game_date: PLAY_TIME,
+                                          report_ends: PLAY_TIME + 1_800,
+                                          // A GameState variant, not an Airdrop
+                                          // Status one — the two enums share
+                                          // several names but not this one.
+                                          state: { type: "Reporting" },
+                                          max_group_size: 5,
+                                          rounds: 3,
+                                          pending_attendance: 0,
+                                          airdrops_scheduled: state.game.airdropsScheduled,
+                                      };
+                            },
+                        },
+                        GameSchedules: {
+                            getValue: async (o) => {
+                                seen(o);
+                                return (state.schedules ?? []).map((t) => ({
+                                    game_play_time: t,
+                                    rounds: 3,
+                                    max_group_size: 5,
+                                    airdrops: [],
+                                }));
+                            },
+                        },
+                        StoredPhaseDurations: {
+                            getValue: async (o) => {
+                                seen(o);
+                                return undefined;
+                            },
+                        },
+                    },
+                    Airdrop: {
+                        Events: {
+                            getValue: async (id, o) => {
+                                seen(o);
+                                return {
+                                    id,
+                                    info: {
+                                        prize: {
+                                            asset_id: {
+                                                parents: 1,
+                                                interior: { type: "Here", value: undefined },
+                                            },
+                                            asset_amount: 100n,
+                                            max_winners: 5,
+                                            winner_cap: 10_000,
+                                        },
+                                        registration_starts: 1n,
+                                        draw_time: 2n,
+                                        end_time: 3n,
+                                    },
+                                    status: {
+                                        type: "Claiming",
+                                        value: {
+                                            total_participants: 9,
+                                            effective_winners: 2,
+                                            claimed: 1,
+                                        },
+                                    },
+                                };
+                            },
+                        },
+                        Winners: {
+                            getValue: async (id, _entry, o) => {
+                                seen(o);
+                                return state.wins?.includes(id) ? TICKET : undefined;
+                            },
+                        },
+                        EventEntropy: {
+                            getValue: async (_id, o) => {
+                                seen(o);
+                                return undefined;
+                            },
+                        },
+                        Registrations: {
+                            getEntries: async (_id, o) => {
+                                seen(o);
+                                return [];
+                            },
+                        },
+                    },
+                },
+            },
+            raw: {
+                individuality: {
+                    getFinalizedBlock: async () => {
+                        pins += 1;
+                        return BLOCK;
+                    },
+                },
+            },
+        };
+        return { chain, blocks: () => blocks, pins: () => pins };
+    }
+
+    describe("readPrizeStatus, on the running game", () => {
+        test("reports one draw per scheduled airdrop, in index order", async () => {
+            const { chain } = fakeChain({ game: { index: 41, airdropsScheduled: 3 } });
+            const status = unwrapOk(await readPrizeStatus(chain));
+
+            expect(status.tag).toBe("Draws");
+            if (status.tag !== "Draws") return;
+            expect(status.gameIndex).toBe(41);
+            expect(status.drawCountFrom).toBe("chain");
+            expect(status.draws.map((d) => d.eventId)).toEqual([
+                eventId(41, 0),
+                eventId(41, 1),
+                eventId(41, 2),
+            ]);
+        });
+
+        test("pins one block and reads everything at it", async () => {
+            // The reason this function exists rather than a caller composing the
+            // two reads: those pin one block each.
+            const { chain, blocks, pins } = fakeChain({
+                game: { index: 41, airdropsScheduled: 2 },
+            });
+            const status = unwrapOk(await readPrizeStatus(chain));
+
+            expect(pins()).toBe(1);
+            expect(new Set(blocks())).toEqual(new Set([BLOCK.hash]));
+            expect(status.at).toEqual({ blockHash: BLOCK.hash, blockNumber: BLOCK.number });
+        });
+
+        test("carries the running game alongside its draws", async () => {
+            const { chain } = fakeChain({ game: { index: 41, airdropsScheduled: 1 } });
+            const status = unwrapOk(await readPrizeStatus(chain));
+            if (status.tag !== "Draws") throw new Error("expected Draws");
+
+            expect(status.game?.index).toBe(41);
+            expect(status.game?.phase).toBe("Reporting");
+        });
+
+        test("reports a win against the draw that holds it", async () => {
+            const { chain } = fakeChain({
+                game: { index: 41, airdropsScheduled: 3 },
+                wins: [eventId(41, 1)],
+            });
+            const status = unwrapOk(
+                await readPrizeStatus(chain, {
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            if (status.tag !== "Draws") throw new Error("expected Draws");
+
+            expect(status.draws.map((d) => d.outcome.tag)).toEqual(["NotWon", "Won", "NotWon"]);
+        });
+
+        test("without a registrant every outcome is Unchecked, not NotWon", async () => {
+            const { chain } = fakeChain({
+                game: { index: 41, airdropsScheduled: 2 },
+                wins: [eventId(41, 0)],
+            });
+            const status = unwrapOk(await readPrizeStatus(chain));
+            if (status.tag !== "Draws") throw new Error("expected Draws");
+
+            expect(status.draws.map((d) => d.outcome.tag)).toEqual(["Unchecked", "Unchecked"]);
+        });
+
+        test("a game with no draws is Draws with an empty list", async () => {
+            // The game exists, it just scheduled nothing. Distinct from NoGame.
+            const { chain } = fakeChain({ game: { index: 41, airdropsScheduled: 0 } });
+            const status = unwrapOk(await readPrizeStatus(chain));
+
+            expect(status.tag).toBe("Draws");
+            if (status.tag !== "Draws") return;
+            expect(status.draws).toEqual([]);
+        });
+    });
+
+    describe("readPrizeStatus, on a caller-supplied game", () => {
+        test("reports its draws without reading the game", async () => {
+            // The past-game case, which is the ordinary one for a claim: the game
+            // is gone and only the caller still knows its draw count.
+            const { chain, blocks } = fakeChain({ wins: [eventId(7, 0)] });
+            const status = unwrapOk(
+                await readPrizeStatus(chain, {
+                    game: { index: 7, airdropsScheduled: 1 },
+                    registrant: { tag: "Account", accountAddress: ALICE },
+                }),
+            );
+            if (status.tag !== "Draws") throw new Error("expected Draws");
+
+            expect(status.gameIndex).toBe(7);
+            expect(status.drawCountFrom).toBe("caller");
+            expect(status.draws[0]?.outcome).toEqual({ tag: "Won", ticket: TICKET });
+            // Three reads for the one draw, and none of the four game reads.
+            expect(blocks()).toHaveLength(3);
+        });
+
+        test("game is null even though a different game is running", async () => {
+            const { chain } = fakeChain({ game: { index: 41, airdropsScheduled: 2 } });
+            const status = unwrapOk(
+                await readPrizeStatus(chain, { game: { index: 7, airdropsScheduled: 1 } }),
+            );
+            if (status.tag !== "Draws") throw new Error("expected Draws");
+
+            expect(status.game).toBeNull();
+            expect(status.gameIndex).toBe(7);
+        });
+
+        test("a count above MAX_GAME_AIRDROPS arrives on the err channel", async () => {
+            const { chain } = fakeChain({});
+            const error = unwrapErr(
+                await readPrizeStatus(chain, { game: { index: 7, airdropsScheduled: 17 } }),
+            );
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+        });
+    });
+
+    describe("readPrizeStatus, between games", () => {
+        test("no running game and no captured one yields NoGame with the schedule", async () => {
+            const { chain } = fakeChain({ schedules: [PLAY_TIME] });
+            const status = unwrapOk(await readPrizeStatus(chain));
+
+            expect(status.tag).toBe("NoGame");
+            if (status.tag !== "NoGame") return;
+            expect(status.upcoming.map((s) => s.gamePlayTime)).toEqual([PLAY_TIME]);
+        });
+
+        test("does not fall back to lastGameIndex", async () => {
+            // The index is known there but the draw count is not, and a guessed
+            // count would read as "you won nothing".
+            const { chain, blocks } = fakeChain({});
+            const status = unwrapOk(await readPrizeStatus(chain));
+
+            expect(status.tag).toBe("NoGame");
+            // Four game reads and no draw reads.
+            expect(blocks()).toHaveLength(4);
+        });
+    });
+
+    describe("failures", () => {
+        test("an already-aborted signal costs no round trip", async () => {
+            const { chain, blocks, pins } = fakeChain({
+                game: { index: 41, airdropsScheduled: 2 },
+            });
+            const controller = new AbortController();
+            controller.abort();
+
+            const error = unwrapErr(await readPrizeStatus(chain, { signal: controller.signal }));
+            expect(error).toBeInstanceOf(ProductIndividualityError);
+            expect(pins()).toBe(0);
+            expect(blocks()).toHaveLength(0);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/prize-status.ts
+++ b/product-sdk/packages/individuality/src/prize-status.ts
@@ -60,7 +60,17 @@ export type PrizeStatus =
      * No game is running and the caller named none, so there are no draws to
      * report. Carries the upcoming schedule, which is the useful answer here.
      */
-    | { tag: "NoGame"; at: FinalizedSnapshot; upcoming: GameSchedulePreview[] }
+    | {
+          tag: "NoGame";
+          at: FinalizedSnapshot;
+          /**
+           * The game that just ended, which is the index a late claim is keyed by.
+           * Its draw count is still unknown, so pair it with a count you captured
+           * and pass both back as {@link ReadPrizeStatusOptions.game}.
+           */
+          lastGameIndex: number | null;
+          upcoming: GameSchedulePreview[];
+      }
     /** A game's draws, in airdrop-index order. */
     | {
           tag: "Draws";
@@ -112,7 +122,12 @@ async function runPrizeStatusRead(
 
     const resolved = await resolveGame(chain, captured, snapshot, signal);
     if (resolved.tag === "NoGame") {
-        return { tag: "NoGame", at: snapshot, upcoming: resolved.upcoming };
+        return {
+            tag: "NoGame",
+            at: snapshot,
+            lastGameIndex: resolved.lastGameIndex,
+            upcoming: resolved.upcoming,
+        };
     }
 
     const base = await chain.individuality.constants.Game.airdrop_event_id_base();
@@ -140,7 +155,7 @@ async function runPrizeStatusRead(
 
 /** Which game's draws to report, and where its count came from. */
 type ResolvedGame =
-    | { tag: "NoGame"; upcoming: GameSchedulePreview[] }
+    | { tag: "NoGame"; lastGameIndex: number | null; upcoming: GameSchedulePreview[] }
     | {
           tag: "Game";
           index: number;
@@ -172,7 +187,11 @@ async function resolveGame(
         // `lastGameIndex` names the game that just ended, but not its draw count,
         // so it cannot stand in for a captured game. Reporting no draws here is
         // honest; guessing a count would not be.
-        return { tag: "NoGame", upcoming: current.upcoming };
+        return {
+            tag: "NoGame",
+            lastGameIndex: current.lastGameIndex,
+            upcoming: current.upcoming,
+        };
     }
 
     return {
@@ -328,6 +347,12 @@ if (import.meta.vitest) {
                             getEntries: async (_id, o) => {
                                 seen(o);
                                 return [];
+                            },
+                        },
+                        SupportedAssets: {
+                            getValue: async (_a, o) => {
+                                seen(o);
+                                return 1n;
                             },
                         },
                     },

--- a/product-sdk/packages/individuality/src/read.ts
+++ b/product-sdk/packages/individuality/src/read.ts
@@ -28,11 +28,7 @@ import {
 import { ProductIndividualityError } from "./errors.js";
 import type { FinalizedSnapshot, PersonhoodParticipant, PersonhoodResult } from "./types.js";
 
-/** Options every storage read is given, so all six agree on one block. */
-interface ReadAt {
-    at: string;
-    signal?: AbortSignal;
-}
+import type { ReadAt } from "./pinned.js";
 
 /** `AccountToAlias`, narrowed to the contextual alias the read keys on. */
 export interface RawAccountAlias {

--- a/product-sdk/packages/sdk/src/identity/product-account.test.ts
+++ b/product-sdk/packages/sdk/src/identity/product-account.test.ts
@@ -90,9 +90,9 @@ describe("verifyContextAlias", () => {
         expect(verifyContextAlias("not-an-address", ALICE, CONTEXT)).toBe(false);
     });
 
-    // Guards the byte-level comparison: `addressesEqual` from
-    // @parity/product-sdk-address compares SS58 strings exactly and would
-    // return false here, silently narrowing behaviour.
+    // Guards the byte-level comparison. `addressesEqual` compared SS58 strings
+    // exactly until it was fixed to compare keys, so this is what would catch a
+    // regression back to a string compare.
     it("compares public keys, so it accepts an alias encoded at another prefix", () => {
         const alias = deriveContextAlias(ALICE, CONTEXT, 42);
         const reencoded = ss58Encode(ss58Decode(alias.address).publicKey, 0);

--- a/product-sdk/packages/sdk/src/individuality/contract.test.ts
+++ b/product-sdk/packages/sdk/src/individuality/contract.test.ts
@@ -24,7 +24,10 @@
 import type { getChainAPI } from "@parity/product-sdk-chain-client";
 import type { RingVRFProof as HostRingVRFProof } from "@parity/product-sdk-host";
 import type {
+    AirdropChain,
+    GameChain,
     IndividualityChain,
+    PrizeStatusChain,
     RingVRFProof as AsPersonRingVRFProof,
 } from "@parity/product-sdk-individuality";
 import { expect, test } from "vitest";
@@ -41,6 +44,23 @@ type DevnetClient = Awaited<ReturnType<typeof getChainAPI<"devnet">>>;
 type PaseoSatisfiesContract = Assert<PaseoClient extends IndividualityChain ? true : false>;
 type DevnetSatisfiesContract = Assert<DevnetClient extends IndividualityChain ? true : false>;
 
+// Separate from the personhood contract: reading draws needs neither `Resources`
+// nor `PeopleLite`. Both chains satisfy it, which is weaker than it looks — devnet's
+// event-id base is 28 bytes to paseo's 27, and `SizedHex<N>` erases `N`, so only the
+// length check in `airdrop-ids.ts` catches that.
+type PaseoSatisfiesAirdropContract = Assert<PaseoClient extends AirdropChain ? true : false>;
+type DevnetSatisfiesAirdropContract = Assert<DevnetClient extends AirdropChain ? true : false>;
+
+// Same again for the current-game contract, which shares no entry with either of
+// the other two — but paseo only, and that asymmetry is the point.
+type PaseoSatisfiesGameContract = Assert<PaseoClient extends GameChain ? true : false>;
+
+// Devnet's metadata predates the multi-airdrop game work — the 28-byte base above is
+// one symptom, `game-types.ts` lists the rest — so the game surface is paseo-only.
+// Asserted negatively on purpose: a devnet re-pin breaks this line, which is the
+// prompt to flip it positive and check the read against it.
+type DevnetPredatesTheGameContract = Assert<DevnetClient extends GameChain ? false : true>;
+
 // Negative control, kept type-only so it emits no runtime code. If
 // `IndividualityChain` ever stopped constraining, this flips to `false` and the
 // file fails to typecheck, which is what keeps the assertions above honest.
@@ -51,6 +71,65 @@ type ClientWithoutIndividuality = {
 };
 type RejectsBogusClient = Assert<
     ClientWithoutIndividuality extends IndividualityChain ? false : true
+>;
+type RejectsBogusAirdropClient = Assert<
+    ClientWithoutIndividuality extends AirdropChain ? false : true
+>;
+type RejectsBogusGameClient = Assert<ClientWithoutIndividuality extends GameChain ? false : true>;
+
+// `Game.Game` being optional is what makes "between games" representable at all,
+// and `GameIndex` / `GameSchedules` being `ValueQuery` is what lets the read treat
+// them as always answering. The structural contract pins the latter two by typing
+// them non-optional; this pins the first, which no assignability check would
+// catch — a suddenly-required `Game` would still satisfy an optional contract.
+type GameStorage = PaseoClient["individuality"]["query"]["Game"];
+type GameValue = Awaited<ReturnType<GameStorage["Game"]["getValue"]>>;
+type GameIsOptional = Assert<undefined extends GameValue ? true : false>;
+// Negative control: `GameIndex` is `ValueQuery`, so it must *not* admit undefined.
+type GameIndexValue = Awaited<ReturnType<GameStorage["GameIndex"]["getValue"]>>;
+type GameIndexIsNotOptional = Assert<undefined extends GameIndexValue ? false : true>;
+
+// The event id is derived from a runtime constant rather than a storage entry, so
+// the constant has to exist and still be a plain string. Its *width* cannot be
+// asserted here: PAPI's `SizedHex<N>` is `string & { __hexString?: N | unknown }`,
+// and the `| unknown` collapses every width to the same type, so `SizedHex<32>`
+// and `SizedHex<27>` are mutually assignable and any such assertion would pass
+// vacuously. The 27-byte expectation is enforced at runtime instead, by the
+// length check in `airdrop-ids.ts` and the pinned vectors beside it.
+type GameConstants = PaseoClient["individuality"]["constants"]["Game"];
+type EventIdBaseExists = Assert<"airdrop_event_id_base" extends keyof GameConstants ? true : false>;
+type AirdropEventIdBase = Awaited<ReturnType<GameConstants["airdrop_event_id_base"]>>;
+type EventIdBaseIsAString = Assert<AirdropEventIdBase extends string ? true : false>;
+
+// The composed prize-status read spans both pallets, so it is the intersection
+// that has to hold — and on paseo only, since it inherits `GameChain`.
+type PaseoSatisfiesPrizeStatusContract = Assert<
+    PaseoClient extends PrizeStatusChain ? true : false
+>;
+type DevnetPredatesThePrizeStatusContract = Assert<
+    DevnetClient extends PrizeStatusChain ? false : true
+>;
+
+// `Registrations` is keyed by the entropy slot with the entry as its *value*, so
+// `readDrawRegistration` can only work by scanning the event's prefix. Pinning the
+// arity here is what would catch a descriptor regeneration that added a reverse
+// index and made the scan unnecessary.
+type RegistrationsEntries = Awaited<
+    ReturnType<PaseoClient["individuality"]["query"]["Airdrop"]["Registrations"]["getEntries"]>
+>;
+type RegistrationsKeyIsEventIdAndSlot = Assert<
+    RegistrationsEntries[number]["keyArgs"] extends [unknown, unknown] ? true : false
+>;
+
+// `Winners` is a double map keyed by the registration entry, which is what makes
+// "did I win" a point lookup instead of a scan of every winner. If a descriptor
+// regeneration ever collapsed it to a single key, the read layer would silently
+// need rewriting, so the arity is pinned.
+type WinnersKey = Parameters<
+    PaseoClient["individuality"]["query"]["Airdrop"]["Winners"]["getValue"]
+>;
+type WinnersTakesTwoKeys = Assert<
+    WinnersKey extends [unknown, unknown, ...unknown[]] ? true : false
 >;
 
 // The write half declares its own `RingVRFProof` rather than importing the

--- a/product-sdk/packages/sdk/src/individuality/contract.test.ts
+++ b/product-sdk/packages/sdk/src/individuality/contract.test.ts
@@ -34,6 +34,7 @@ import type { getChainAPI } from "@parity/product-sdk-chain-client";
 import type { RingVRFProof as HostRingVRFProof } from "@parity/product-sdk-host";
 import type {
     AirdropChain,
+    ClaimChain,
     ConsumersChain,
     GameChain,
     IndividualityChain,
@@ -207,6 +208,25 @@ type SignUpWithAliasTakesTheDocumentedArgs = Assert<
 // as `any`, so this pins a shape that is missing `sig` and requires it to fail.
 type SignUpArgsWithoutSig = Pick<SignUpWithAliasArgs, "identifier_key" | "statement_account">;
 type RejectsSignUpArgsMissingSig = Assert<"sig" extends keyof SignUpArgsWithoutSig ? false : true>;
+
+// The claim is the one contract here that touches `tx` as well as storage. Paseo
+// only, like the game surface it composes with.
+type PaseoSatisfiesClaimContract = Assert<PaseoClient extends ClaimChain ? true : false>;
+type RejectsBogusClaimClient = Assert<ClientWithoutIndividuality extends ClaimChain ? false : true>;
+
+// `claim_airdrop`'s three arguments, pinned by name. `ClaimChain` types them
+// structurally, and PAPI encodes whatever object it is handed — so a renamed field
+// would encode as `undefined` and fail on chain with nothing local to point at it.
+type ClaimAirdropArgs = Parameters<GameTx["claim_airdrop"]>[0];
+type ClaimAirdropTakesTheDocumentedArgs = Assert<
+    "game_index" extends keyof ClaimAirdropArgs
+        ? "airdrop_index" extends keyof ClaimAirdropArgs
+            ? "beneficiary" extends keyof ClaimAirdropArgs
+                ? true
+                : false
+            : false
+        : false
+>;
 
 test("the individuality chain contract is asserted at compile time", () => {
     // The type assertions above are the test. This keeps vitest from reporting

--- a/product-sdk/pending-changesets/airdrop-draw-reads.md
+++ b/product-sdk/pending-changesets/airdrop-draw-reads.md
@@ -1,0 +1,103 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk": minor
+---
+
+**Read a prize draw: derive its event id, then read its state and winner at one pinned block.**
+
+A prize draw is an `Airdrop` pallet event, and no storage entry lists it. Its 32-byte id is
+derived from a base plus a counter, so the derivation is the entry point to every read here.
+Two pallets schedule draws through the same mechanism and their layouts differ:
+
+```ts
+import {
+    gameAirdropEventId,       // base(27) ++ airdrop_index(u8) ++ game_index(u32 BE)
+    peopleAirdropsEventId,    // base(24) ++ draw_index(u64 BE)
+    readAirdropDraw,
+    readGameAirdropEventIds,
+} from "@parity/product-sdk-individuality";
+
+const chain = await getChainAPI("paseo");
+const ids = await readGameAirdropEventIds(chain, { gameIndex, airdropsScheduled });
+if (!ids.ok) return;
+
+const draw = await readAirdropDraw(chain, {
+    eventId: ids.value[0],
+    registrant: { tag: "Account", accountAddress },
+});
+if (draw.ok && draw.value.outcome.tag === "Won") {
+    console.log(draw.value.outcome.ticket, draw.value.phase);
+}
+```
+
+`readGameAirdropEventIds` reads `Game.airdrop_event_id_base` from the chain rather than
+assuming it. That is the point of it: `GAME_AIRDROP_EVENT_ID_BASE` is exported for tests and
+offline callers, and a hardcoded copy would go on deriving ids for draws that do not exist if
+the base ever moved, with nothing local to notice. `PeopleAirdrops`' base is *not* exposed as a
+runtime constant, so that one is hardcoded and guarded by pinned vectors instead — there is
+nothing to read.
+
+**"Did I win" is a point lookup, not a scan.** `Airdrop.Winners` hashes the registration entry,
+so an identity is all it takes. Pass `registrant` and the outcome comes back as `Won` with the
+ticket, or `NotWon`. Omit it and the outcome is `Unchecked` — a third case on purpose, so "we
+did not ask" cannot be read as "did not win".
+
+**A draw that is not in storage is a success value, not an error.** It arrives as
+`phase: "Gone"` with `event: null`, which is the steady state for every past draw once the
+lifecycle cleans it up. It is not evidence the draw existed: an id that was never scheduled
+answers identically, and the chain cannot tell the two apart.
+
+**All reads share one finalized block**, like the personhood read, and the block is reported
+back on the result. A draw's phase and its winner set move together, so reading them a block
+apart can report a draw as still registering while it already holds its winners.
+
+The eight-variant chain `Status` is collapsed to a six-value `AirdropPhase`
+(`Upcoming`, `Registering`, `Drawing`, `Claiming`, `Settling`, `Gone`) for rendering, with the
+raw variant kept alongside it — the collapse is lossy, and an operator debugging a stalled draw
+needs to know whether it is waiting on randomness or already assigning winners.
+
+Three chain-data traps the compiler cannot catch, all handled here and all worth knowing if you
+read these entries yourself:
+
+- **`Status` fields are not uniform across its variants.** `total_participants` is absent in
+  `Scheduled` and `Finalizing`, `effective_winners` in `Scheduled` and `Registering`, and
+  `claimed` appears only from `Claiming` onwards. These are states a normal draw passes
+  through, so `?? 0` is wrong in production, not in a corner case: a `Finalizing` draw did have
+  participants, the chain just stopped carrying the figure. They map to `null`.
+- **`winner_cap` is a `Permill`** — parts per million, not a count and not a percentage.
+  Exported as `winnerCapPermill` so it cannot be spent as a number of winners.
+- **The prize is a foreign asset.** `prize.assetId` is an XCM location, so formatting
+  `assetAmount` with the chain's own `tokenDecimals` is wrong. Read `Assets.Metadata` for that
+  id and use its `decimals`.
+
+`AirdropChain` is typed structurally, like `IndividualityChain`, so a test double satisfies it
+and the package still needs no runtime dependency on `@parity/product-sdk-chain-client`. A
+compile-time assertion in `@parity/product-sdk` checks that a real `getChainAPI` client still
+satisfies it. One thing that assertion cannot cover: PAPI's `SizedHex<N>` erases `N`, so
+`SizedHex<27>` and `SizedHex<32>` are mutually assignable and the base's width is unassertable
+in the type system. It is checked at runtime instead, against a pinned vector.
+
+**`readDrawRegistration` is new, and separate on purpose.** Before a draw runs, an absent
+`Winners` entry means "not drawn yet" and says nothing about whether you entered.
+`Airdrop.Registrations` is keyed by the 32-byte entropy slot with the registration entry as its
+*value*, so there is no reverse index — and the slot is the schnorrkel-expanded VRF output, which
+not even the player who minted the VRF holds. Answering therefore means scanning every
+registration under the event:
+
+```ts
+const registration = await readDrawRegistration(chain, { eventId, registrant });
+// registration.value.slot         — the slot, which is also the ticket, or null
+// registration.value.entriesScanned — what the scan cost
+```
+
+It is its own call rather than a field on `readPrizeStatus` because the cost grows with the
+draw's participant count and nothing bounds it client-side. `entriesScanned` is reported so the
+cost is visible after the fact. Call it when a UI needs "you are in tonight's draw", not on every
+status poll.
+
+**Registration state is not read here.** "Am I registered, before the draw runs" is a prefix
+scan of every entry under the event: `Airdrop.Registrations` is keyed by the 32-byte entropy
+slot with the registration entry as its *value*, so there is no reverse index — and the slot is
+the schnorrkel-expanded VRF output, which not even the player who minted the VRF holds. The
+scan costs `total_participants` reads, unbounded from the client's side, so it does not belong
+inside a status call a UI polls.

--- a/product-sdk/pending-changesets/claim-prize.md
+++ b/product-sdk/pending-changesets/claim-prize.md
@@ -1,0 +1,67 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk": minor
+---
+
+**Claim a prize: check whether you can, build the call, and confirm afterwards that it landed.**
+
+```ts
+import { readClaimEligibility, claimPrizeTx, confirmClaim } from "@parity/product-sdk-individuality";
+import { submitAndWatch } from "@parity/product-sdk-tx";
+
+const check = await readClaimEligibility(chain, {
+    gameIndex, airdropIndex, registrant: { tag: "Account", accountAddress },
+});
+if (check.ok && check.value.claimable) {
+    const tx = claimPrizeTx(chain, { gameIndex, airdropIndex, beneficiary });
+    await submitAndWatch(tx, signer, { waitFor: "finalized" });
+}
+```
+
+**`Game.claim_airdrop` has five gates and only two are about personhood.** A caller checking
+recognition alone still gets `NotEligibleForAirdrop`, `NotClaiming`, `ClaimingWindowClosed` or
+`NoSuchWinner` back from the chain with nothing local to explain them:
+
+| Gate | On-chain error |
+|---|---|
+| recognized, or reached personhood | `Game.NotEligibleForAirdrop` |
+| `last_attended_game == game_index` | `Game.NotEligibleForAirdrop` |
+| the draw's status is `Claiming` | `Airdrop.NotClaiming` |
+| now is before the draw's `end_time` | `Airdrop.ClaimingWindowClosed` |
+| a `Winners` entry for this identity | `Airdrop.NoSuchWinner` |
+
+`ClaimEligibility.blockers` carries **every** cause rather than the first found — a UI that says
+"not recognized" while the window has also closed sends the player to fix the wrong thing.
+`deriveClaimEligibility` is the pure form, for a caller that already holds a draw and a
+participant.
+
+**The binding deadline is not a timestamp.** Attending the next game overwrites
+`last_attended_game` and closes the claim, usually well before the draw's `end_time`. So
+`ClaimWindow` reports `closesOnNextAttendance` alongside `endTime`, because a countdown alone
+misleads. The runtime's own comment contemplates relaxing `==` to `>=`, which would make that
+`false` — the comparison is in one place for that reason.
+
+**Resuming after a reload needs no subscription.** A successful claim *removes* the `Winners`
+row, so `confirmClaim` re-reads it: a ticket still present means the claim has not landed, and
+its absence means it has. That survives a reload, a dropped socket and a closed tab.
+
+The one caveat is honest in the type: if the draw has also left `Claiming`, the row could have
+been swept by the lifecycle instead, so the answer is `Unknown` rather than `Claimed`. Persist
+the ticket when you claim — it is the only local evidence separating "claimed" from "never won".
+
+**Submission stays with `@parity/product-sdk-tx`.** `claimPrizeTx` returns the unsigned PAPI
+transaction, so retries, batching and fee estimation work without this package knowing about
+them — the same split `withAsPerson` uses. For a person origin rather than a signed account, wrap
+the signer with `withAsPerson`; the call is identical, because `claim_airdrop` accepts both and
+derives the registration entry from whichever it got. The claim is `Pays::No`, so only a rejected
+one costs a fee.
+
+Two things worth knowing if you read these entries yourself. `Score.Participants` keys the alias
+variant `Person` where `Airdrop`'s registration entry calls it `Alias` — same identity, two
+spellings, and the wrong one reads nothing and looks like a missing record. And
+`readClaimEligibility` takes `now` in Unix **seconds**, defaulting to the device clock; pass the
+chain's own time if you have it, since a clock minutes fast will call a live window closed.
+
+**Also corrected:** `AirdropOutcome.NotWon` was documented as meaning "not drawn yet" or "did not
+win". It has a third meaning — **won and already claimed**, since claiming removes the row. The
+doc now says so.

--- a/product-sdk/pending-changesets/current-game-read.md
+++ b/product-sdk/pending-changesets/current-game-read.md
@@ -1,0 +1,68 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk": minor
+---
+
+**Read the current game: its phase, the deadline that phase runs to, and what is scheduled next.**
+
+```ts
+import { readCurrentGame } from "@parity/product-sdk-individuality";
+
+const chain = await getChainAPI("paseo");
+const result = await readCurrentGame(chain);
+if (!result.ok) return;
+
+if (result.value.tag === "Running") {
+    const { index, phase, nextDeadline, airdropsScheduled } = result.value.game;
+} else {
+    // No game right now — the chain's normal state between games.
+    const next = result.value.upcoming[0];
+}
+```
+
+**No game running is a success value, not an error.** One game exists at a time and each is
+killed when it ends, so `BetweenGames` is the state the chain is in most of the time. It carries
+`lastGameIndex` — the counter only moves when a game is *created*, so it still names the game
+that just ended, which is the index a prize from that game is claimed against. It is `null`
+before any game has ever existed, because games are numbered from 1.
+
+**The phase comes from the chain's `GameState`, never from comparing timestamps to a clock.**
+Transitions run in an offchain worker's own time, so a boundary can be in the past while its
+phase is still current. `nextDeadline` is selected from the stored boundary matching the phase,
+and is `null` for `PlayerProcess` and `Cancelling`, which end when their work finishes rather
+than at a time.
+
+**Stored boundaries and derived ones are kept apart on purpose.** A running game carries the
+boundaries it was created with, and `CurrentGame` reports those and never re-derives them —
+governance can change `Game.StoredPhaseDurations` afterwards, at which point a re-derivation
+would contradict the chain's own stored values. An upcoming schedule stores only its play time,
+so its boundaries have nowhere to come from *but* derivation: `GameSchedulePreview.timeline`
+mirrors the runtime's `GameTimes` trait, saturating arithmetic included, and is documented as a
+projection that moves if the durations do. `gameTimeline` is exported for callers doing their
+own reads.
+
+Also exported: `readCurrentGame` reports the `durations` its projections were built with, so a
+caller can tell which source they came from — `Game.StoredPhaseDurations` when governance has
+set an override, and the `Game.DefaultPhaseDurations` constant otherwise. The constant is read
+only in the fallback case, which keeps the one un-block-pinned value in this read out of the
+common path. PAPI serves constants from the client's current runtime rather than from a block,
+so it can only disagree with the pinned block across a runtime upgrade landing mid-read.
+
+Two counts that look interchangeable and are not. `CurrentGame.airdropsScheduled` is how many
+draws the game *actually* got — scheduling stops at the first failure — and is the count event
+ids may be derived from. `GameSchedulePreview.airdrops` is what a schedule *asks* for, useful
+for showing a prize before the game exists and wrong for deriving ids.
+
+**The game surface is paseo-only for now, and the descriptors say so.** The committed devnet
+metadata predates the multi-airdrop game work: its `GameSchedule` carries a single optional
+`airdrop_prize` rather than a list of draws, its `GameInfo` has no `airdrops_scheduled`, its
+`PhaseDurationValues` still carries the `airdrop_claim_window` that moved onto each draw, and
+its `Game.airdrop_event_id_base` is 28 bytes to paseo's 27 — a different event-id layout
+altogether. A devnet client therefore fails `GameChain` structurally, and the compile-time
+contract in `@parity/product-sdk` asserts that failure deliberately, so a re-pinned devnet
+breaks the assertion instead of leaving the read quietly unsupported.
+
+That last divergence is worth knowing if you derive event ids yourself: nothing in the type
+system catches it, because PAPI's `SizedHex<N>` erases `N` and a 28-byte base satisfies every
+signature a 27-byte one does. The length check in `gameAirdropEventId` is the whole guard, which
+is why it throws rather than padding or truncating.

--- a/product-sdk/pending-changesets/prize-status-read.md
+++ b/product-sdk/pending-changesets/prize-status-read.md
@@ -1,0 +1,49 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk": minor
+---
+
+**Read a game's prize draws and whether you won any of them, all at one block.**
+
+```ts
+import { readPrizeStatus } from "@parity/product-sdk-individuality";
+
+const status = await readPrizeStatus(chain, {
+    registrant: { tag: "Account", accountAddress },
+});
+if (status.ok && status.value.tag === "Draws") {
+    for (const draw of status.value.draws) {
+        if (draw.outcome.tag === "Won") console.log(draw.eventId, draw.phase);
+    }
+}
+```
+
+**This exists as one function because the composition is the hard part.** `readCurrentGame` and
+`readAirdropDraw` each pin their own finalized block when called alone, so assembling this by
+hand reads two blocks and can report a draw as still registering while it already holds its
+winners. `readPrizeStatus` pins once and hands the snapshot to every inner read.
+
+**Claiming after the game ends is the ordinary case, and it needs a count only you have.**
+`airdrops_scheduled` lives on `Game.Game`, which holds the *running* game — but a claim window
+runs to the draw's `end_time`, by which point the chain has moved on and the ended game's draw
+count is unreadable. So pass what you captured while it ran:
+
+```ts
+await readPrizeStatus(chain, { game: { index: 41, airdropsScheduled: 2 }, registrant });
+```
+
+Supplying `game` skips the game read entirely — four fewer storage reads — so `game` on the
+result is `null` even if that index happens to be the running one. The result reports
+`drawCountFrom: "chain" | "caller"` so a consumer knows which it got.
+
+**There is no probe fallback, deliberately.** Probing event ids upward cannot distinguish a draw
+that was cleaned up from one that was never scheduled, so a short answer would read as "you won
+nothing" — the one wrong answer that matters here. Between games with no captured game, the
+result is `NoGame` carrying the upcoming schedule, rather than a guess.
+
+`readPrizeStatus` deliberately does not scan `Airdrop.Registrations`; `readDrawRegistration`
+does, and ships in the same wave.
+
+Internally, block pinning moved into one place so the inner reads can share a snapshot. No public
+API changed for that, and `readCurrentGame` / `readAirdropDraw` still pin their own block when
+called directly.

--- a/product-sdk/pending-changesets/review-fixes-game-prize.md
+++ b/product-sdk/pending-changesets/review-fixes-game-prize.md
@@ -1,6 +1,6 @@
 ---
 "@parity/product-sdk-individuality": minor
-"@parity/product-sdk-address": patch
+"@parity/product-sdk-address": minor
 "@parity/product-sdk": minor
 ---
 
@@ -14,6 +14,10 @@ entered. It now compares decoded public keys. Aliases keep the case-insensitive 
 32-byte alias really is hex. `addressesEqual` in `@parity/product-sdk-address` had the
 same limitation and is fixed the same way, so it now returns true for one account written
 under two prefixes and still returns false, rather than throwing, for a malformed input.
+
+`@parity/product-sdk-address` takes a `minor` rather than a `patch` for two reasons the repo's
+convention names: `publicKeysEqual` is new public surface, and the `addressesEqual` change is
+breaking under pre-1.0 semver, since a comparison that returned false now returns true.
 
 **Behaviour change worth reading if you use `addressesEqual`.** It now compares the account, not
 the encoding, so two SS58 strings for one key are equal even when their network prefixes differ.

--- a/product-sdk/pending-changesets/review-fixes-game-prize.md
+++ b/product-sdk/pending-changesets/review-fixes-game-prize.md
@@ -1,0 +1,67 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk-address": patch
+"@parity/product-sdk": minor
+---
+
+**Fixes from review of the game and prize surface.**
+
+Two correctness fixes, both changing behaviour a caller can see.
+
+`readDrawRegistration` compared SS58 address strings, so the same account encoded under a
+different network prefix did not match and a player who was entered in a draw read as not
+entered. It now compares decoded public keys. Aliases keep the case-insensitive compare, since a
+32-byte alias really is hex. `addressesEqual` in `@parity/product-sdk-address` had the
+same limitation and is fixed the same way, so it now returns true for one account written
+under two prefixes and still returns false, rather than throwing, for a malformed input.
+
+**Behaviour change worth reading if you use `addressesEqual`.** It now compares the account, not
+the encoding, so two SS58 strings for one key are equal even when their network prefixes differ.
+Anything that relied on the old string compare to tell networks apart needs the prefix from
+`ss58Decode` instead. The doc comment above the function said the opposite until now, which is
+fixed too.
+
+The correctness comes at a cost: a non-matching pair is decoded, roughly 20 microseconds, where an
+exact match still short-circuits for nothing. That is fine per call and adds up in a loop, so
+`publicKeysEqual` is now exported for that case. Decode the address you are searching for once
+with `ss58Decode`, then compare keys against each candidate.
+
+`confirmClaim` mapped every non-claiming draw to one of two phases, so a draw still assigning
+winners was reported as though the lifecycle had swept the winner row, which reads as "the window
+is over". It now reports the draw's real phase, and an unrecognised status variant fails on the
+error channel instead of being reported as some existing phase, matching every other decode here.
+
+**`claim_airdrop` has six gates, not five.** The prize asset must still be enabled for airdrops,
+and the check was missing. That matters because `Pays::No` applies only on success, so a claim
+this library green-lit and the chain refused cost the caller a fee. `readClaimEligibility` now
+reads `Airdrop.SupportedAssets` and reports a `PrizeAssetDisabled` blocker.
+
+**Breaking, before anything shipped:** `ClaimBlocker`'s `AttendedALaterGame` is now
+`DidNotAttendThisGame`. The chain tests `last_attended_game == game_index`, so the blocker also
+fires for a player who attended an earlier game or none at all, and the old name made a product
+render "you played again" to someone who never played. Compare `lastAttendedGame` to the game
+index to tell the three cases apart. `ClaimInputs` also gains a required `prizeAssetEnabled`.
+
+`claimPrizeTx` returned `unknown`, so the usage in its own documentation did not typecheck when
+passed to `submitAndWatch`. `ClaimChain` is now generic in the transaction type and the type is
+inferred from the chain, so the documented call compiles with no type argument and no cast.
+
+`readPrizeStatus`'s `NoGame` result now carries `lastGameIndex`, the game that just ended. That is
+the index a late claim is keyed by, and it was being discarded even though the underlying read
+returned it, forcing a second call on a second block.
+
+`ClaimEligibility.window` now documents what it does: the draw's deadlines whenever the draw
+exists, independent of whether this caller can claim. Read `claimable` for that.
+
+`readClaimEligibility` no longer reports `PrizeAssetDisabled` for a draw whose event row is gone.
+There is no asset id to look up there, so the gate is not applicable rather than failed, and
+`DrawNotClaiming` already explains the situation. `ClaimInputs.prizeAssetEnabled` is
+`boolean | null` for that reason.
+
+The registration scan builds its comparison once instead of per entry, which halved the time on a
+10,000-entry draw in a local measurement. It also makes a malformed account address fail the same
+way every time, where before it threw only if the draw happened to contain an account entry and
+answered "not registered" otherwise.
+
+The `product-sdk-individuality` skill now documents the game, the draws and the claim, including
+the six gates, the fee on a refused claim, and why the claim deadline is not a timestamp.

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -210,6 +210,81 @@ if (!result.ok) {
 
 Both implement the cross-package `SdkError` marker, so `isSdkError(e)` from `@parity/product-sdk-errors` recognizes them. Error messages are fixed strings and never interpolate chain data.
 
+## The Game and Its Prize Draws
+
+Reading the game, its draws, and whether you won one. Every read pins a single finalized block and reports it, for the same reason the personhood read does.
+
+```ts
+import { readCurrentGame, readPrizeStatus } from "@parity/product-sdk-individuality";
+
+const game = await readCurrentGame(chain);
+if (game.ok && game.value.tag === "Running") {
+  console.log(game.value.game.phase, game.value.game.nextDeadline);
+}
+
+const status = await readPrizeStatus(chain, {
+  registrant: { tag: "Account", accountAddress },
+});
+if (status.ok && status.value.tag === "Draws") {
+  for (const draw of status.value.draws) {
+    if (draw.outcome.tag === "Won") console.log(draw.eventId, draw.phase);
+  }
+}
+```
+
+> **PASEO ONLY.** The committed devnet metadata predates this work: one optional prize per schedule instead of a draw list, no `airdrops_scheduled`, and a 28-byte event-id base against paseo's 27. A devnet client fails `GameChain` and the umbrella contract test asserts that on purpose.
+
+> **NO GAME RUNNING IS A SUCCESS VALUE.** One game exists at a time and each is killed when it ends, so `BetweenGames` and `NoGame` are the normal state, not errors. Both carry `lastGameIndex`, which is the index a late claim is keyed by.
+
+> **A DRAW NOT IN STORAGE IS A SUCCESS VALUE TOO.** It arrives as `phase: "Gone"`, the steady state for every past draw once the lifecycle cleans it up. It is not evidence the draw existed: an id that was never scheduled answers identically.
+
+### Claiming a prize
+
+```ts
+import { readClaimEligibility, claimPrizeTx, confirmClaim } from "@parity/product-sdk-individuality";
+import { submitAndWatch } from "@parity/product-sdk-tx";
+
+const check = await readClaimEligibility(chain, { gameIndex, airdropIndex, registrant });
+if (check.ok && check.value.claimable) {
+  await submitAndWatch(claimPrizeTx(chain, { gameIndex, airdropIndex, beneficiary }), signer);
+}
+```
+
+> **`claim_airdrop` HAS SIX GATES AND ONLY TWO ARE ABOUT PERSONHOOD.** Checking recognition alone still gets you `NotClaiming`, `ClaimingWindowClosed`, `AssetNotEnabled` or `NoSuchWinner` from the chain with nothing local to explain them. `ClaimEligibility.blockers` reports every cause, not the first, so a UI does not send someone to fix the wrong thing.
+
+The nine reasons a claim can be blocked, in the shape the seven personhood states use above:
+
+| `blockers[].tag` | Means |
+|---|---|
+| `NotAParticipant` | No `Score.Participants` record at all |
+| `NotRecognized` | Neither recognized nor over the personhood threshold |
+| `Suspended` | Recognition is suspended, which is not the same as never having had it |
+| `DidNotAttendThisGame` | `last_attended_game` is not this game. Covers never attended, attended an earlier one, or played again since. Compare `lastAttendedGame` to the game index to tell which |
+| `DrawNotClaiming` | The draw is not taking claims. `phase` says where it is instead |
+| `ClaimWindowClosed` | Past the draw's `end_time` |
+| `PrizeAssetDisabled` | The prize asset was disabled for airdrops. Nothing the player can do |
+| `NoPrize` | No winning entry, which includes already claimed |
+| `OutcomeUnchecked` | The draw was read without a registrant, so winning was never checked |
+
+`AirdropPhase` is `Upcoming`, `Registering`, `Drawing`, `Claiming`, `Settling` or `Gone`, where `Gone` is the row's absence rather than a chain status. `confirmClaim` answers `Claimed`, `Pending` or `Unknown`, the last when the row is gone but the draw has also left `Claiming`, so the lifecycle may have swept it instead.
+
+> **A REFUSED CLAIM COSTS A FEE.** `Pays::No` applies only on success, so a claim this library green-lights and the chain rejects costs the player money. That is why all six gates are pre-checked.
+
+> **THE DEADLINE IS NOT A TIMESTAMP.** Attending the next game overwrites `last_attended_game` and closes the claim, usually well before the draw's `end_time`. `ClaimWindow` reports `closesOnNextAttendance` next to `endTime` because a countdown alone misleads.
+
+> **THERE IS NO SUBSCRIPTION, AND NONE IS NEEDED.** A successful claim removes the `Winners` row, so `confirmClaim` re-reads it: a ticket still present means the claim has not landed. That survives a reload, a dropped socket and a closed tab, which a watch does not. Persist the ticket when you claim, it is the only local evidence separating "claimed" from "never won".
+
+### Game and Prize Gotchas
+
+- **`NotWon` means three things.** Not drawn yet, did not win, or won and already claimed, since claiming removes the row. `phase` separates the first from the rest; only a kept ticket or the `PrizeClaimed` event separates the last two.
+- **A past game's draw count is unreadable.** `airdrops_scheduled` lives on `Game.Game`, which holds only the running game, but claims outlive their game. Capture the count while the game runs and pass it as `game: { index, airdropsScheduled }`. There is no probe fallback, because a cleaned-up draw and one that never existed answer identically.
+- **The prize is a foreign asset.** `prize.assetId` is an XCM location, so formatting `assetAmount` with the chain's own `tokenDecimals` is wrong. Read `Assets.Metadata` for that id.
+- **`winnerCapPermill` is parts per million**, not a count and not a percent.
+- **`Status` counters are absent, not zero,** in the states that have not computed them. A `Finalizing` draw did have participants; the chain stopped reporting the figure.
+- **A running game's boundaries are stored, an upcoming one's are projected.** Governance can move the phase durations, so re-deriving a running game's boundaries would contradict storage. `GameTimeline` appears only on an upcoming schedule.
+- **`readDrawRegistration` is a prefix scan.** It answers "am I in tonight's draw" before the draw runs, which no point read can, but its cost grows with the participant count. Not for polling.
+- **`Score.Participants` spells the alias variant `Person`** where the airdrop registration entry calls it `Alias`. The wrong spelling reads nothing and looks like a missing record.
+
 ## Acting As a Person (Write)
 
 `withAsPerson` wraps a signer so the call dispatches under a person origin. It returns a `PolkadotSigner`, so submission stays with `@parity/product-sdk-tx` and nothing about `submitAndWatch` changes.


### PR DESCRIPTION
Part of #286.
Refs #291.

### Description

Adds the game and prize surface to `@parity/product-sdk-individuality`: what game is running, what prize draws it has, whether you won one, and claiming it.

The claim's alias origin comes from `withAsPerson`, added in #309.

### Changes

`individuality/src/airdrop-ids.ts` Event-id derivation for both schedulers, `base ++ index` layouts that no storage entry lists. `Game`'s base is read from the chain; `PeopleAirdrops`' never reaches metadata, so it is pinned with byte vectors.

`individuality/src/airdrop-types.ts`, `airdrop-decode.ts` Draw shapes and the `Status` to phase collapse. Covers three things the compiler cannot: absent-not-zero counters, `winner_cap` being a Permill, and `u64` second timestamps.

`individuality/src/airdrop-read.ts` `readAirdropDraw` at one pinned block. "Did I win" is a point lookup since `Winners` hashes the registration entry. `readDrawRegistration` is the prefix scan for "am I entered", separate because its cost grows with the participant count.

`individuality/src/game-types.ts`, `game-decode.ts`, `game-read.ts` `readCurrentGame`. The phase comes from the chain's `GameState`, never from comparing timestamps to a clock. A running game reports stored boundaries; only an upcoming schedule gets derived ones.

`individuality/src/prize-status.ts`, `pinned.ts` `readPrizeStatus` composes the two reads. One function because each pins its own block alone, so composing by hand reads two. `pinned.ts` holds the pinning.

`individuality/src/claim-types.ts`, `claim-derive.ts`, `claim.ts` `readClaimEligibility`, `claimPrizeTx`, `confirmClaim`. `claim_airdrop` has six gates and only two are about personhood, so `blockers` reports every cause. Submission stays with `@parity/product-sdk-tx`.

`address/src/display.ts`, `index.ts` `addressesEqual` compared SS58 strings, so one account under two network prefixes compared unequal. Now compares decoded keys. New `publicKeysEqual` for the loop case, since the correct comparison costs a decode.

`sdk/src/individuality/contract.test.ts` Compile-time assertions that a real `getChainAPI` client satisfies each chain interface. The only place that check is not vacuous.

`skills/product-sdk-individuality/SKILL.md` The game, the draws, the claim, the nine blocker tags. Plus five changesets.

### Why these changes

A product wanting "what game is on, did I win, can I claim" read the `Game` and `Airdrop` pallets by hand, and two products need the same logic. It also puts two easy-to-miss facts in types: a claim closes when the player next attends a game, a deadline with no timestamp, and a claimed prize is removed from `Winners`, so "no winning entry" also means "already claimed".

### Testing

```
cd product-sdk
pnpm install
pnpm --filter "@parity/product-sdk-individuality" build
pnpm -r test
pnpm --filter "@parity/product-sdk" typecheck
pnpm check
```

Build the individuality package before the umbrella typecheck, otherwise it resolves a stale `dist`. That typecheck is the load-bearing check: it proves a real client satisfies `AirdropChain`, `GameChain`, `PrizeStatusChain` and `ClaimChain`, where the same assertion inside the package passes even against a bogus contract.

Before, on the merge base: individuality 154 tests, address 36.
After: individuality 340, address 45, umbrella 148. 19 packages typecheck, `pnpm check` clean.

The individuality suite has twice reported one unexplained failure in the run right after a source edit, never reproducible after. If CI hits it, run vitest with `--reporter=verbose` and do not pipe through `grep`.
