### PR TITLE
test(e2e): skip contracts-demo query specs against a reaped contract

### DIFF
--- a/product-sdk/examples/contracts-demo/e2e/query.spec.ts
+++ b/product-sdk/examples/contracts-demo/e2e/query.spec.ts
@@ -40,7 +40,17 @@ import { waitForAppReady } from "./helpers";
  */
 const FRESH_SHOP_KEY = ("0x" + randomBytes(32).toString("hex")) as `0x${string}`;
 
-test.describe("@parity/product-sdk-contracts via Host API — query", () => {
+// TODO(contracts-demo-redeploy): the @t3rminal/bulletin-index contract at
+// 0xD35CFc6E9F07B42Cc524A9Fa4A001F6ac90586E2 no longer exists on Paseo Asset
+// Hub — it was reaped in the genesis reset (see the "re-pin paseo chains after
+// genesis reset" descriptor bump). A ReviveApi.call dry-run to that address now
+// returns success:true with flags:0 and empty (0-byte) output data and 0 gas,
+// which the SDK correctly decodes to `undefined`, so these deterministic-empty
+// assertions (uint256 0, string[] [], string "") fail. This is stale chain
+// state, not an SDK regression: the wrap.ts "PAPI 2.x boundary" unit tests that
+// cover this exact decode all pass. Re-enable once the contract is redeployed
+// and the address + cdm.json are updated. Tracking: <issue link>.
+test.describe.skip("@parity/product-sdk-contracts via Host API — query", () => {
     test("getReportCount(fresh shopKey) decodes uint256 → 0 (deterministic)", async ({
         testHost,
     }) => {

--- a/product-sdk/examples/contracts-demo/e2e/query.spec.ts
+++ b/product-sdk/examples/contracts-demo/e2e/query.spec.ts
@@ -49,7 +49,7 @@ const FRESH_SHOP_KEY = ("0x" + randomBytes(32).toString("hex")) as `0x${string}`
 // assertions (uint256 0, string[] [], string "") fail. This is stale chain
 // state, not an SDK regression: the wrap.ts "PAPI 2.x boundary" unit tests that
 // cover this exact decode all pass. Re-enable once the contract is redeployed
-// and the address + cdm.json are updated. Tracking: <issue link>.
+// and the address + cdm.json are updated. Tracking: #322
 test.describe.skip("@parity/product-sdk-contracts via Host API — query", () => {
     test("getReportCount(fresh shopKey) decodes uint256 → 0 (deterministic)", async ({
         testHost,


### PR DESCRIPTION
The `contracts-demo` e2e query tests target `@t3rminal/bulletin-index` at `0xD35C…86E2`, which no longer exists on Paseo AH (reaped in the genesis reset). A `ReviveApi.call` dry-run there returns `success:true` with 0-byte data and 0 gas → the SDK correctly decodes `undefined` → the deterministic-empty assertions fail.

This is stale chain state, **not** an SDK regression, all 162 contracts unit tests, including the `wrap.ts` PAPI 2.x boundary decode suite, pass. Only `contracts-demo` fails in the whole e2e run; every other demo is green.

Skips the `query` describe block (mirroring the existing `cloud-storage` and `signing-rejected` skips) so the E2E workflow stops being blocked. Re-enable once the contract is redeployed and the address + `cdm.json` are updated.

Tracking: #322 