### PR TITLE
feat(individuality): add the game sign-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,6 @@ When the user's question matches a skill, invoke it via the `Skill` tool rather 
 - `product-sdk-contracts` — contract calls (queries, txs).
 - `product-sdk-cloud-storage` — cloud-storage chain client.
 - `product-sdk-statement-store` — statement store.
-- `product-sdk-individuality` — personhood / membership state reads, and the account to username read.
+- `product-sdk-individuality` — personhood / membership state reads, the account to username read, the game and its prize draws, game sign-up, and the AsPerson extension.
 - `product-sdk-utilities` — address, crypto, logger, local-storage, utils.
 - `migrating-to-product-sdk` — porting from legacy stacks.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ TypeScript SDK for building products in the Polkadot ecosystem. Provides typed A
 | `@parity/product-sdk-contracts` | Typed contract interactions on Polkadot Asset Hub |
 | `@parity/product-sdk-cloud-storage` | Upload and retrieve data via Cloud Storage (currently backed by the Polkadot Bulletin Chain) |
 | `@parity/product-sdk-statement-store` | Publish/subscribe client for the Polkadot Statement Store |
-| `@parity/product-sdk-individuality` | Read a person's personhood state and the usernames an account holds, and dispatch calls under a person origin |
+| `@parity/product-sdk-individuality` | Read a person's personhood state, usernames, and the game and its prize draws, sign up for a game, and dispatch calls under a person origin |
 | `@parity/product-sdk-keys` | Hierarchical key derivation, session keys, and sr25519 product-account derivation |
 | `@parity/product-sdk-local-storage` | Key-value local storage with automatic host/browser backend detection |
 | `@parity/product-sdk-host` | Host container detection and storage access for Desktop/Mobile |
@@ -66,7 +66,7 @@ Or open a new Claude Code session and ask "build me a Polkadot app" — the `pro
 | `product-sdk-contracts` | Smart contract calls on Asset Hub (PolkaVM/Solidity) |
 | `product-sdk-cloud-storage` | CID-based upload/retrieve via Cloud Storage |
 | `product-sdk-statement-store` | Publish/subscribe on the Polkadot Statement Store |
-| `product-sdk-individuality` | Personhood / membership state reads, the account to username read, and the AsPerson extension |
+| `product-sdk-individuality` | Personhood / membership state reads, the account to username read, the game and its prize draws, game sign-up, and the AsPerson extension |
 | `product-sdk-utilities` | Addresses, crypto, encoding, token formatting, logging |
 | `migrating-to-product-sdk` | Porting an existing codebase from legacy stacks |
 

--- a/product-sdk/README.md
+++ b/product-sdk/README.md
@@ -13,7 +13,7 @@ TypeScript SDK for building products in the Polkadot ecosystem. Provides typed A
 | `@parity/product-sdk-contracts` | Typed contract interactions on Polkadot Asset Hub |
 | `@parity/product-sdk-cloud-storage` | Upload and retrieve data via Cloud Storage (currently backed by the Polkadot Bulletin Chain) |
 | `@parity/product-sdk-statement-store` | Publish/subscribe client for the Polkadot Statement Store |
-| `@parity/product-sdk-individuality` | Read a person's personhood state and the usernames an account holds, and dispatch calls under a person origin |
+| `@parity/product-sdk-individuality` | Read a person's personhood state, usernames, and the game and its prize draws, sign up for a game, and dispatch calls under a person origin |
 | `@parity/product-sdk-keys` | Hierarchical key derivation, session keys, and sr25519 product-account derivation |
 | `@parity/product-sdk-local-storage` | Key-value local storage with automatic host/browser backend detection |
 | `@parity/product-sdk-host` | Host container detection and storage access for Desktop/Mobile |

--- a/product-sdk/packages/individuality/package.json
+++ b/product-sdk/packages/individuality/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@parity/product-sdk-individuality",
-    "description": "Read a person's standing and usernames on the individuality chain, and dispatch calls under a person origin",
+    "description": "Read a person's standing, usernames, game and prize draws on the individuality chain, sign up for a game, and dispatch calls under a person origin",
     "version": "0.1.0",
     "type": "module",
     "main": "./dist/index.js",

--- a/product-sdk/packages/individuality/src/as-person-signer.ts
+++ b/product-sdk/packages/individuality/src/as-person-signer.ts
@@ -28,6 +28,9 @@
  * );
  * ```
  *
+ * The origin works, the call does not: `sig`, the statement-account proof, is a
+ * bare `blake2_256` hash and the host's `signRaw` always `<Bytes>`-wraps it.
+ *
  * Order inside `signTx` is not arbitrary, and getting it wrong produces a bad
  * proof with nothing local to read:
  *

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -66,6 +66,10 @@
  *     signer,
  * );
  * ```
+ *
+ * The origin works, the call does not: `sig`, the statement-account proof, is a
+ * bare `blake2_256` hash and the host's `signRaw` always `<Bytes>`-wraps it.
+ * `signup-types.ts` has the sign-up blockers.
  */
 
 // The seven-state union, its wrappers, and the pinned-block coordinates.

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -214,6 +214,37 @@ export type {
 export { readCurrentGame } from "./game-read.js";
 export type { GameChain, ReadCurrentGameOptions } from "./game-read.js";
 
+// Signing up for the game, and entering its prize draws in the same call. The
+// requirement read comes first because the event ids depend on the game index and
+// the draw count together, and the entry count must match `airdrops_scheduled`
+// exactly. Only the `Account` variant is buildable: the `Alias` one needs a
+// ring-VRF proof at a chain-chosen context, and every context a host will sign
+// under is derived from the product id. `signup-types.ts` has the detail.
+export type {
+    AccountVrfSignature,
+    AirdropVrfVariant,
+    GameSignUpRequirement,
+    SignUpBlocker,
+} from "./signup-types.js";
+export {
+    airdropVrfDomain,
+    airdropVrfTranscript,
+    AIRDROP_VRF_TRANSCRIPT_LABEL,
+} from "./signup-vrf.js";
+export type { VrfTranscript, VrfTranscriptItem } from "./signup-vrf.js";
+export {
+    mintAccountAirdropVrfs,
+    readGameSignUpRequirement,
+    signUpWithAccountTx,
+} from "./signup.js";
+export type {
+    AirdropVrfSigner,
+    MintAccountAirdropVrfsOptions,
+    ReadGameSignUpRequirementOptions,
+    SignUpChain,
+    SignUpWithAccountOptions,
+} from "./signup.js";
+
 // Claiming a prize. `claim_airdrop` has six gates and only two are about
 // personhood, so the predicate is exported separately from the read that feeds
 // it. Submission stays with `@parity/product-sdk-tx`: `claimPrizeTx` returns the

--- a/product-sdk/packages/individuality/src/signup-types.ts
+++ b/product-sdk/packages/individuality/src/signup-types.ts
@@ -43,6 +43,9 @@ export interface AccountVrfSignature {
  *
  * Several of these stop only the draws. {@link GameSignUpRequirement} is what
  * separates the two, not this type.
+ *
+ * A tag must name a condition that is true on its own, or it sends the player to
+ * fix the wrong thing.
  */
 export type SignUpBlocker =
     /** `Game.Game` is empty → `Game.NoGame`. */
@@ -59,6 +62,11 @@ export type SignUpBlocker =
     | { tag: "AlreadyRegistered" }
     /** Draws only. Recognized, so the chain wants `Alias` proofs no host can mint. */
     | { tag: "AliasVrfsUnavailable" }
+    /**
+     * Draws only. The account arm needs an account origin, the alias arm needs
+     * recognition, so an unrecognized person satisfies neither. They can sign up.
+     */
+    | { tag: "AccountVrfsNeedAnAccount" }
     /** Draws only. No draws scheduled, so anything but `None` fails the count check. */
     | { tag: "NoDrawsScheduled" }
     /**

--- a/product-sdk/packages/individuality/src/signup-types.ts
+++ b/product-sdk/packages/individuality/src/signup-types.ts
@@ -88,7 +88,11 @@ export interface GameSignUpRequirement {
     phase: GamePhase | null;
     /** Unix seconds. `null` between games. */
     registrationEnds: number | null;
-    /** Whether a sign-up call works at all, with or without draw entry. */
+    /**
+     * Whether the **chain** would accept a sign-up, with or without draw entry.
+     * Not whether this package can build one: an `Alias` registrant needs
+     * `sign_up_with_alias`, which cannot be assembled, and still reads `true`.
+     */
     canSignUp: boolean;
     /** Never true when {@link canSignUp} is false: the draws ride on the sign-up. */
     canEnterDraws: boolean;
@@ -96,7 +100,7 @@ export interface GameSignUpRequirement {
     variant: AirdropVrfVariant | null;
     /** `Game.airdrops_scheduled`. The `airdrops` list must have exactly this many entries. */
     airdropsScheduled: number;
-    /** Ids for indices `0..airdropsScheduled`, in the order entries must be supplied. */
+    /** Ids for airdrop indices `0` to `airdropsScheduled - 1`, in supply order. */
     eventIds: string[];
     /** Empty exactly when both {@link canSignUp} and {@link canEnterDraws} hold. */
     blockers: SignUpBlocker[];

--- a/product-sdk/packages/individuality/src/signup-types.ts
+++ b/product-sdk/packages/individuality/src/signup-types.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Game sign-up, and the prize-draw entry it carries.
+ *
+ * Sign-up and draw entry are one extrinsic: both sign-up calls take
+ * `airdrops: Option<AirdropVrfs>`, one entry per scheduled draw. `None` enters no
+ * draw.
+ *
+ * **The variant is not the caller's choice.** The chain picks it from `Score`
+ * recognition and rejects the other with `InvalidAirdropVrfVariantForRecognition`.
+ * `is_recognized()` is true only for `Recognized` and `ExternallyRecognized`, so
+ * `Suspended` takes `Account`.
+ *
+ * **`Alias` cannot be built.** It needs a ring-VRF proof at
+ * `blake2_256("pop:polkadot.network/airdrop" ++ event_id)`, and hosts only sign at
+ * `blake2b_256("product/" ++ productId ++ "/" ++ suffix)`, which they compute
+ * themselves. Fixing that is a chain or host change, not more code here. A
+ * recognized player can still sign up with an account, passing no draws.
+ */
+import type { GamePhase } from "./game-types.js";
+import type { FinalizedSnapshot } from "./types.js";
+
+/** Which variant the chain demands of this player. Read it, never choose it. */
+export type AirdropVrfVariant =
+    /** Not recognized: sr25519 VRFs from the signing account's own key. */
+    | "Account"
+    /** Recognized: ring-VRF membership proofs. Unbuildable, see the module doc. */
+    | "Alias";
+
+/** One `AirdropVrfs::Account` entry, shaped as the host's `signVrf` returns it. */
+export interface AccountVrfSignature {
+    /** 32 bytes. */
+    preOutput: Uint8Array;
+    /** 64 bytes, the DLEQ proof. */
+    proof: Uint8Array;
+}
+
+/**
+ * Why a sign-up, or the draw entry inside it, cannot go ahead. A list rather than
+ * the first hit: a player told "registration has closed" who is also already
+ * registered fixes the wrong thing.
+ *
+ * Several of these stop only the draws. {@link GameSignUpRequirement} is what
+ * separates the two, not this type.
+ */
+export type SignUpBlocker =
+    /** `Game.Game` is empty → `Game.NoGame`. */
+    | { tag: "NoGameRunning" }
+    /** Left the registration phase → `Game.NoRegistration`. */
+    | { tag: "NotInRegistration"; phase: GamePhase }
+    /**
+     * Past `registrationEnds` but still in the phase → `Game.NoRegistration`. The
+     * chain checks the clock as well as the state, and the offchain worker that
+     * moves the phase runs in its own time, so this is reachable.
+     */
+    | { tag: "RegistrationEnded"; registrationEnds: number }
+    /** `Game.Players[who].registered` → `Game.AlreadyRegistered`. */
+    | { tag: "AlreadyRegistered" }
+    /** Draws only. Recognized, so the chain wants `Alias` proofs no host can mint. */
+    | { tag: "AliasVrfsUnavailable" }
+    /** Draws only. No draws scheduled, so anything but `None` fails the count check. */
+    | { tag: "NoDrawsScheduled" }
+    /**
+     * Draws only, and only when the caller supplied `keyType`. The pallet
+     * reinterprets the account id **as** an sr25519 public key, so another scheme
+     * produces VRFs that cannot verify. Unreadable from chain state.
+     */
+    | { tag: "NotSr25519"; keyType: string };
+
+/**
+ * What the chain will accept from this player, at one pinned block. Index and draw
+ * count must come from the same block: an id built from one game's index and
+ * another's count addresses a draw that does not exist.
+ */
+export interface GameSignUpRequirement {
+    at: FinalizedSnapshot;
+    /** `null` between games. Not the `lastGameIndex` a late claim uses. */
+    gameIndex: number | null;
+    phase: GamePhase | null;
+    /** Unix seconds. `null` between games. */
+    registrationEnds: number | null;
+    /** Whether a sign-up call works at all, with or without draw entry. */
+    canSignUp: boolean;
+    /** Never true when {@link canSignUp} is false: the draws ride on the sign-up. */
+    canEnterDraws: boolean;
+    /** `null` between games, where recognition is known but there is nothing to enter. */
+    variant: AirdropVrfVariant | null;
+    /** `Game.airdrops_scheduled`. The `airdrops` list must have exactly this many entries. */
+    airdropsScheduled: number;
+    /** Ids for indices `0..airdropsScheduled`, in the order entries must be supplied. */
+    eventIds: string[];
+    /** Empty exactly when both {@link canSignUp} and {@link canEnterDraws} hold. */
+    blockers: SignUpBlocker[];
+}

--- a/product-sdk/packages/individuality/src/signup-vrf.ts
+++ b/product-sdk/packages/individuality/src/signup-vrf.ts
@@ -98,7 +98,9 @@ export function airdropVrfTranscript(options: {
             { label: ascii("domain"), value: airdropVrfDomain(options.eventId) },
             {
                 label: ascii("signer"),
-                value: sized(options.publicKey, PUBLIC_KEY_BYTES, "signer key"),
+                // Copied: the other two items allocate, so this is the only path
+                // where a caller mutating its buffer would change the transcript.
+                value: Uint8Array.from(sized(options.publicKey, PUBLIC_KEY_BYTES, "signer key")),
             },
         ],
     };

--- a/product-sdk/packages/individuality/src/signup-vrf.ts
+++ b/product-sdk/packages/individuality/src/signup-vrf.ts
@@ -1,0 +1,181 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The Merlin transcript an `AirdropVrfs::Account` entry signs, mirroring
+ * `indiv_pallet_airdrop::vrf::transcript_for_event`:
+ *
+ * ```
+ * label          = "pop:airdrop"
+ * item "domain"  = "pop:airdrop" ‖ event_id(32)
+ * item "signer"  = sr25519 public key(32)
+ * ```
+ *
+ * Neither constant reaches metadata, unlike `Game`'s event-id base, so the pinned
+ * vectors below are the only guard.
+ *
+ * Two bindings that are easy to get wrong. `signer` must be the account that signs
+ * the sign-up, since the pallet reinterprets the account id *as* the public key.
+ * And entry `i` binds to airdrop index `i`, where one mismatch fails the whole
+ * sign-up, deposit included.
+ *
+ * No workspace package is imported here, so these tests run against an unbuilt tree.
+ */
+import { ProductIndividualityError } from "./errors.js";
+
+/** `VRF_TRANSCRIPT_LABEL`, which is also the domain item's prefix. */
+export const AIRDROP_VRF_TRANSCRIPT_LABEL = "pop:airdrop";
+
+/** Merlin `append_message(label, value)`, as the host's `signVrf` takes it. */
+export interface VrfTranscriptItem {
+    label: Uint8Array;
+    value: Uint8Array;
+}
+
+export interface VrfTranscript {
+    label: Uint8Array;
+    /** `domain` then `signer`. The order is part of the message. */
+    items: VrfTranscriptItem[];
+}
+
+const EVENT_ID_BYTES = 32;
+const PUBLIC_KEY_BYTES = 32;
+
+const ascii = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+/** 32 bytes from `0x` hex or raw bytes. Anything else is a caller error. */
+function eventIdBytes(eventId: string | Uint8Array): Uint8Array {
+    if (eventId instanceof Uint8Array) {
+        return sized(eventId, EVENT_ID_BYTES, "event id");
+    }
+    if (!eventId.startsWith("0x")) {
+        throw new ProductIndividualityError("airdrop event id must be 0x-prefixed hex");
+    }
+    const digits = eventId.slice(2);
+    if (digits.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(digits)) {
+        throw new ProductIndividualityError("airdrop event id is not valid hex");
+    }
+    const bytes = new Uint8Array(digits.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = Number.parseInt(digits.slice(i * 2, i * 2 + 2), 16);
+    }
+    return sized(bytes, EVENT_ID_BYTES, "event id");
+}
+
+function sized(bytes: Uint8Array, length: number, what: string): Uint8Array {
+    if (bytes.length !== length) {
+        throw new ProductIndividualityError(`airdrop VRF ${what} must be ${length} bytes`);
+    }
+    return bytes;
+}
+
+/**
+ * `domain_for_event`: label bytes then the event id. Exported as the one part
+ * worth checking against a chain-side value.
+ */
+export function airdropVrfDomain(eventId: string | Uint8Array): Uint8Array {
+    const label = ascii(AIRDROP_VRF_TRANSCRIPT_LABEL);
+    const id = eventIdBytes(eventId);
+    const domain = new Uint8Array(label.length + id.length);
+    domain.set(label, 0);
+    domain.set(id, label.length);
+    return domain;
+}
+
+/**
+ * The transcript for one draw.
+ *
+ * @param options.publicKey - 32 bytes. The scheme is not checkable here, so an
+ *   ed25519 account yields a well-formed transcript and an unverifiable VRF.
+ * @throws ProductIndividualityError on a malformed event id or a wrong-width key.
+ */
+export function airdropVrfTranscript(options: {
+    eventId: string | Uint8Array;
+    publicKey: Uint8Array;
+}): VrfTranscript {
+    return {
+        label: ascii(AIRDROP_VRF_TRANSCRIPT_LABEL),
+        items: [
+            { label: ascii("domain"), value: airdropVrfDomain(options.eventId) },
+            {
+                label: ascii("signer"),
+                value: sized(options.publicKey, PUBLIC_KEY_BYTES, "signer key"),
+            },
+        ],
+    };
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test } = import.meta.vitest;
+
+    /** Hand-rolled: a vector sharing an encoder with the code under test pins nothing. */
+    const hex = (bytes: Uint8Array): string =>
+        [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+    const EVENT_ID = `0x${"ab".repeat(32)}`;
+    const KEY = new Uint8Array(32).fill(0x11);
+
+    describe("the pinned label", () => {
+        test("is the pallet's VRF_TRANSCRIPT_LABEL, 11 bytes", () => {
+            expect(AIRDROP_VRF_TRANSCRIPT_LABEL).toBe("pop:airdrop");
+            expect(new TextEncoder().encode(AIRDROP_VRF_TRANSCRIPT_LABEL)).toHaveLength(11);
+        });
+    });
+
+    describe("airdropVrfDomain", () => {
+        test("is the label followed by the event id, 43 bytes", () => {
+            const domain = airdropVrfDomain(EVENT_ID);
+            expect(domain).toHaveLength(43);
+            expect(hex(domain)).toBe(
+                `${hex(new TextEncoder().encode("pop:airdrop"))}${"ab".repeat(32)}`,
+            );
+        });
+
+        test("takes raw bytes identically to hex", () => {
+            const bytes = new Uint8Array(32).fill(0xab);
+            expect(hex(airdropVrfDomain(bytes))).toBe(hex(airdropVrfDomain(EVENT_ID)));
+        });
+
+        test("rejects an event id of the wrong width", () => {
+            // 31 bytes still makes a plausible-looking domain, addressing no draw.
+            expect(() => airdropVrfDomain(`0x${"ab".repeat(31)}`)).toThrow(
+                ProductIndividualityError,
+            );
+        });
+
+        test("rejects an unprefixed or malformed id", () => {
+            expect(() => airdropVrfDomain("ab".repeat(32))).toThrow(ProductIndividualityError);
+            expect(() => airdropVrfDomain(`0x${"zz".repeat(32)}`)).toThrow(
+                ProductIndividualityError,
+            );
+        });
+    });
+
+    describe("airdropVrfTranscript", () => {
+        test("binds domain then signer, in that order", () => {
+            const transcript = airdropVrfTranscript({ eventId: EVENT_ID, publicKey: KEY });
+
+            expect(new TextDecoder().decode(transcript.label)).toBe("pop:airdrop");
+            expect(transcript.items.map((item) => new TextDecoder().decode(item.label))).toEqual([
+                "domain",
+                "signer",
+            ]);
+            expect(hex(transcript.items[0].value)).toBe(hex(airdropVrfDomain(EVENT_ID)));
+            expect(hex(transcript.items[1].value)).toBe("11".repeat(32));
+        });
+
+        test("gives two events different domains and the same signer", () => {
+            const a = airdropVrfTranscript({ eventId: `0x${"01".repeat(32)}`, publicKey: KEY });
+            const b = airdropVrfTranscript({ eventId: `0x${"02".repeat(32)}`, publicKey: KEY });
+
+            expect(hex(a.items[0].value)).not.toBe(hex(b.items[0].value));
+            expect(hex(a.items[1].value)).toBe(hex(b.items[1].value));
+        });
+
+        test("rejects a key that is not 32 bytes", () => {
+            // A 33-byte ecdsa key is the realistic way to reach this.
+            expect(() =>
+                airdropVrfTranscript({ eventId: EVENT_ID, publicKey: new Uint8Array(33) }),
+            ).toThrow(ProductIndividualityError);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/signup.ts
+++ b/product-sdk/packages/individuality/src/signup.ts
@@ -3,21 +3,43 @@
 /**
  * Signing up for the game, and entering its prize draws in the same call.
  *
- * Three steps, in order, each needing the previous one's output:
+ * Two signers: no object satisfies both this package and `submitAndWatch`.
+ * `publicKey` must be the key `vrfSigner` binds, or the VRFs verify against
+ * nothing.
  *
  * ```ts
+ * const vrfSigner = {
+ *     signVrf: (label, items) =>
+ *         accounts.signVrf(account, label, items).match(
+ *             (sig) => sig,
+ *             (cause) => {
+ *                 throw cause;
+ *             },
+ *         ),
+ * };
+ *
  * const req = await readGameSignUpRequirement(chain, { registrant });
- * if (req.ok && req.value.canEnterDraws) {
- *     const vrfs = await mintAccountAirdropVrfs(signer, {
+ * if (!req.ok || !req.value.canSignUp) return;
+ *
+ * // A recognized player has canSignUp true and canEnterDraws false, and must
+ * // still be signed up.
+ * let airdrops;
+ * if (req.value.canEnterDraws) {
+ *     const vrfs = await mintAccountAirdropVrfs(vrfSigner, {
  *         eventIds: req.value.eventIds,
  *         publicKey: account.publicKey,
  *     });
- *     if (vrfs.ok) {
- *         // Throws on a wrong-width identifier key, the one input a caller owns.
- *         const tx = signUpWithAccountTx(chain, { identifierKey, airdrops: vrfs.value });
- *         await submitAndWatch(tx, signer, { waitFor: "finalized" });
- *     }
+ *     if (!vrfs.ok) return;
+ *     airdrops = vrfs.value;
  * }
+ *
+ * // Throws on a wrong-width key or a count mismatch.
+ * const tx = signUpWithAccountTx(chain, {
+ *     identifierKey,
+ *     airdrops,
+ *     airdropsScheduled: req.value.airdropsScheduled,
+ * });
+ * await submitAndWatch(tx, txSigner, { waitFor: "finalized" });
  * ```
  *
  * Submission stays with `@parity/product-sdk-tx`, as for `claimPrizeTx`.
@@ -240,8 +262,13 @@ function isRecognized(recognition: string): boolean {
 }
 
 /**
+ * An sr25519 VRF over one draw's transcript.
+ *
+ * Wire this to `AccountsProvider.signVrf(account, label, items)`. Neither host
+ * call satisfies it directly, since both take the account first, so the adapter
+ * closes over it and unwraps the `Result`. The module doc has one.
+ *
  * Structural, so the package keeps no dependency on `@parity/product-sdk-host`.
- * `AccountsProvider.signVrf` satisfies it once its `ResultAsync` is unwrapped.
  */
 export interface AirdropVrfSigner {
     signVrf(transcriptLabel: Uint8Array, items: VrfTranscriptItem[]): Promise<AccountVrfSignature>;
@@ -291,8 +318,14 @@ export interface SignUpWithAccountOptions {
      * never interpreted by the chain; it is how co-players reach each other.
      */
     identifierKey: Uint8Array;
-    /** Omit to enter no draw. Length must equal `airdropsScheduled`. */
+    /** Omit to enter no draw. Length must equal {@link airdropsScheduled}. */
     airdrops?: AccountVrfSignature[];
+    /**
+     * From {@link GameSignUpRequirement}, checked against `airdrops` when both are
+     * given. A mismatch fails the whole sign-up on chain with the deposit taken,
+     * and is reachable by re-reading the requirement between minting and building.
+     */
+    airdropsScheduled?: number;
 }
 
 const IDENTIFIER_KEY_BYTES = 65;
@@ -306,8 +339,9 @@ const VRF_PROOF_BYTES = 64;
  * No `Alias` argument: a recognized player needs one that cannot be produced, and
  * an argument that always fails on chain is worse than none.
  *
- * @throws ProductIndividualityError on a wrong-width key or signature, checked
- *   because the chain's own failure rejects the sign-up with nothing to inspect.
+ * @throws ProductIndividualityError on a wrong-width key or signature, or an
+ *   airdrop count that disagrees with `airdropsScheduled`. Checked because the
+ *   chain's own failure rejects the sign-up with nothing to inspect.
  */
 export function signUpWithAccountTx<Tx>(
     chain: SignUpChain<Tx>,
@@ -316,6 +350,16 @@ export function signUpWithAccountTx<Tx>(
     if (options.identifierKey.length !== IDENTIFIER_KEY_BYTES) {
         throw new ProductIndividualityError(
             `game sign-up identifier key must be ${IDENTIFIER_KEY_BYTES} bytes`,
+        );
+    }
+    const count = options.airdrops?.length;
+    if (
+        options.airdropsScheduled !== undefined &&
+        count !== undefined &&
+        count !== options.airdropsScheduled
+    ) {
+        throw new ProductIndividualityError(
+            `game sign-up needs one airdrop VRF per scheduled draw, got ${count} for ${options.airdropsScheduled}`,
         );
     }
 
@@ -732,6 +776,34 @@ if (import.meta.vitest) {
                 identifier_key: `0x${"22".repeat(65)}`,
                 airdrops: { type: "Account", value: [] },
             });
+        });
+
+        test("rejects an airdrop count that disagrees with the schedule", () => {
+            // Both sides optional, so only a stated disagreement throws.
+            const { chain } = fakeChain();
+            const one = [{ preOutput: new Uint8Array(32), proof: new Uint8Array(64) }];
+
+            expect(() =>
+                signUpWithAccountTx(chain, {
+                    identifierKey: IDENTIFIER,
+                    airdrops: one,
+                    airdropsScheduled: 2,
+                }),
+            ).toThrow(ProductIndividualityError);
+
+            expect(() =>
+                signUpWithAccountTx(chain, {
+                    identifierKey: IDENTIFIER,
+                    airdrops: one,
+                    airdropsScheduled: 1,
+                }),
+            ).not.toThrow();
+            expect(() =>
+                signUpWithAccountTx(chain, { identifierKey: IDENTIFIER, airdrops: one }),
+            ).not.toThrow();
+            expect(() =>
+                signUpWithAccountTx(chain, { identifierKey: IDENTIFIER, airdropsScheduled: 2 }),
+            ).not.toThrow();
         });
 
         test("rejects a wrong-width identifier key and signature", () => {

--- a/product-sdk/packages/individuality/src/signup.ts
+++ b/product-sdk/packages/individuality/src/signup.ts
@@ -161,9 +161,6 @@ export async function readGameSignUpRequirement(
         if (player?.registered === true) {
             blockers.push({ tag: "AlreadyRegistered" });
         }
-        if (options.keyType !== undefined && options.keyType !== "sr25519" && !recognized) {
-            blockers.push({ tag: "NotSr25519", keyType: options.keyType });
-        }
 
         if (game.tag === "BetweenGames") {
             // Only `NoGameRunning`: anything gathered above is about draw entry,
@@ -193,6 +190,9 @@ export async function readGameSignUpRequirement(
 
         // What the chain demands, which stays `Account` for an unrecognized person
         // who cannot supply it. The blocker says why not.
+        //
+        // Every draw-entry blocker lives in this one chain, below the count check,
+        // so none of them can name a reason for a draw that does not exist.
         const variant: AirdropVrfVariant = recognized ? "Alias" : "Account";
         if (airdropsScheduled === 0) {
             blockers.push({ tag: "NoDrawsScheduled" });
@@ -200,6 +200,8 @@ export async function readGameSignUpRequirement(
             blockers.push({ tag: "AliasVrfsUnavailable" });
         } else if (registrant.tag === "Alias") {
             blockers.push({ tag: "AccountVrfsNeedAnAccount" });
+        } else if (options.keyType !== undefined && options.keyType !== "sr25519") {
+            blockers.push({ tag: "NotSr25519", keyType: options.keyType });
         }
 
         const eventIds =
@@ -613,6 +615,21 @@ if (import.meta.vitest) {
             );
 
             expect(value.blockers).toEqual([{ tag: "NoGameRunning" }]);
+        });
+
+        test("a game with no draws does not also blame the key", async () => {
+            // The key blocker used to sit above the game read, so it named a
+            // reason for draws that were never scheduled.
+            const { chain } = fakeChain({ game: { ...RUNNING_GAME, airdrops_scheduled: 0 } });
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, {
+                    registrant,
+                    keyType: "ed25519",
+                    now: 1_000,
+                }),
+            );
+
+            expect(value.blockers).toEqual([{ tag: "NoDrawsScheduled" }]);
         });
 
         test("a known non-sr25519 key blocks the draws, not the sign-up", async () => {

--- a/product-sdk/packages/individuality/src/signup.ts
+++ b/product-sdk/packages/individuality/src/signup.ts
@@ -13,6 +13,7 @@
  *         publicKey: account.publicKey,
  *     });
  *     if (vrfs.ok) {
+ *         // Throws on a wrong-width identifier key, the one input a caller owns.
  *         const tx = signUpWithAccountTx(chain, { identifierKey, airdrops: vrfs.value });
  *         await submitAndWatch(tx, signer, { waitFor: "finalized" });
  *     }
@@ -42,6 +43,21 @@ import type {
     GameSignUpRequirement,
     SignUpBlocker,
 } from "./signup-types.js";
+
+/**
+ * Which blockers stop only the draw entry. Exhaustive so a new tag fails to
+ * compile until classified, rather than silently blocking the extrinsic.
+ */
+const DRAW_ONLY = {
+    NoGameRunning: false,
+    NotInRegistration: false,
+    RegistrationEnded: false,
+    AlreadyRegistered: false,
+    AliasVrfsUnavailable: true,
+    AccountVrfsNeedAnAccount: true,
+    NoDrawsScheduled: true,
+    NotSr25519: true,
+} satisfies Record<SignUpBlocker["tag"], boolean>;
 
 /** The chain's `AirdropVrfs`. `Alias` is never constructed, only declared. */
 type AirdropVrfsArg =
@@ -100,7 +116,7 @@ export interface ReadGameSignUpRequirementOptions {
      * Only `"sr25519"` can mint `Account` VRFs, and no chain read reveals the
      * scheme. Pass it for a `NotSr25519` blocker, omit it and the check is yours.
      */
-    keyType?: string;
+    keyType?: "sr25519" | "ed25519" | "ecdsa";
     /** Unix **seconds**; defaults to the device clock. */
     now?: number;
     signal?: AbortSignal;
@@ -150,7 +166,8 @@ export async function readGameSignUpRequirement(
         }
 
         if (game.tag === "BetweenGames") {
-            blockers.push({ tag: "NoGameRunning" });
+            // Only `NoGameRunning`: anything gathered above is about draw entry,
+            // and there is no draw here.
             return ok({
                 at: snapshot,
                 gameIndex: null,
@@ -161,7 +178,7 @@ export async function readGameSignUpRequirement(
                 variant: null,
                 airdropsScheduled: 0,
                 eventIds: [],
-                blockers,
+                blockers: [{ tag: "NoGameRunning" }],
             });
         }
 
@@ -174,11 +191,15 @@ export async function readGameSignUpRequirement(
             blockers.push({ tag: "RegistrationEnded", registrationEnds });
         }
 
+        // What the chain demands, which stays `Account` for an unrecognized person
+        // who cannot supply it. The blocker says why not.
         const variant: AirdropVrfVariant = recognized ? "Alias" : "Account";
-        if (recognized) {
-            blockers.push({ tag: "AliasVrfsUnavailable" });
-        } else if (airdropsScheduled === 0) {
+        if (airdropsScheduled === 0) {
             blockers.push({ tag: "NoDrawsScheduled" });
+        } else if (recognized) {
+            blockers.push({ tag: "AliasVrfsUnavailable" });
+        } else if (registrant.tag === "Alias") {
+            blockers.push({ tag: "AccountVrfsNeedAnAccount" });
         }
 
         const eventIds =
@@ -190,10 +211,8 @@ export async function readGameSignUpRequirement(
                       airdropsScheduled,
                   });
 
-        // The rest stop only the draws. This split is what lets a recognized
-        // player sign up.
-        const drawOnly = new Set(["AliasVrfsUnavailable", "NoDrawsScheduled", "NotSr25519"]);
-        const canSignUp = blockers.every((blocker) => drawOnly.has(blocker.tag));
+        // This split is what lets a recognized player sign up.
+        const canSignUp = blockers.every((blocker) => DRAW_ONLY[blocker.tag]);
 
         return ok({
             at: snapshot,
@@ -367,7 +386,7 @@ if (import.meta.vitest) {
             player?: unknown;
         } = {},
     ) {
-        const calls: { tx: unknown[] } = { tx: [] };
+        const calls: { tx: unknown[]; keys: Record<string, unknown> } = { tx: [], keys: {} };
         const chain = {
             raw: {
                 individuality: {
@@ -390,10 +409,22 @@ if (import.meta.vitest) {
                         },
                         GameSchedules: { getValue: async () => [] },
                         StoredPhaseDurations: { getValue: async () => undefined },
-                        Players: { getValue: async () => overrides.player },
+                        // Both doubles record the key: `playerKey` is the only
+                        // logic here that fails silently, by reading nothing.
+                        Players: {
+                            getValue: async (key: unknown) => {
+                                calls.keys.players = key;
+                                return overrides.player;
+                            },
+                        },
                     },
                     Score: {
-                        Participants: { getValue: async () => overrides.participant },
+                        Participants: {
+                            getValue: async (key: unknown) => {
+                                calls.keys.participants = key;
+                                return overrides.participant;
+                            },
+                        },
                     },
                 },
                 tx: {
@@ -412,6 +443,15 @@ if (import.meta.vitest) {
     }
 
     const registrant = { tag: "Account", accountAddress: ACCOUNT } as const;
+    const ALIAS = `0x${"dd".repeat(32)}`;
+    const RECOGNIZED = {
+        score: 10,
+        streak: { type: "Attended", value: 1 },
+        attendance_history: 1,
+        reached_personhood: true,
+        recognition: { type: "Recognized", value: `0x${"cc".repeat(32)}` },
+        last_attended_game: 6,
+    };
 
     describe("readGameSignUpRequirement", () => {
         test("an unrecognized player in registration can sign up and enter the draws", async () => {
@@ -433,16 +473,7 @@ if (import.meta.vitest) {
 
         test("a recognized player may sign up but not enter the draws", async () => {
             // The whole point of splitting sign-up blockers from draw blockers.
-            const { chain } = fakeChain({
-                participant: {
-                    score: 10,
-                    streak: { type: "Attended", value: 1 },
-                    attendance_history: 1,
-                    reached_personhood: true,
-                    recognition: { type: "Recognized", value: `0x${"cc".repeat(32)}` },
-                    last_attended_game: 6,
-                },
-            });
+            const { chain } = fakeChain({ participant: RECOGNIZED });
             const value = unwrapOk(
                 await readGameSignUpRequirement(chain, { registrant, now: 1_000 }),
             );
@@ -506,6 +537,82 @@ if (import.meta.vitest) {
 
             expect(value.canSignUp).toBe(false);
             expect(value.blockers).toEqual([{ tag: "AlreadyRegistered" }]);
+        });
+
+        test("keys both reads by AccountOrPerson, spelling the alias arm Person", async () => {
+            // Both entries take the same key, and the airdrop registration entry
+            // spells this arm `Alias`.
+            const account = fakeChain();
+            await readGameSignUpRequirement(account.chain, { registrant, now: 1_000 });
+            expect(account.calls.keys.players).toEqual({ type: "Account", value: ACCOUNT });
+            expect(account.calls.keys.participants).toEqual({ type: "Account", value: ACCOUNT });
+
+            const alias = fakeChain();
+            await readGameSignUpRequirement(alias.chain, {
+                registrant: { tag: "Alias", alias: ALIAS },
+                now: 1_000,
+            });
+            expect(alias.calls.keys.players).toEqual({ type: "Person", value: ALIAS });
+            expect(alias.calls.keys.participants).toEqual({ type: "Person", value: ALIAS });
+        });
+
+        test("an unrecognized person cannot enter the draws with either variant", async () => {
+            // The chain rejects the whole sign-up here, and the fee is paid.
+            const { chain } = fakeChain();
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, {
+                    registrant: { tag: "Alias", alias: ALIAS },
+                    now: 1_000,
+                }),
+            );
+
+            expect(value.variant).toBe("Account");
+            expect(value.canSignUp).toBe(true);
+            expect(value.canEnterDraws).toBe(false);
+            expect(value.blockers).toEqual([{ tag: "AccountVrfsNeedAnAccount" }]);
+        });
+
+        test("a recognized person still reports the alias blocker, not the origin one", async () => {
+            const { chain } = fakeChain({ participant: RECOGNIZED });
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, {
+                    registrant: { tag: "Alias", alias: ALIAS },
+                    now: 1_000,
+                }),
+            );
+
+            expect(value.blockers).toEqual([{ tag: "AliasVrfsUnavailable" }]);
+        });
+
+        test("a game with no draws says so, whatever the recognition", async () => {
+            // The truthful cause: there is nothing to enter, whatever the variant.
+            for (const participant of [undefined, RECOGNIZED]) {
+                const { chain } = fakeChain({
+                    game: { ...RUNNING_GAME, airdrops_scheduled: 0 },
+                    participant,
+                });
+                const value = unwrapOk(
+                    await readGameSignUpRequirement(chain, { registrant, now: 1_000 }),
+                );
+
+                expect(value.blockers).toEqual([{ tag: "NoDrawsScheduled" }]);
+                expect(value.canSignUp).toBe(true);
+                expect(value.eventIds).toEqual([]);
+            }
+        });
+
+        test("between games reports only NoGameRunning", async () => {
+            // Draw-entry blockers name nothing actionable with no game.
+            const { chain } = fakeChain({ game: undefined });
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, {
+                    registrant,
+                    keyType: "ed25519",
+                    now: 1_000,
+                }),
+            );
+
+            expect(value.blockers).toEqual([{ tag: "NoGameRunning" }]);
         });
 
         test("a known non-sr25519 key blocks the draws, not the sign-up", async () => {

--- a/product-sdk/packages/individuality/src/signup.ts
+++ b/product-sdk/packages/individuality/src/signup.ts
@@ -1,0 +1,626 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Signing up for the game, and entering its prize draws in the same call.
+ *
+ * Three steps, in order, each needing the previous one's output:
+ *
+ * ```ts
+ * const req = await readGameSignUpRequirement(chain, { registrant });
+ * if (req.ok && req.value.canEnterDraws) {
+ *     const vrfs = await mintAccountAirdropVrfs(signer, {
+ *         eventIds: req.value.eventIds,
+ *         publicKey: account.publicKey,
+ *     });
+ *     if (vrfs.ok) {
+ *         const tx = signUpWithAccountTx(chain, { identifierKey, airdrops: vrfs.value });
+ *         await submitAndWatch(tx, signer, { waitFor: "finalized" });
+ *     }
+ * }
+ * ```
+ *
+ * Submission stays with `@parity/product-sdk-tx`, as for `claimPrizeTx`.
+ *
+ * **The requirement read is not optional.** `eventIds` needs the game index and
+ * the draw count from the same block, and the entry count must equal
+ * `airdrops_scheduled` exactly or the whole sign-up fails, deposit included.
+ *
+ * Only the `Account` variant is buildable. `signup-types.ts` says why.
+ */
+import { err, normalizeError, ok, type Result } from "@parity/result";
+import { bytesToHex } from "@parity/product-sdk-utils";
+import { gameAirdropEventIds } from "./airdrop-ids.js";
+import type { AirdropRegistrant } from "./airdrop-types.js";
+import { toPersonhoodParticipant, type RawParticipant } from "./decode.js";
+import { ProductIndividualityError } from "./errors.js";
+import { runGameRead, type GameChain } from "./game-read.js";
+import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
+import { airdropVrfTranscript, type VrfTranscriptItem } from "./signup-vrf.js";
+import type {
+    AccountVrfSignature,
+    AirdropVrfVariant,
+    GameSignUpRequirement,
+    SignUpBlocker,
+} from "./signup-types.js";
+
+/** The chain's `AirdropVrfs`. `Alias` is never constructed, only declared. */
+type AirdropVrfsArg =
+    | { type: "Account"; value: { pre_output: string; proof: string }[] }
+    | { type: "Alias"; value: { proofs: Uint8Array[]; ring_index: number; revision: number } };
+
+/**
+ * The sign-up call, plus the reads that decide what it may carry. Composed with
+ * {@link GameChain}, which supplies the game. Matched by hand against the paseo
+ * descriptors on 2026-08-21.
+ */
+export interface SignUpChain<Tx = unknown> extends PinnedChain {
+    individuality: {
+        constants: { Game: { airdrop_event_id_base(): Promise<string> } };
+        query: {
+            Game: {
+                /** Absent for a player who has never signed up. */
+                Players: {
+                    getValue(
+                        key: { type: string; value: unknown },
+                        options: ReadAt,
+                    ): Promise<{ registered: boolean } | undefined>;
+                };
+            };
+            Score: {
+                Participants: {
+                    getValue(
+                        key: { type: string; value: unknown },
+                        options: ReadAt,
+                    ): Promise<RawParticipant | undefined>;
+                };
+            };
+        };
+        tx: {
+            Game: {
+                sign_up_with_account(args: {
+                    identifier_key: string;
+                    /**
+                     * Both arms, though only `Account` is built. PAPI `tx` entries
+                     * are function-typed properties, so this argument is checked
+                     * contravariantly: naming only `Account` is narrower than the
+                     * chain's and the real client stops satisfying the interface.
+                     */
+                    airdrops?: AirdropVrfsArg;
+                }): Tx;
+            };
+        };
+    };
+}
+
+/** Options for {@link readGameSignUpRequirement}. */
+export interface ReadGameSignUpRequirementOptions {
+    /** Keys both reads, and must be the identity that will sign. */
+    registrant: AirdropRegistrant;
+    /**
+     * Only `"sr25519"` can mint `Account` VRFs, and no chain read reveals the
+     * scheme. Pass it for a `NotSr25519` blocker, omit it and the check is yours.
+     */
+    keyType?: string;
+    /** Unix **seconds**; defaults to the device clock. */
+    now?: number;
+    signal?: AbortSignal;
+}
+
+function playerKey(registrant: AirdropRegistrant): { type: string; value: unknown } {
+    // `AccountOrPerson` spells the alias arm `Person` where the airdrop pallet's
+    // registration entry spells it `Alias`. Same identity, two names, and the
+    // wrong one reads nothing rather than failing.
+    return registrant.tag === "Account"
+        ? { type: "Account", value: registrant.accountAddress }
+        : { type: "Person", value: registrant.alias };
+}
+
+/**
+ * What this player may do about the running game, at one pinned block. Between
+ * games is not a failure, it is a `NoGameRunning` blocker on the success channel.
+ */
+export async function readGameSignUpRequirement(
+    chain: GameChain & SignUpChain,
+    options: ReadGameSignUpRequirementOptions,
+): Promise<Result<GameSignUpRequirement, ProductIndividualityError>> {
+    try {
+        const { registrant, signal } = options;
+        const snapshot = await pinBlock(chain, signal);
+        const at = readAt(snapshot, signal);
+        const key = playerKey(registrant);
+
+        const [game, rawParticipant, player] = await Promise.all([
+            runGameRead(chain, { signal }, snapshot),
+            chain.individuality.query.Score.Participants.getValue(key, at),
+            chain.individuality.query.Game.Players.getValue(key, at),
+        ]);
+
+        // No `Score` record onboards as `NotRecognized`, the same default
+        // `validate_register_for_airdrop` takes.
+        const recognized =
+            rawParticipant !== undefined &&
+            isRecognized(toPersonhoodParticipant(rawParticipant).recognition);
+
+        const blockers: SignUpBlocker[] = [];
+        if (player?.registered === true) {
+            blockers.push({ tag: "AlreadyRegistered" });
+        }
+        if (options.keyType !== undefined && options.keyType !== "sr25519" && !recognized) {
+            blockers.push({ tag: "NotSr25519", keyType: options.keyType });
+        }
+
+        if (game.tag === "BetweenGames") {
+            blockers.push({ tag: "NoGameRunning" });
+            return ok({
+                at: snapshot,
+                gameIndex: null,
+                phase: null,
+                registrationEnds: null,
+                canSignUp: false,
+                canEnterDraws: false,
+                variant: null,
+                airdropsScheduled: 0,
+                eventIds: [],
+                blockers,
+            });
+        }
+
+        const { index, phase, registrationEnds, airdropsScheduled } = game.game;
+        if (phase !== "Registration") {
+            blockers.push({ tag: "NotInRegistration", phase });
+        } else if ((options.now ?? Math.floor(Date.now() / 1000)) >= registrationEnds) {
+            // The chain checks the clock as well as the state, and the phase moves
+            // on an offchain worker's schedule rather than at the deadline.
+            blockers.push({ tag: "RegistrationEnded", registrationEnds });
+        }
+
+        const variant: AirdropVrfVariant = recognized ? "Alias" : "Account";
+        if (recognized) {
+            blockers.push({ tag: "AliasVrfsUnavailable" });
+        } else if (airdropsScheduled === 0) {
+            blockers.push({ tag: "NoDrawsScheduled" });
+        }
+
+        const eventIds =
+            airdropsScheduled === 0
+                ? []
+                : gameAirdropEventIds({
+                      base: await chain.individuality.constants.Game.airdrop_event_id_base(),
+                      gameIndex: index,
+                      airdropsScheduled,
+                  });
+
+        // The rest stop only the draws. This split is what lets a recognized
+        // player sign up.
+        const drawOnly = new Set(["AliasVrfsUnavailable", "NoDrawsScheduled", "NotSr25519"]);
+        const canSignUp = blockers.every((blocker) => drawOnly.has(blocker.tag));
+
+        return ok({
+            at: snapshot,
+            gameIndex: index,
+            phase,
+            registrationEnds,
+            canSignUp,
+            canEnterDraws: canSignUp && blockers.length === 0,
+            variant,
+            airdropsScheduled,
+            eventIds,
+            blockers,
+        });
+    } catch (cause) {
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+function isRecognized(recognition: string): boolean {
+    // `Suspended` is not recognized, which is why this is not a "not
+    // NotRecognized" check.
+    return recognition === "Recognized" || recognition === "ExternallyRecognized";
+}
+
+/**
+ * Structural, so the package keeps no dependency on `@parity/product-sdk-host`.
+ * `AccountsProvider.signVrf` satisfies it once its `ResultAsync` is unwrapped.
+ */
+export interface AirdropVrfSigner {
+    signVrf(transcriptLabel: Uint8Array, items: VrfTranscriptItem[]): Promise<AccountVrfSignature>;
+}
+
+/** Options for {@link mintAccountAirdropVrfs}. */
+export interface MintAccountAirdropVrfsOptions {
+    /** In airdrop-index order: entry `i` is checked against airdrop index `i`. */
+    eventIds: string[];
+    /** The signing account's sr25519 key, 32 bytes. */
+    publicKey: Uint8Array;
+    signal?: AbortSignal;
+}
+
+/**
+ * One VRF per scheduled draw, minted through the host.
+ *
+ * Sequential, not parallel: each is a user-visible signing operation, and firing
+ * sixteen at once is hidden by an `AutoSigning` allowance until a product ships
+ * without one.
+ *
+ * No local verification, though one bad entry fails the whole sign-up. Schnorrkel
+ * VRF verification does not exist in this workspace, and the failure it guards
+ * against is the wrong key, which the transcript binds and the width checks catch.
+ */
+export async function mintAccountAirdropVrfs(
+    signer: AirdropVrfSigner,
+    options: MintAccountAirdropVrfsOptions,
+): Promise<Result<AccountVrfSignature[], ProductIndividualityError>> {
+    try {
+        const signatures: AccountVrfSignature[] = [];
+        for (const eventId of options.eventIds) {
+            options.signal?.throwIfAborted();
+            const transcript = airdropVrfTranscript({ eventId, publicKey: options.publicKey });
+            signatures.push(await signer.signVrf(transcript.label, transcript.items));
+        }
+        return ok(signatures);
+    } catch (cause) {
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+/** Options for {@link signUpWithAccountTx}. */
+export interface SignUpWithAccountOptions {
+    /**
+     * `CommunicationIdentifier`, exactly 65 bytes. Stored against the account and
+     * never interpreted by the chain; it is how co-players reach each other.
+     */
+    identifierKey: Uint8Array;
+    /** Omit to enter no draw. Length must equal `airdropsScheduled`. */
+    airdrops?: AccountVrfSignature[];
+}
+
+const IDENTIFIER_KEY_BYTES = 65;
+const VRF_PRE_OUTPUT_BYTES = 32;
+const VRF_PROOF_BYTES = 64;
+
+/**
+ * Build `Game.sign_up_with_account`, unsigned. `Pays::No` on success, though a new
+ * or archived player still pays a deposit.
+ *
+ * No `Alias` argument: a recognized player needs one that cannot be produced, and
+ * an argument that always fails on chain is worse than none.
+ *
+ * @throws ProductIndividualityError on a wrong-width key or signature, checked
+ *   because the chain's own failure rejects the sign-up with nothing to inspect.
+ */
+export function signUpWithAccountTx<Tx>(
+    chain: SignUpChain<Tx>,
+    options: SignUpWithAccountOptions,
+): Tx {
+    if (options.identifierKey.length !== IDENTIFIER_KEY_BYTES) {
+        throw new ProductIndividualityError(
+            `game sign-up identifier key must be ${IDENTIFIER_KEY_BYTES} bytes`,
+        );
+    }
+
+    return chain.individuality.tx.Game.sign_up_with_account({
+        identifier_key: `0x${bytesToHex(options.identifierKey)}`,
+        // `undefined` is PAPI's `None`. An empty `Account` list is a different
+        // thing, and fails the count check against any game with draws.
+        airdrops:
+            options.airdrops === undefined
+                ? undefined
+                : {
+                      type: "Account",
+                      value: options.airdrops.map((signature) => ({
+                          pre_output: `0x${bytesToHex(
+                              sizedSignaturePart(
+                                  signature.preOutput,
+                                  VRF_PRE_OUTPUT_BYTES,
+                                  "pre-output",
+                              ),
+                          )}`,
+                          proof: `0x${bytesToHex(
+                              sizedSignaturePart(signature.proof, VRF_PROOF_BYTES, "proof"),
+                          )}`,
+                      })),
+                  },
+    });
+}
+
+function sizedSignaturePart(bytes: Uint8Array, length: number, what: string): Uint8Array {
+    if (bytes.length !== length) {
+        throw new ProductIndividualityError(`airdrop VRF ${what} must be ${length} bytes`);
+    }
+    return bytes;
+}
+
+if (import.meta.vitest) {
+    const { describe, expect, test, vi } = import.meta.vitest;
+    const { unwrapOk, unwrapErr } = await import("@parity/result");
+
+    const ACCOUNT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const BASE = "pop:game:airdrop:          ";
+    const KEY = new Uint8Array(32).fill(0x11);
+    const IDENTIFIER = new Uint8Array(65).fill(0x22);
+
+    const RUNNING_GAME = {
+        index: 7,
+        registration_ends: 2_000,
+        shuffle_deadline: 3_000,
+        game_date: 4_000,
+        report_ends: 5_000,
+        state: { type: "Registration", value: { next_player_index: 0 } },
+        max_group_size: 6,
+        rounds: 3,
+        pending_attendance: 0,
+        airdrops_scheduled: 2,
+    };
+
+    const DURATIONS = {
+        registration: 100,
+        shuffle: 100,
+        post_shuffle_margin: 100,
+        reporting: 100,
+        player_process: 100,
+    };
+
+    function fakeChain(
+        overrides: {
+            game?: unknown;
+            participant?: unknown;
+            player?: unknown;
+        } = {},
+    ) {
+        const calls: { tx: unknown[] } = { tx: [] };
+        const chain = {
+            raw: {
+                individuality: {
+                    getFinalizedBlock: async () => ({ hash: `0x${"aa".repeat(32)}`, number: 42 }),
+                },
+            },
+            individuality: {
+                constants: {
+                    Game: {
+                        airdrop_event_id_base: async () => BASE,
+                        DefaultPhaseDurations: async () => DURATIONS,
+                    },
+                },
+                query: {
+                    Game: {
+                        GameIndex: { getValue: async () => 7 },
+                        Game: {
+                            getValue: async () =>
+                                "game" in overrides ? overrides.game : RUNNING_GAME,
+                        },
+                        GameSchedules: { getValue: async () => [] },
+                        StoredPhaseDurations: { getValue: async () => undefined },
+                        Players: { getValue: async () => overrides.player },
+                    },
+                    Score: {
+                        Participants: { getValue: async () => overrides.participant },
+                    },
+                },
+                tx: {
+                    Game: {
+                        sign_up_with_account: (args: unknown) => {
+                            calls.tx.push(args);
+                            return args;
+                        },
+                    },
+                },
+            },
+        };
+        // The structural interfaces are wider than this double in ways the read
+        // never touches, which is the point of them being structural.
+        return { chain: chain as unknown as GameChain & SignUpChain<unknown>, calls };
+    }
+
+    const registrant = { tag: "Account", accountAddress: ACCOUNT } as const;
+
+    describe("readGameSignUpRequirement", () => {
+        test("an unrecognized player in registration can sign up and enter the draws", async () => {
+            const { chain } = fakeChain();
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, { registrant, now: 1_000 }),
+            );
+
+            expect(value.canSignUp).toBe(true);
+            expect(value.canEnterDraws).toBe(true);
+            expect(value.variant).toBe("Account");
+            expect(value.blockers).toEqual([]);
+            expect(value.airdropsScheduled).toBe(2);
+            expect(value.eventIds).toHaveLength(2);
+            // Ids come from the same block's index and count, and differ only in
+            // the airdrop-index byte.
+            expect(value.eventIds[0]).not.toBe(value.eventIds[1]);
+        });
+
+        test("a recognized player may sign up but not enter the draws", async () => {
+            // The whole point of splitting sign-up blockers from draw blockers.
+            const { chain } = fakeChain({
+                participant: {
+                    score: 10,
+                    streak: { type: "Attended", value: 1 },
+                    attendance_history: 1,
+                    reached_personhood: true,
+                    recognition: { type: "Recognized", value: `0x${"cc".repeat(32)}` },
+                    last_attended_game: 6,
+                },
+            });
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, { registrant, now: 1_000 }),
+            );
+
+            expect(value.variant).toBe("Alias");
+            expect(value.canSignUp).toBe(true);
+            expect(value.canEnterDraws).toBe(false);
+            expect(value.blockers).toEqual([{ tag: "AliasVrfsUnavailable" }]);
+        });
+
+        test("a suspended player is not recognized, so it stays on the account path", async () => {
+            // `is_recognized()` is false for Suspended, so "not NotRecognized" is
+            // the wrong test and would send this player to an unbuildable variant.
+            const { chain } = fakeChain({
+                participant: {
+                    score: 1,
+                    streak: { type: "Absent", value: 2 },
+                    attendance_history: 0,
+                    reached_personhood: false,
+                    recognition: { type: "Suspended", value: `0x${"cc".repeat(32)}` },
+                    last_attended_game: 6,
+                },
+            });
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, { registrant, now: 1_000 }),
+            );
+
+            expect(value.variant).toBe("Account");
+            expect(value.canEnterDraws).toBe(true);
+        });
+
+        test("between games it reports NoGameRunning rather than failing", async () => {
+            const { chain } = fakeChain({ game: undefined });
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, { registrant, now: 1_000 }),
+            );
+
+            expect(value.canSignUp).toBe(false);
+            expect(value.gameIndex).toBeNull();
+            expect(value.eventIds).toEqual([]);
+            expect(value.blockers).toEqual([{ tag: "NoGameRunning" }]);
+        });
+
+        test("a deadline that has passed inside the registration phase still blocks", async () => {
+            // The offchain worker moves the phase in its own time, so the clock and
+            // the state disagree here, and the chain checks both.
+            const { chain } = fakeChain();
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, { registrant, now: 2_001 }),
+            );
+
+            expect(value.canSignUp).toBe(false);
+            expect(value.blockers).toEqual([{ tag: "RegistrationEnded", registrationEnds: 2_000 }]);
+        });
+
+        test("an already-registered player is blocked from signing up again", async () => {
+            const { chain } = fakeChain({ player: { registered: true } });
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, { registrant, now: 1_000 }),
+            );
+
+            expect(value.canSignUp).toBe(false);
+            expect(value.blockers).toEqual([{ tag: "AlreadyRegistered" }]);
+        });
+
+        test("a known non-sr25519 key blocks the draws, not the sign-up", async () => {
+            const { chain } = fakeChain();
+            const value = unwrapOk(
+                await readGameSignUpRequirement(chain, {
+                    registrant,
+                    keyType: "ed25519",
+                    now: 1_000,
+                }),
+            );
+
+            expect(value.canSignUp).toBe(true);
+            expect(value.canEnterDraws).toBe(false);
+            expect(value.blockers).toEqual([{ tag: "NotSr25519", keyType: "ed25519" }]);
+        });
+    });
+
+    describe("mintAccountAirdropVrfs", () => {
+        test("signs once per event, in order, with the same key", async () => {
+            const seen: Uint8Array[] = [];
+            const signer: AirdropVrfSigner = {
+                signVrf: async (_label, items) => {
+                    seen.push(items[0].value);
+                    return { preOutput: new Uint8Array(32), proof: new Uint8Array(64) };
+                },
+            };
+
+            const ids = [`0x${"01".repeat(32)}`, `0x${"02".repeat(32)}`];
+            const result = await mintAccountAirdropVrfs(signer, { eventIds: ids, publicKey: KEY });
+
+            expect(unwrapOk(result)).toHaveLength(2);
+            // Each transcript's domain carries its own event id, which is the
+            // binding that stops one entry standing in for another.
+            expect(seen).toHaveLength(2);
+            expect(seen[0]).not.toEqual(seen[1]);
+        });
+
+        test("a host rejection becomes an error, not a short list", async () => {
+            // A partial list would be submitted and fail the count check on chain,
+            // costing the deposit for a failure that was already known here.
+            const signer: AirdropVrfSigner = {
+                signVrf: vi
+                    .fn()
+                    .mockResolvedValueOnce({
+                        preOutput: new Uint8Array(32),
+                        proof: new Uint8Array(64),
+                    })
+                    .mockRejectedValueOnce(new Error("host rejected")),
+            };
+
+            const result = await mintAccountAirdropVrfs(signer, {
+                eventIds: [`0x${"01".repeat(32)}`, `0x${"02".repeat(32)}`],
+                publicKey: KEY,
+            });
+
+            expect(unwrapErr(result)).toBeInstanceOf(ProductIndividualityError);
+        });
+    });
+
+    describe("signUpWithAccountTx", () => {
+        test("omits airdrops entirely when none are given", async () => {
+            const { chain, calls } = fakeChain();
+            signUpWithAccountTx(chain, { identifierKey: IDENTIFIER });
+
+            expect(calls.tx[0]).toEqual({
+                identifier_key: `0x${"22".repeat(65)}`,
+                airdrops: undefined,
+            });
+        });
+
+        test("wraps the signatures in the Account variant, hex-encoded", () => {
+            const { chain, calls } = fakeChain();
+            signUpWithAccountTx(chain, {
+                identifierKey: IDENTIFIER,
+                airdrops: [
+                    {
+                        preOutput: new Uint8Array(32).fill(0xaa),
+                        proof: new Uint8Array(64).fill(0xbb),
+                    },
+                ],
+            });
+
+            expect(calls.tx[0]).toEqual({
+                identifier_key: `0x${"22".repeat(65)}`,
+                airdrops: {
+                    type: "Account",
+                    value: [{ pre_output: `0x${"aa".repeat(32)}`, proof: `0x${"bb".repeat(64)}` }],
+                },
+            });
+        });
+
+        test("an empty list is not the same as none", () => {
+            // `Some([])` fails the count check against any game with draws, where
+            // `None` is always valid. Keeping them distinct is deliberate.
+            const { chain, calls } = fakeChain();
+            signUpWithAccountTx(chain, { identifierKey: IDENTIFIER, airdrops: [] });
+
+            expect(calls.tx[0]).toEqual({
+                identifier_key: `0x${"22".repeat(65)}`,
+                airdrops: { type: "Account", value: [] },
+            });
+        });
+
+        test("rejects a wrong-width identifier key and signature", () => {
+            const { chain } = fakeChain();
+            expect(() => signUpWithAccountTx(chain, { identifierKey: new Uint8Array(64) })).toThrow(
+                ProductIndividualityError,
+            );
+            expect(() =>
+                signUpWithAccountTx(chain, {
+                    identifierKey: IDENTIFIER,
+                    airdrops: [{ preOutput: new Uint8Array(31), proof: new Uint8Array(64) }],
+                }),
+            ).toThrow(ProductIndividualityError);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/signup.ts
+++ b/product-sdk/packages/individuality/src/signup.ts
@@ -50,10 +50,12 @@
  *
  * Only the `Account` variant is buildable. `signup-types.ts` says why.
  */
+import { Enum } from "polkadot-api";
 import { err, normalizeError, ok, type Result } from "@parity/result";
 import { bytesToHex } from "@parity/product-sdk-utils";
 import { gameAirdropEventIds } from "./airdrop-ids.js";
 import type { AirdropRegistrant } from "./airdrop-types.js";
+import type { PersonhoodParticipant } from "./types.js";
 import { toPersonhoodParticipant, type RawParticipant } from "./decode.js";
 import { ProductIndividualityError } from "./errors.js";
 import { runGameRead, type GameChain } from "./game-read.js";
@@ -81,6 +83,18 @@ const DRAW_ONLY = {
     NotSr25519: true,
 } satisfies Record<SignUpBlocker["tag"], boolean>;
 
+/**
+ * The `AccountOrPerson` key both reads take.
+ *
+ * Two things keep the umbrella contract test honest here, both verified by
+ * breaking them. The narrow type catches a descriptor re-pin that renames an arm.
+ * Property syntax on the two `getValue`s catches widening this back to
+ * `{ type: string }`, which method syntax would accept, since method parameters
+ * are bivariant. Without either, a renamed arm reads nothing and looks like an
+ * absent record.
+ */
+type PlayerKey = { type: "Account"; value: string } | { type: "Person"; value: string };
+
 /** The chain's `AirdropVrfs`. `Alias` is never constructed, only declared. */
 type AirdropVrfsArg =
     | { type: "Account"; value: { pre_output: string; proof: string }[] }
@@ -98,18 +112,18 @@ export interface SignUpChain<Tx = unknown> extends PinnedChain {
             Game: {
                 /** Absent for a player who has never signed up. */
                 Players: {
-                    getValue(
-                        key: { type: string; value: unknown },
+                    getValue: (
+                        key: PlayerKey,
                         options: ReadAt,
-                    ): Promise<{ registered: boolean } | undefined>;
+                    ) => Promise<{ registered: boolean } | undefined>;
                 };
             };
             Score: {
                 Participants: {
-                    getValue(
-                        key: { type: string; value: unknown },
+                    getValue: (
+                        key: PlayerKey,
                         options: ReadAt,
-                    ): Promise<RawParticipant | undefined>;
+                    ) => Promise<RawParticipant | undefined>;
                 };
             };
         };
@@ -144,13 +158,13 @@ export interface ReadGameSignUpRequirementOptions {
     signal?: AbortSignal;
 }
 
-function playerKey(registrant: AirdropRegistrant): { type: string; value: unknown } {
+function playerKey(registrant: AirdropRegistrant): PlayerKey {
     // `AccountOrPerson` spells the alias arm `Person` where the airdrop pallet's
     // registration entry spells it `Alias`. Same identity, two names, and the
     // wrong one reads nothing rather than failing.
     return registrant.tag === "Account"
-        ? { type: "Account", value: registrant.accountAddress }
-        : { type: "Person", value: registrant.alias };
+        ? Enum("Account", registrant.accountAddress)
+        : Enum("Person", registrant.alias);
 }
 
 /**
@@ -255,7 +269,7 @@ export async function readGameSignUpRequirement(
     }
 }
 
-function isRecognized(recognition: string): boolean {
+function isRecognized(recognition: PersonhoodParticipant["recognition"]): boolean {
     // `Suspended` is not recognized, which is why this is not a "not
     // NotRecognized" check.
     return recognition === "Recognized" || recognition === "ExternallyRecognized";
@@ -280,6 +294,10 @@ export interface MintAccountAirdropVrfsOptions {
     eventIds: string[];
     /** The signing account's sr25519 key, 32 bytes. */
     publicKey: Uint8Array;
+    /**
+     * Checked between draws only. `AirdropVrfSigner` takes no signal, so a
+     * signature already being prompted for cannot be cancelled, unlike the reads.
+     */
     signal?: AbortSignal;
 }
 
@@ -294,6 +312,20 @@ export interface MintAccountAirdropVrfsOptions {
  * VRF verification does not exist in this workspace, and the failure it guards
  * against is the wrong key, which the transcript binds and the width checks catch.
  */
+/**
+ * The adapter is caller-written and usually unwraps a `Result`, so resolving with
+ * the `Result` itself is a likelier mistake than rejecting. Unchecked it reaches
+ * the builder and throws a `TypeError` there, outside any `Result` channel.
+ */
+function checkSignature(value: AccountVrfSignature): AccountVrfSignature {
+    if (!(value?.preOutput instanceof Uint8Array) || !(value?.proof instanceof Uint8Array)) {
+        throw new ProductIndividualityError(
+            "the VRF signer returned no signature; unwrap the Result before resolving",
+        );
+    }
+    return value;
+}
+
 export async function mintAccountAirdropVrfs(
     signer: AirdropVrfSigner,
     options: MintAccountAirdropVrfsOptions,
@@ -303,7 +335,9 @@ export async function mintAccountAirdropVrfs(
         for (const eventId of options.eventIds) {
             options.signal?.throwIfAborted();
             const transcript = airdropVrfTranscript({ eventId, publicKey: options.publicKey });
-            signatures.push(await signer.signVrf(transcript.label, transcript.items));
+            signatures.push(
+                checkSignature(await signer.signVrf(transcript.label, transcript.items)),
+            );
         }
         return ok(signatures);
     } catch (cause) {

--- a/product-sdk/packages/sdk/src/individuality/contract.test.ts
+++ b/product-sdk/packages/sdk/src/individuality/contract.test.ts
@@ -39,6 +39,7 @@ import type {
     GameChain,
     IndividualityChain,
     PrizeStatusChain,
+    SignUpChain,
     RingVRFProof as AsPersonRingVRFProof,
 } from "@parity/product-sdk-individuality";
 import { expect, test } from "vitest";
@@ -224,6 +225,57 @@ type ClaimAirdropTakesTheDocumentedArgs = Assert<
             ? "beneficiary" extends keyof ClaimAirdropArgs
                 ? true
                 : false
+            : false
+        : false
+>;
+
+// Game sign-up.
+type PaseoSatisfiesSignUpContract = Assert<PaseoClient extends SignUpChain ? true : false>;
+type RejectsBogusSignUpClient = Assert<
+    ClientWithoutIndividuality extends SignUpChain ? false : true
+>;
+
+// `SignUpChain` alone does not reject devnet and cannot: a `tx` argument is
+// checked contravariantly and excess-property checking does not apply between
+// named types, so an interface naming `airdrops` is satisfied by devnet's call,
+// which has only `airdrop`. `identifier_key` does not separate them either, since
+// `SizedHex<N>`'s brand is optional. Assert on the intersection the read takes,
+// where `GameChain` is the half that rejects devnet.
+type PaseoSatisfiesSignUpRead = Assert<PaseoClient extends GameChain & SignUpChain ? true : false>;
+type DevnetPredatesTheSignUpRead = Assert<
+    DevnetClient extends GameChain & SignUpChain ? false : true
+>;
+
+// The divergence itself: devnet's argument is `airdrop`, so `signUpWithAccountTx`
+// emitting `airdrops` would encode as `undefined` and enter no draw at all.
+type DevnetGameTx = DevnetClient["individuality"]["tx"]["Game"];
+type DevnetSignUpArgs = Parameters<DevnetGameTx["sign_up_with_account"]>[0];
+type DevnetHasNoAirdropsArg = Assert<"airdrops" extends keyof DevnetSignUpArgs ? false : true>;
+type DevnetHasTheSingularArg = Assert<"airdrop" extends keyof DevnetSignUpArgs ? true : false>;
+
+// Pinned by name for the same reason `claim_airdrop`'s are: PAPI encodes the
+// object it is handed, so a renamed field silently encodes as `undefined`.
+type SignUpWithAccountArgs = Parameters<GameTx["sign_up_with_account"]>[0];
+type SignUpWithAccountTakesTheDocumentedArgs = Assert<
+    "identifier_key" extends keyof SignUpWithAccountArgs
+        ? "airdrops" extends keyof SignUpWithAccountArgs
+            ? true
+            : false
+        : false
+>;
+
+// `None` is how a player enters no draw, and the only form a recognized player
+// can use at all.
+type AirdropsArg = SignUpWithAccountArgs["airdrops"];
+type AirdropsIsOptional = Assert<undefined extends AirdropsArg ? true : false>;
+
+// Extracted from the enum rather than restated, so a renamed field fails here
+// instead of on chain.
+type AccountVrfs = Extract<NonNullable<AirdropsArg>, { type: "Account" }>["value"][number];
+type AccountVrfHasPreOutputAndProof = Assert<
+    "pre_output" extends keyof AccountVrfs
+        ? "proof" extends keyof AccountVrfs
+            ? true
             : false
         : false
 >;

--- a/product-sdk/packages/sdk/src/individuality/contract.test.ts
+++ b/product-sdk/packages/sdk/src/individuality/contract.test.ts
@@ -31,7 +31,11 @@
  * `@ts-expect-error` would report as unused and this file would fail.
  */
 import type { getChainAPI } from "@parity/product-sdk-chain-client";
-import type { RingVRFProof as HostRingVRFProof } from "@parity/product-sdk-host";
+import type {
+    RingVRFProof as HostRingVRFProof,
+    VrfSignature as HostVrfSignature,
+    VrfTranscriptItem as HostVrfTranscriptItem,
+} from "@parity/product-sdk-host";
 import type {
     AirdropChain,
     ClaimChain,
@@ -40,6 +44,8 @@ import type {
     IndividualityChain,
     PrizeStatusChain,
     SignUpChain,
+    AccountVrfSignature,
+    VrfTranscriptItem as IndividualityVrfTranscriptItem,
     RingVRFProof as AsPersonRingVRFProof,
 } from "@parity/product-sdk-individuality";
 import { expect, test } from "vitest";
@@ -279,6 +285,39 @@ type AccountVrfHasPreOutputAndProof = Assert<
             : false
         : false
 >;
+
+// The VRF types are local copies of the host's, declared here for the same reason
+// `AsPersonRingVRFProof` is: so the package keeps no host dependency. Those host
+// types are mapped straight off truapi's wire types, so a rename there changes them
+// with no line of this repo touched, and the break would land as a runtime
+// TypeError rather than a failed typecheck.
+type HostVrfSignatureSatisfiesLocal = Assert<
+    HostVrfSignature extends AccountVrfSignature ? true : false
+>;
+type HostVrfItemSatisfiesLocal = Assert<
+    HostVrfTranscriptItem extends IndividualityVrfTranscriptItem ? true : false
+>;
+
+// Negative controls, so the two above cannot pass vacuously.
+type RejectsSignatureMissingProof = Assert<
+    { preOutput: Uint8Array } extends AccountVrfSignature ? false : true
+>;
+type RejectsItemMissingValue = Assert<
+    { label: Uint8Array } extends IndividualityVrfTranscriptItem ? false : true
+>;
+
+// `Game.Players`: the variant spelling the read keys by, and the one field it uses.
+// Sibling reads got exactly these pins.
+type PlayersEntry = PaseoClient["individuality"]["query"]["Game"]["Players"];
+type PlayersKey = Parameters<PlayersEntry["getValue"]>[0];
+type PlayersKeyIsAccountOrPerson = Assert<
+    PlayersKey extends { type: "Account" | "Person" } ? true : false
+>;
+type RejectsAliasSpelling = Assert<
+    { type: "Alias"; value: string } extends PlayersKey ? false : true
+>;
+type PlayersValue = NonNullable<Awaited<ReturnType<PlayersEntry["getValue"]>>>;
+type PlayersHasRegistered = Assert<"registered" extends keyof PlayersValue ? true : false>;
 
 test("the individuality chain contract is asserted at compile time", () => {
     // The type assertions above are the test. This keeps vitest from reporting

--- a/product-sdk/pending-changesets/game-signup-account.md
+++ b/product-sdk/pending-changesets/game-signup-account.md
@@ -100,7 +100,8 @@ belongs to, so this cannot be read — pass `keyType` (`"sr25519" | "ed25519" | 
 `NotSr25519` blocker, or omit it and own the check. For the same reason the transcript's `signer` item must be the account that
 signs the sign-up, not any other key the player holds.
 
-`airdropVrfTranscript` is exported for a caller minting VRFs some other way. Both the transcript
+`airdropVrfTranscript`, `airdropVrfDomain` and `AIRDROP_VRF_TRANSCRIPT_LABEL` are exported for a
+caller minting VRFs some other way. Both the transcript
 label and its domain prefix are module-level `pub const`s in the airdrop pallet, so unlike
 `Game`'s event-id base neither reaches metadata; the pinned test vectors are the only guard, the
 same situation the `PeopleAirdrops` event-id base is in.
@@ -112,6 +113,9 @@ binds and this code checks without any crypto. VRFs are minted sequentially rath
 parallel: each is a signing operation, and firing sixteen at once is hidden by an `AutoSigning`
 allowance right up until a product ships without one.
 
-**Paseo only.** Devnet's pinned metadata predates the multi-airdrop sign-up, and the umbrella's
-contract test asserts that a devnet client *fails* `SignUpChain` so a re-pin breaks the
-assertion rather than leaving the surface quietly unsupported.
+**Paseo only.** Devnet's pinned metadata predates the multi-airdrop sign-up: its call takes
+`airdrop`, singular, so `airdrops` would encode as `undefined` and enter no draw, silently. The
+umbrella contract test asserts a devnet client fails `GameChain & SignUpChain`. `SignUpChain`
+alone cannot reject devnet, since a `tx` argument is checked against a supertype and
+excess-property checking does not apply between named types; `GameChain` is the half that rejects
+it, by needing `airdrops_scheduled`.

--- a/product-sdk/pending-changesets/game-signup-account.md
+++ b/product-sdk/pending-changesets/game-signup-account.md
@@ -45,6 +45,13 @@ scheduled draw, in airdrop-index order. Pass nothing to sign up without entering
 `Suspended` is *not* recognized, so a suspended player stays on the account path — the check is
 `is_recognized()`, not "anything but `NotRecognized`".
 
+**Recognition is only half the gate.** The account arm also destructures the origin, so a
+**person** who is not recognized satisfies neither arm: the account variant wants an account
+origin, the alias variant wants recognition. Such a player can sign up but can enter no draw,
+which is the `AccountVrfsNeedAnAccount` blocker. Worth knowing because a rejected sign-up costs a
+fee, `Pays::No` applies on success only, and the airdrop registration rides inside the same
+extrinsic, so a refused draw entry loses the game sign-up with it.
+
 **A recognized player cannot enter the draws through any SDK or host available today.** The
 `Alias` variant needs a ring-VRF proof at the context
 `blake2_256("pop:polkadot.network/airdrop" ++ event_id)`, and every context a host will sign
@@ -62,12 +69,14 @@ ids derived from a stale index address draws that do not exist.
 `GameSignUpRequirement.blockers` reports every cause rather than the first, and separates the
 ones that stop the extrinsic (`NoGameRunning`, `NotInRegistration`, `RegistrationEnded`,
 `AlreadyRegistered`) from the ones that stop only the draws (`AliasVrfsUnavailable`,
-`NoDrawsScheduled`, `NotSr25519`).
+`AccountVrfsNeedAnAccount`, `NoDrawsScheduled`, `NotSr25519`). Each tag names a condition that
+holds on its own: a game that scheduled no draws reports `NoDrawsScheduled`, not a variant the
+player could not have supplied anyway.
 
 **Only sr25519 accounts can take the account path**, because the pallet reinterprets the account
 id *as* the sr25519 public key. Nothing on chain records which scheme a 32-byte account id
-belongs to, so this cannot be read — pass `keyType` and get a `NotSr25519` blocker, or omit it
-and own the check. For the same reason the transcript's `signer` item must be the account that
+belongs to, so this cannot be read — pass `keyType` (`"sr25519" | "ed25519" | "ecdsa"`) and get a
+`NotSr25519` blocker, or omit it and own the check. For the same reason the transcript's `signer` item must be the account that
 signs the sign-up, not any other key the player holds.
 
 `airdropVrfTranscript` is exported for a caller minting VRFs some other way. Both the transcript

--- a/product-sdk/pending-changesets/game-signup-account.md
+++ b/product-sdk/pending-changesets/game-signup-account.md
@@ -13,20 +13,38 @@ import {
 } from "@parity/product-sdk-individuality";
 import { submitAndWatch } from "@parity/product-sdk-tx";
 
+// `accounts.signVrf` takes the account first and returns a Result, so it needs an
+// adapter. `txSigner` is the ordinary PolkadotSigner, not the same object.
+const vrfSigner = {
+    signVrf: (label, items) =>
+        accounts.signVrf(account, label, items).match(
+            (sig) => sig,
+            (cause) => { throw cause },
+        ),
+};
+
 const req = await readGameSignUpRequirement(chain, {
     registrant: { tag: "Account", accountAddress },
     keyType: "sr25519",
 });
-if (req.ok && req.value.canEnterDraws) {
-    const vrfs = await mintAccountAirdropVrfs(signer, {
+if (!req.ok || !req.value.canSignUp) return;
+
+let airdrops;
+if (req.value.canEnterDraws) {
+    const vrfs = await mintAccountAirdropVrfs(vrfSigner, {
         eventIds: req.value.eventIds,
         publicKey: account.publicKey,
     });
-    if (vrfs.ok) {
-        const tx = signUpWithAccountTx(chain, { identifierKey, airdrops: vrfs.value });
-        await submitAndWatch(tx, signer, { waitFor: "finalized" });
-    }
+    if (!vrfs.ok) return;
+    airdrops = vrfs.value;
 }
+
+const tx = signUpWithAccountTx(chain, {
+    identifierKey,
+    airdrops,
+    airdropsScheduled: req.value.airdropsScheduled,
+});
+await submitAndWatch(tx, txSigner, { waitFor: "finalized" });
 ```
 
 **Registering for the game and entering its prize draws are one extrinsic.**
@@ -61,6 +79,9 @@ agree, so this needs a chain or host change rather than more SDK code. It surfac
 `AliasVrfsUnavailable` blocker, and it is why `signUpWithAccountTx` offers no `Alias` argument:
 an argument that always fails on chain is worse than no argument. **Such a player can still sign
 up** — with no draw entry — which is the whole difference the blocker makes.
+
+**Gate the sign-up on `canSignUp`, and only the draw entry on `canEnterDraws`.** A recognized
+player has `canSignUp: true` and `canEnterDraws: false`, so gating both drops them silently.
 
 **Read the requirement first; it is not optional.** Event ids are derived from the game index
 *and* the draw count, which must come from the same block, and the entry count must equal

--- a/product-sdk/pending-changesets/game-signup-account.md
+++ b/product-sdk/pending-changesets/game-signup-account.md
@@ -1,0 +1,87 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk": minor
+---
+
+**Sign up for the game, and enter its prize draws in the same call.**
+
+```ts
+import {
+    readGameSignUpRequirement,
+    mintAccountAirdropVrfs,
+    signUpWithAccountTx,
+} from "@parity/product-sdk-individuality";
+import { submitAndWatch } from "@parity/product-sdk-tx";
+
+const req = await readGameSignUpRequirement(chain, {
+    registrant: { tag: "Account", accountAddress },
+    keyType: "sr25519",
+});
+if (req.ok && req.value.canEnterDraws) {
+    const vrfs = await mintAccountAirdropVrfs(signer, {
+        eventIds: req.value.eventIds,
+        publicKey: account.publicKey,
+    });
+    if (vrfs.ok) {
+        const tx = signUpWithAccountTx(chain, { identifierKey, airdrops: vrfs.value });
+        await submitAndWatch(tx, signer, { waitFor: "finalized" });
+    }
+}
+```
+
+**Registering for the game and entering its prize draws are one extrinsic.**
+`sign_up_with_account` takes `airdrops: Option<AirdropVrfs>` holding exactly one VRF per
+scheduled draw, in airdrop-index order. Pass nothing to sign up without entering any draw.
+
+**The `AirdropVrfs` variant is not the caller's choice** — the chain picks it from the player's
+`Score` recognition and rejects the other one with
+`Game.InvalidAirdropVrfVariantForRecognition`:
+
+| `recognition.is_recognized()` | Required variant | Buildable |
+|---|---|---|
+| `false` — `NotRecognized`, `Suspended` | `Account` — sr25519 VRFs | yes |
+| `true` — `Recognized`, `ExternallyRecognized` | `Alias` — ring-VRF membership proofs | **no** |
+
+`Suspended` is *not* recognized, so a suspended player stays on the account path — the check is
+`is_recognized()`, not "anything but `NotRecognized`".
+
+**A recognized player cannot enter the draws through any SDK or host available today.** The
+`Alias` variant needs a ring-VRF proof at the context
+`blake2_256("pop:polkadot.network/airdrop" ++ event_id)`, and every context a host will sign
+under is `blake2b_256("product/" ++ productId ++ "/" ++ suffix)`, computed by the host itself
+from a `ProductProofContext` that admits nothing else. The two preimages cannot be made to
+agree, so this needs a chain or host change rather than more SDK code. It surfaces as the
+`AliasVrfsUnavailable` blocker, and it is why `signUpWithAccountTx` offers no `Alias` argument:
+an argument that always fails on chain is worse than no argument. **Such a player can still sign
+up** — with no draw entry — which is the whole difference the blocker makes.
+
+**Read the requirement first; it is not optional.** Event ids are derived from the game index
+*and* the draw count, which must come from the same block, and the entry count must equal
+`airdrops_scheduled` exactly. A count mismatch fails the whole sign-up, deposit included, and
+ids derived from a stale index address draws that do not exist.
+`GameSignUpRequirement.blockers` reports every cause rather than the first, and separates the
+ones that stop the extrinsic (`NoGameRunning`, `NotInRegistration`, `RegistrationEnded`,
+`AlreadyRegistered`) from the ones that stop only the draws (`AliasVrfsUnavailable`,
+`NoDrawsScheduled`, `NotSr25519`).
+
+**Only sr25519 accounts can take the account path**, because the pallet reinterprets the account
+id *as* the sr25519 public key. Nothing on chain records which scheme a 32-byte account id
+belongs to, so this cannot be read — pass `keyType` and get a `NotSr25519` blocker, or omit it
+and own the check. For the same reason the transcript's `signer` item must be the account that
+signs the sign-up, not any other key the player holds.
+
+`airdropVrfTranscript` is exported for a caller minting VRFs some other way. Both the transcript
+label and its domain prefix are module-level `pub const`s in the airdrop pallet, so unlike
+`Game`'s event-id base neither reaches metadata; the pinned test vectors are the only guard, the
+same situation the `PeopleAirdrops` event-id base is in.
+
+**There is no local VRF verification step.** dim2-spa verifies before submitting, because one
+bad entry fails the whole sign-up — but schnorrkel VRF verification has no implementation in
+this workspace, and the failure it guards against is the wrong signing key, which the transcript
+binds and this code checks without any crypto. VRFs are minted sequentially rather than in
+parallel: each is a signing operation, and firing sixteen at once is hidden by an `AutoSigning`
+allowance right up until a product ships without one.
+
+**Paseo only.** Devnet's pinned metadata predates the multi-airdrop sign-up, and the umbrella's
+contract test asserts that a devnet client *fails* `SignUpChain` so a re-pin breaks the
+assertion rather than leaving the surface quietly unsupported.

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -9,7 +9,10 @@ description: >
   UsernameUnowned and a missing consumer record are both success values rather than errors, using
   the pure derivation without a chain client, the decode helpers for raw Score.Participants and
   Resources.Consumers values, and withAsPerson for the AsPerson transaction extension including
-  the RestrictOrigins requirement that otherwise fails every call.
+  the RestrictOrigins requirement that otherwise fails every call. Also covers the game surface:
+  reading the current game and its prize draws, whether you won one and claiming it, and signing
+  up for a game with its airdrop VRFs, including which sign-up paths the chain and the hosts
+  cannot currently support.
 ---
 
 # Product SDK Individuality
@@ -352,7 +355,7 @@ if (req.ok && req.value.canEnterDraws) {
 
 > **`sign_up_with_alias` CANNOT BE ASSEMBLED EITHER.** Its `sig`, the statement-account proof, is a bare `blake2_256` hash and the host's `signRaw` always `<Bytes>`-wraps it. `withAsPerson` gives the origin; that argument has no source. The example in the write section shows the origin, not a working flow.
 
-The seven reasons a sign-up or its draw entry can be blocked:
+The eight reasons a sign-up or its draw entry can be blocked:
 
 | Tag | Means |
 |---|---|

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -367,6 +367,8 @@ await submitAndWatch(
 );
 ```
 
+> **PASEO ONLY, AND DEVNET FAILS SILENTLY.** Devnet's call takes `airdrop`, singular, where paseo takes `airdrops`. PAPI encodes the object it is handed, so on devnet `airdrops` drops to `undefined` and the player signs up entering **no draw at all**, with no error on any channel. The umbrella contract test asserts a devnet client fails `GameChain & SignUpChain` so a re-pin breaks a build rather than a product.
+
 > **THE VARIANT IS NOT YOURS TO PICK.** The chain reads `Score` recognition and rejects the other with `InvalidAirdropVrfVariantForRecognition`: not recognized takes `Account`, recognized takes `Alias`. `is_recognized()` covers only `Recognized` and `ExternallyRecognized`, so a **`Suspended` player takes the account path**. Recognition is only half the gate: the account arm also destructures the origin, so a **person** who is not recognized satisfies neither arm and cannot enter any draw.
 
 > **A RECOGNIZED PLAYER CANNOT ENTER THE DRAWS AT ALL.** `Alias` needs a ring-VRF proof at `blake2_256("pop:polkadot.network/airdrop" ++ event_id)`, and hosts only sign at `blake2b_256("product/" ++ productId ++ "/" ++ suffix)`, which they compute themselves. That is a chain or host change, not more SDK code. It arrives as the `AliasVrfsUnavailable` blocker, and such a player **can** still sign up with an account, passing no draws.

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -319,6 +319,61 @@ The nine reasons a claim can be blocked, in the shape the seven personhood state
 - **`readDrawRegistration` is a prefix scan.** It answers "am I in tonight's draw" before the draw runs, which no point read can, but its cost grows with the participant count. Not for polling.
 - **`Score.Participants` spells the alias variant `Person`** where the airdrop registration entry calls it `Alias`. The wrong spelling reads nothing and looks like a missing record.
 
+### Signing Up for the Game
+
+Sign-up and draw entry are one extrinsic: `sign_up_with_account` takes `airdrops: Option<AirdropVrfs>`, one VRF per scheduled draw. Read the requirement, mint the VRFs, build the call.
+
+```ts
+import {
+  readGameSignUpRequirement,
+  mintAccountAirdropVrfs,
+  signUpWithAccountTx,
+} from "@parity/product-sdk-individuality";
+import { submitAndWatch } from "@parity/product-sdk-tx";
+
+const req = await readGameSignUpRequirement(chain, { registrant, keyType: "sr25519" });
+if (req.ok && req.value.canEnterDraws) {
+  const vrfs = await mintAccountAirdropVrfs(signer, {
+    eventIds: req.value.eventIds,
+    publicKey: account.publicKey,
+  });
+  if (vrfs.ok) {
+    await submitAndWatch(
+      signUpWithAccountTx(chain, { identifierKey, airdrops: vrfs.value }),
+      signer,
+    );
+  }
+}
+```
+
+> **THE VARIANT IS NOT YOURS TO PICK.** The chain reads `Score` recognition and rejects the other with `InvalidAirdropVrfVariantForRecognition`: not recognized takes `Account`, recognized takes `Alias`. `is_recognized()` covers only `Recognized` and `ExternallyRecognized`, so a **`Suspended` player takes the account path**.
+
+> **A RECOGNIZED PLAYER CANNOT ENTER THE DRAWS AT ALL.** `Alias` needs a ring-VRF proof at `blake2_256("pop:polkadot.network/airdrop" ++ event_id)`, and hosts only sign at `blake2b_256("product/" ++ productId ++ "/" ++ suffix)`, which they compute themselves. That is a chain or host change, not more SDK code. It arrives as the `AliasVrfsUnavailable` blocker, and such a player **can** still sign up with an account, passing no draws.
+
+> **`sign_up_with_alias` CANNOT BE ASSEMBLED EITHER.** Its `sig`, the statement-account proof, is a bare `blake2_256` hash and the host's `signRaw` always `<Bytes>`-wraps it. `withAsPerson` gives the origin; that argument has no source. The example in the write section shows the origin, not a working flow.
+
+The seven reasons a sign-up or its draw entry can be blocked:
+
+| Tag | Means |
+|---|---|
+| `NoGameRunning` | `Game.Game` is empty, the normal state between games |
+| `NotInRegistration` | The game left its registration phase |
+| `RegistrationEnded` | Past `registrationEnds`, still in the phase: the offchain worker moves phases on its own schedule |
+| `AlreadyRegistered` | `Game.Players[who].registered` is set |
+| `AliasVrfsUnavailable` | Draws only. Recognized, so the chain wants proofs no host can mint |
+| `NoDrawsScheduled` | Draws only. Nothing scheduled, so anything but `None` fails the count check |
+| `NotSr25519` | Draws only, and only if you passed `keyType`. Another scheme cannot mint `Account` VRFs |
+
+The first four stop the extrinsic; the last three stop only the draw entry. `canSignUp` and `canEnterDraws` are the split.
+
+### Sign-Up Gotchas
+
+- **Derive the event ids from one block.** An id built from one game's index and another's count addresses a draw that does not exist. Use the `eventIds` the read returns.
+- **The entry count must equal `airdropsScheduled` exactly.** A mismatch fails the whole sign-up, deposit included. `Some([])` is not `None`: omit `airdrops` to enter no draw.
+- **Only sr25519 accounts can take the account path.** The pallet reinterprets the account id **as** the public key, and nothing on chain records the scheme, so the SDK cannot check it unless you pass `keyType`.
+- **The transcript binds the signing key.** The `signer` item must be the account that signs the sign-up, not another key the player holds.
+- **No local VRF verification exists.** One bad entry fails everything, but schnorrkel verification is not in this workspace. What it would catch is the wrong key, which the transcript already binds.
+
 ## Acting As a Person (Write)
 
 `withAsPerson` wraps a signer so the call dispatches under a person origin. It returns a `PolkadotSigner`, so submission stays with `@parity/product-sdk-tx` and nothing about `submitAndWatch` changes.

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -346,7 +346,7 @@ if (req.ok && req.value.canEnterDraws) {
 }
 ```
 
-> **THE VARIANT IS NOT YOURS TO PICK.** The chain reads `Score` recognition and rejects the other with `InvalidAirdropVrfVariantForRecognition`: not recognized takes `Account`, recognized takes `Alias`. `is_recognized()` covers only `Recognized` and `ExternallyRecognized`, so a **`Suspended` player takes the account path**.
+> **THE VARIANT IS NOT YOURS TO PICK.** The chain reads `Score` recognition and rejects the other with `InvalidAirdropVrfVariantForRecognition`: not recognized takes `Account`, recognized takes `Alias`. `is_recognized()` covers only `Recognized` and `ExternallyRecognized`, so a **`Suspended` player takes the account path**. Recognition is only half the gate: the account arm also destructures the origin, so a **person** who is not recognized satisfies neither arm and cannot enter any draw.
 
 > **A RECOGNIZED PLAYER CANNOT ENTER THE DRAWS AT ALL.** `Alias` needs a ring-VRF proof at `blake2_256("pop:polkadot.network/airdrop" ++ event_id)`, and hosts only sign at `blake2b_256("product/" ++ productId ++ "/" ++ suffix)`, which they compute themselves. That is a chain or host change, not more SDK code. It arrives as the `AliasVrfsUnavailable` blocker, and such a player **can** still sign up with an account, passing no draws.
 
@@ -361,10 +361,11 @@ The seven reasons a sign-up or its draw entry can be blocked:
 | `RegistrationEnded` | Past `registrationEnds`, still in the phase: the offchain worker moves phases on its own schedule |
 | `AlreadyRegistered` | `Game.Players[who].registered` is set |
 | `AliasVrfsUnavailable` | Draws only. Recognized, so the chain wants proofs no host can mint |
+| `AccountVrfsNeedAnAccount` | Draws only. A person who is not recognized: the account arm needs an account origin, the alias arm needs recognition, so the chain takes neither |
 | `NoDrawsScheduled` | Draws only. Nothing scheduled, so anything but `None` fails the count check |
 | `NotSr25519` | Draws only, and only if you passed `keyType`. Another scheme cannot mint `Account` VRFs |
 
-The first four stop the extrinsic; the last three stop only the draw entry. `canSignUp` and `canEnterDraws` are the split.
+The first four stop the extrinsic; the last four stop only the draw entry. `canSignUp` and `canEnterDraws` are the split.
 
 ### Sign-Up Gotchas
 
@@ -372,6 +373,7 @@ The first four stop the extrinsic; the last three stop only the draw entry. `can
 - **The entry count must equal `airdropsScheduled` exactly.** A mismatch fails the whole sign-up, deposit included. `Some([])` is not `None`: omit `airdrops` to enter no draw.
 - **Only sr25519 accounts can take the account path.** The pallet reinterprets the account id **as** the public key, and nothing on chain records the scheme, so the SDK cannot check it unless you pass `keyType`.
 - **The transcript binds the signing key.** The `signer` item must be the account that signs the sign-up, not another key the player holds.
+- **A rejected sign-up costs a fee.** `Pays::No` applies on success only, and the airdrop registration rides inside the same extrinsic, so one bad VRF entry loses the game sign-up too. Read the blockers before submitting.
 - **No local VRF verification exists.** One bad entry fails everything, but schnorrkel verification is not in this workspace. What it would catch is the wrong key, which the transcript already binds.
 
 ## Acting As a Person (Write)

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -324,7 +324,7 @@ The nine reasons a claim can be blocked, in the shape the seven personhood state
 
 ### Signing Up for the Game
 
-Sign-up and draw entry are one extrinsic: `sign_up_with_account` takes `airdrops: Option<AirdropVrfs>`, one VRF per scheduled draw. Read the requirement, mint the VRFs, build the call.
+Sign-up and draw entry are one extrinsic: `sign_up_with_account` takes `airdrops: Option<AirdropVrfs>`, one VRF per scheduled draw. Read the requirement, mint the VRFs, build the call. **Gate the sign-up on `canSignUp` and only the minting on `canEnterDraws`**, or a recognized player is never signed up at all.
 
 ```ts
 import {
@@ -334,19 +334,37 @@ import {
 } from "@parity/product-sdk-individuality";
 import { submitAndWatch } from "@parity/product-sdk-tx";
 
+// `accounts.signVrf` takes the account first and returns a Result, so it needs
+// this adapter. `txSigner` is the ordinary PolkadotSigner, not the same object.
+const vrfSigner = {
+  signVrf: (label, items) =>
+    accounts.signVrf(account, label, items).match(
+      (sig) => sig,
+      (cause) => { throw cause },
+    ),
+};
+
 const req = await readGameSignUpRequirement(chain, { registrant, keyType: "sr25519" });
-if (req.ok && req.value.canEnterDraws) {
-  const vrfs = await mintAccountAirdropVrfs(signer, {
+if (!req.ok || !req.value.canSignUp) return;
+
+let airdrops;
+if (req.value.canEnterDraws) {
+  const vrfs = await mintAccountAirdropVrfs(vrfSigner, {
     eventIds: req.value.eventIds,
     publicKey: account.publicKey,
   });
-  if (vrfs.ok) {
-    await submitAndWatch(
-      signUpWithAccountTx(chain, { identifierKey, airdrops: vrfs.value }),
-      signer,
-    );
-  }
+  if (!vrfs.ok) return;
+  airdrops = vrfs.value;
 }
+
+await submitAndWatch(
+  signUpWithAccountTx(chain, {
+    identifierKey,
+    airdrops,
+    airdropsScheduled: req.value.airdropsScheduled,
+  }),
+  txSigner,
+);
 ```
 
 > **THE VARIANT IS NOT YOURS TO PICK.** The chain reads `Score` recognition and rejects the other with `InvalidAirdropVrfVariantForRecognition`: not recognized takes `Account`, recognized takes `Alias`. `is_recognized()` covers only `Recognized` and `ExternallyRecognized`, so a **`Suspended` player takes the account path**. Recognition is only half the gate: the account arm also destructures the origin, so a **person** who is not recognized satisfies neither arm and cannot enter any draw.


### PR DESCRIPTION
Part of #286.
Refs #291, does not close it.

### Description

Adds game sign-up to `@parity/product-sdk-individuality`: what the chain will accept from a player now, the airdrop VRFs the sign-up carries, and the call. Step 5 of #291's build order. Steps 6 and 7 need chain or host changes, see below.

### Changes

`individuality/src/signup-types.ts` The domain types. `AirdropVrfVariant` is read from the chain, never chosen. `SignUpBlocker` reports every cause rather than the first, and splits four that stop the extrinsic from four that stop only the draw entry.

`individuality/src/signup-vrf.ts` The Merlin transcript an `AirdropVrfs::Account` entry signs. Neither the label nor the domain prefix reaches metadata, so pinned byte vectors are the only guard. Imports no workspace package, so its tests run against an unbuilt tree.

`individuality/src/signup.ts` `readGameSignUpRequirement` reads the game, `Score.Participants` and `Game.Players` at one pinned block. `mintAccountAirdropVrfs` signs one VRF per draw, sequentially, through a structural signer so the package keeps no dependency on the host package. `signUpWithAccountTx` builds the unsigned call. Submission stays with `@parity/product-sdk-tx`.

`individuality/src/index.ts`, `as-person-signer.ts` Exports, plus a note on the two `withAsPerson` examples: they show the origin, which works, and the rest of that call cannot be assembled.

`sdk/src/individuality/contract.test.ts` Compile-time assertions that a real client satisfies `SignUpChain`, that devnet fails the intersection the read takes, and that devnet's argument is `airdrop` where paseo's is `airdrops`.

`skills/product-sdk-individuality/SKILL.md`, `README.md`, `packages/individuality/package.json` The sign-up section, placed before the write section so the blocked path is stated ahead of the example a reader would copy. The skill frontmatter and the package descriptions now name the game and sign-up surfaces, which they did not, so questions about them never routed here. Plus one changeset.

### Why these changes

Entering a user into a game and its draws meant building `Game.sign_up_with_account` and minting the VRFs by hand, and two products need the same logic. It also puts three easy-to-miss facts into types: the variant is the chain's choice and `Suspended` counts as not recognized, the entry count must equal `airdrops_scheduled` exactly or the sign-up fails with the deposit, and only sr25519 accounts can take this path because the pallet reads the account id as the public key and no chain read reveals the scheme.

Two parts of #291 are deliberately absent.

Entering the draws as a recognized player needs a ring-VRF proof at `blake2_256("pop:polkadot.network/airdrop" ++ event_id)`, and every context a host will sign under is `blake2b_256("product/" ++ productId ++ "/" ++ suffix)`, which the host computes itself. `sign_up_with_alias` also needs a statement-account proof over a bare `blake2_256` hash, and the host's `signRaw` always wraps what it signs in `<Bytes>`. Both need a chain or host change, so they surface as the `AliasVrfsUnavailable` and `AccountVrfsNeedAnAccount` blockers rather than as a call that fails on chain. That matters because a rejected sign-up costs a fee: `Pays::No` applies on success only, and the airdrop registration rides inside the same extrinsic.

Step 7, the `PeopleAirdrops` path, is untouched and still has no origin any product can produce.

### Testing

```
cd product-sdk
pnpm install
cd packages/descriptors && pnpm generate && cd ../..
pnpm -r build
pnpm --filter "@parity/product-sdk-individuality" test
pnpm --filter "@parity/product-sdk-individuality" build
pnpm --filter "@parity/product-sdk" test
pnpm -r typecheck
pnpm check
```

Build the individuality package before the umbrella typecheck, or it resolves a stale `dist`. That typecheck is the load-bearing check: it proves a real client satisfies `SignUpChain`, where the same assertion inside the package passes against a bogus contract. Confirmed by narrowing the interface, which makes it fail.

`pnpm generate` rewrites eight `chains/*/package.json` files. Not part of this branch, revert with `git checkout -- packages/descriptors/chains/`.

All green: individuality 377 tests, up from 350 on `main`. Umbrella 192, unchanged. 19 packages typecheck, `pnpm check` clean over 329 files.

The last two commits apply two rounds of local review, one Critical, four Moderate, four Optional, each with a test. The Critical is worth knowing when reading the diff: draw entry is gated on recognition and on the origin variant, and modelling only the first made an unrecognized person read as able to enter the draws when the chain rejects the whole sign-up.