### PR TITLE
fix(signing): prefer signed V4 on dual-version runtimes

### DIFF
--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -342,21 +342,40 @@ export interface AccountsProvider {
 }
 
 /**
- * Derive the host's extrinsic-extension version from SCALE-encoded metadata:
- * v4 → 0, otherwise the latest supported version. `unifyMetadata` normalizes
- * v14/v15 so `.extrinsic.version` is an array.
+ * Map metadata's supported extrinsic formats to the host wire protocol.
  *
- * Indirected through {@link deps} so the SCALE decode (which needs a real
- * metadata blob) can be stubbed in unit tests while the rest of the `signTx`
- * flow — genesis extraction, extension mapping, the host call — is exercised.
+ * V5 General transactions have no envelope signature, so prefer V5 only when
+ * PAPI's version-zero extension pipeline exposes the `VerifyMultiSignature`
+ * slot the host uses to authorize a product-account transaction. If that slot
+ * is absent while V4 remains available, use V4's signed envelope instead.
+ *
+ * A V5-only runtime still maps to V5: the host may support another
+ * authorization pipeline, and otherwise returns the authoritative unsupported
+ * error. Unknown future versions retain the previous highest-version behavior.
  */
-function deriveTxExtVersion(metadata: Uint8Array): number {
-    const versions = unifyMetadata(decAnyMetadata(metadata)).extrinsic.version;
+function selectHostTxExtVersion(
+    versions: readonly number[],
+    versionZeroExtensionIds: readonly string[],
+): number {
     if (versions.length === 0) {
         throw new Error("No extrinsic version found in metadata");
     }
-    const latestVersion = versions.reduce((acc, v) => Math.max(acc, v), 0);
-    return latestVersion === 4 ? 0 : latestVersion;
+    if (versions.includes(5) && versionZeroExtensionIds.includes("VerifyMultiSignature")) {
+        return 5;
+    }
+    if (versions.includes(4)) {
+        return 0;
+    }
+    return versions.reduce((acc, version) => Math.max(acc, version), 0);
+}
+
+/** Derive the host's transaction-extension version from SCALE metadata. */
+function deriveTxExtVersion(metadata: Uint8Array): number {
+    const extrinsic = unifyMetadata(decAnyMetadata(metadata)).extrinsic;
+    return selectHostTxExtVersion(
+        extrinsic.version,
+        (extrinsic.signedExtensions[0] ?? []).map(({ identifier }) => identifier),
+    );
 }
 
 /** Internal seam so `import.meta.vitest` can stub the metadata decode. @internal */
@@ -586,6 +605,28 @@ export async function getAccountsProvider(): Promise<AccountsProvider | null> {
 
 if (import.meta.vitest) {
     const { test, expect, vi } = import.meta.vitest;
+
+    test("host signing uses V5 on a dual runtime with its signature extension", () => {
+        expect(selectHostTxExtVersion([4, 5], ["VerifyMultiSignature"])).toBe(5);
+    });
+
+    test("host signing falls back to V4 when dual-runtime V5 cannot carry its signature", () => {
+        expect(selectHostTxExtVersion([4, 5], ["CheckNonce", "AsPgas"])).toBe(0);
+    });
+
+    test("host signing uses V5 when V4 is unavailable", () => {
+        expect(selectHostTxExtVersion([5], ["AsPgas"])).toBe(5);
+    });
+
+    test("host signing maps a V4-only runtime to the wire sentinel", () => {
+        expect(selectHostTxExtVersion([4], ["CheckNonce"])).toBe(0);
+    });
+
+    test("host signing rejects metadata with no extrinsic version", () => {
+        expect(() => selectHostTxExtVersion([], [])).toThrow(
+            "No extrinsic version found in metadata",
+        );
+    });
 
     /** Minimal fake of the truapi account/signing domains used to test the adapter. */
     function makeFakeClient(opts: { onCall?: (method: string, args: unknown) => void } = {}) {

--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -344,24 +344,16 @@ export interface AccountsProvider {
 /**
  * Map metadata's supported extrinsic formats to the host wire protocol.
  *
- * V5 General transactions have no envelope signature, so prefer V5 only when
- * PAPI's version-zero extension pipeline exposes the `VerifyMultiSignature`
- * slot the host uses to authorize a product-account transaction. If that slot
- * is absent while V4 remains available, use V4's signed envelope instead.
- *
- * A V5-only runtime still maps to V5: the host may support another
- * authorization pipeline, and otherwise returns the authoritative unsupported
- * error. Unknown future versions retain the previous highest-version behavior.
+ * V4 carries the account signature in its envelope. V5 General transactions
+ * delegate authorization to the runtime's extension pipeline, but metadata
+ * alone does not say whether the connected host can implement that pipeline.
+ * Prefer an advertised V4 until the host protocol can negotiate V5
+ * authorization capabilities; V5-only and unknown future runtimes retain the
+ * previous highest-version behavior and the host remains authoritative.
  */
-function selectHostTxExtVersion(
-    versions: readonly number[],
-    versionZeroExtensionIds: readonly string[],
-): number {
+function selectHostTxExtVersion(versions: readonly number[]): number {
     if (versions.length === 0) {
         throw new Error("No extrinsic version found in metadata");
-    }
-    if (versions.includes(5) && versionZeroExtensionIds.includes("VerifyMultiSignature")) {
-        return 5;
     }
     if (versions.includes(4)) {
         return 0;
@@ -371,11 +363,8 @@ function selectHostTxExtVersion(
 
 /** Derive the host's transaction-extension version from SCALE metadata. */
 function deriveTxExtVersion(metadata: Uint8Array): number {
-    const extrinsic = unifyMetadata(decAnyMetadata(metadata)).extrinsic;
-    return selectHostTxExtVersion(
-        extrinsic.version,
-        (extrinsic.signedExtensions[0] ?? []).map(({ identifier }) => identifier),
-    );
+    const versions = unifyMetadata(decAnyMetadata(metadata)).extrinsic.version;
+    return selectHostTxExtVersion(versions);
 }
 
 /** Internal seam so `import.meta.vitest` can stub the metadata decode. @internal */
@@ -606,26 +595,20 @@ export async function getAccountsProvider(): Promise<AccountsProvider | null> {
 if (import.meta.vitest) {
     const { test, expect, vi } = import.meta.vitest;
 
-    test("host signing uses V5 on a dual runtime with its signature extension", () => {
-        expect(selectHostTxExtVersion([4, 5], ["VerifyMultiSignature"])).toBe(5);
-    });
-
-    test("host signing falls back to V4 when dual-runtime V5 cannot carry its signature", () => {
-        expect(selectHostTxExtVersion([4, 5], ["CheckNonce", "AsPgas"])).toBe(0);
+    test("host signing prefers V4 on a dual V4/V5 runtime", () => {
+        expect(selectHostTxExtVersion([4, 5])).toBe(0);
     });
 
     test("host signing uses V5 when V4 is unavailable", () => {
-        expect(selectHostTxExtVersion([5], ["AsPgas"])).toBe(5);
+        expect(selectHostTxExtVersion([5])).toBe(5);
     });
 
     test("host signing maps a V4-only runtime to the wire sentinel", () => {
-        expect(selectHostTxExtVersion([4], ["CheckNonce"])).toBe(0);
+        expect(selectHostTxExtVersion([4])).toBe(0);
     });
 
     test("host signing rejects metadata with no extrinsic version", () => {
-        expect(() => selectHostTxExtVersion([], [])).toThrow(
-            "No extrinsic version found in metadata",
-        );
+        expect(() => selectHostTxExtVersion([])).toThrow("No extrinsic version found in metadata");
     });
 
     /** Minimal fake of the truapi account/signing domains used to test the adapter. */

--- a/product-sdk/packages/terminal/src/signer.ts
+++ b/product-sdk/packages/terminal/src/signer.ts
@@ -178,14 +178,36 @@ function buildCreateTransactionRequest(
 }
 
 /**
- * Transaction-extension version the mobile app must assemble:
- *  - Extrinsic V4 → `0` (the protocol mandates 0 for V4).
- *  - Extrinsic V5 → the runtime's version (highest the metadata advertises).
+ * Select the transaction format the paired host can authorize.
+ *
+ * PAPI builds values for metadata's version-zero extension pipeline. A V5
+ * General transaction has no envelope signature, so use it only when that
+ * pipeline exposes `VerifyMultiSignature`; otherwise retain V4's signed
+ * envelope when the runtime advertises it. V5-only and unknown future runtimes
+ * retain the prior highest-version behavior so the host remains authoritative.
  */
+function selectTxExtVersion(
+    versions: readonly number[],
+    versionZeroExtensionIds: readonly string[],
+): number {
+    if (versions.length === 0) {
+        throw new Error("No extrinsic version found in metadata");
+    }
+    if (versions.includes(5) && versionZeroExtensionIds.includes("VerifyMultiSignature")) {
+        return 5;
+    }
+    if (versions.includes(4)) {
+        return 0;
+    }
+    return versions.reduce((max, version) => Math.max(max, version), 0);
+}
+
 function txExtVersionFromMetadata(metadata: Uint8Array): number {
-    const decoded = unifyMetadata(decAnyMetadata(metadata));
-    const latestVersion = decoded.extrinsic.version.reduce((max, v) => Math.max(max, v), 0);
-    return latestVersion === 4 ? 0 : latestVersion;
+    const extrinsic = unifyMetadata(decAnyMetadata(metadata)).extrinsic;
+    return selectTxExtVersion(
+        extrinsic.version,
+        (extrinsic.signedExtensions[0] ?? []).map(({ identifier }) => identifier),
+    );
 }
 
 /**
@@ -548,6 +570,24 @@ if (import.meta.vitest) {
         // metadata decode → SSO round-trip is exercised by the manual smoke
         // test in `manual-tests/qr-pair-and-sign.mjs` since CI cannot drive
         // a real phone.
+
+        test("selects V5 when the active pipeline can carry the account signature", () => {
+            expect(selectTxExtVersion([4, 5], ["VerifyMultiSignature"])).toBe(5);
+        });
+
+        test("falls back to V4 when dual-runtime V5 has no signature slot", () => {
+            expect(selectTxExtVersion([4, 5], ["CheckNonce", "AsPgas"])).toBe(0);
+        });
+
+        test("retains V5 when no V4 fallback exists", () => {
+            expect(selectTxExtVersion([5], ["AsPgas"])).toBe(5);
+        });
+
+        test("rejects metadata with no extrinsic version", () => {
+            expect(() => selectTxExtVersion([], [])).toThrow(
+                "No extrinsic version found in metadata",
+            );
+        });
 
         const checkGenesis = ext("CheckGenesis", [], [0x11, 0x22, 0x33]);
 

--- a/product-sdk/packages/terminal/src/signer.ts
+++ b/product-sdk/packages/terminal/src/signer.ts
@@ -178,23 +178,18 @@ function buildCreateTransactionRequest(
 }
 
 /**
- * Select the transaction format the paired host can authorize.
+ * Select the transaction format the paired host must assemble.
  *
- * PAPI builds values for metadata's version-zero extension pipeline. A V5
- * General transaction has no envelope signature, so use it only when that
- * pipeline exposes `VerifyMultiSignature`; otherwise retain V4's signed
- * envelope when the runtime advertises it. V5-only and unknown future runtimes
- * retain the prior highest-version behavior so the host remains authoritative.
+ * V4 carries the account signature in its envelope. V5 General transactions
+ * delegate authorization to the runtime's extension pipeline, but metadata
+ * alone cannot prove that the paired host implements that pipeline. Prefer an
+ * advertised V4 until the host protocol can negotiate V5 authorization
+ * capabilities; V5-only and unknown future runtimes retain the previous
+ * highest-version behavior.
  */
-function selectTxExtVersion(
-    versions: readonly number[],
-    versionZeroExtensionIds: readonly string[],
-): number {
+function selectTxExtVersion(versions: readonly number[]): number {
     if (versions.length === 0) {
         throw new Error("No extrinsic version found in metadata");
-    }
-    if (versions.includes(5) && versionZeroExtensionIds.includes("VerifyMultiSignature")) {
-        return 5;
     }
     if (versions.includes(4)) {
         return 0;
@@ -203,11 +198,8 @@ function selectTxExtVersion(
 }
 
 function txExtVersionFromMetadata(metadata: Uint8Array): number {
-    const extrinsic = unifyMetadata(decAnyMetadata(metadata)).extrinsic;
-    return selectTxExtVersion(
-        extrinsic.version,
-        (extrinsic.signedExtensions[0] ?? []).map(({ identifier }) => identifier),
-    );
+    const versions = unifyMetadata(decAnyMetadata(metadata)).extrinsic.version;
+    return selectTxExtVersion(versions);
 }
 
 /**
@@ -571,22 +563,20 @@ if (import.meta.vitest) {
         // test in `manual-tests/qr-pair-and-sign.mjs` since CI cannot drive
         // a real phone.
 
-        test("selects V5 when the active pipeline can carry the account signature", () => {
-            expect(selectTxExtVersion([4, 5], ["VerifyMultiSignature"])).toBe(5);
-        });
-
-        test("falls back to V4 when dual-runtime V5 has no signature slot", () => {
-            expect(selectTxExtVersion([4, 5], ["CheckNonce", "AsPgas"])).toBe(0);
+        test("prefers V4 on a dual V4/V5 runtime", () => {
+            expect(selectTxExtVersion([4, 5])).toBe(0);
         });
 
         test("retains V5 when no V4 fallback exists", () => {
-            expect(selectTxExtVersion([5], ["AsPgas"])).toBe(5);
+            expect(selectTxExtVersion([5])).toBe(5);
+        });
+
+        test("maps a V4-only runtime to the wire sentinel", () => {
+            expect(selectTxExtVersion([4])).toBe(0);
         });
 
         test("rejects metadata with no extrinsic version", () => {
-            expect(() => selectTxExtVersion([], [])).toThrow(
-                "No extrinsic version found in metadata",
-            );
+            expect(() => selectTxExtVersion([])).toThrow("No extrinsic version found in metadata");
         });
 
         const checkGenesis = ext("CheckGenesis", [], [0x11, 0x22, 0x33]);

--- a/product-sdk/pending-changesets/authorization-aware-tx-version.md
+++ b/product-sdk/pending-changesets/authorization-aware-tx-version.md
@@ -1,0 +1,8 @@
+---
+"@parity/product-sdk-host": patch
+"@parity/product-sdk-terminal": patch
+---
+
+**Select a transaction format the host can authorize.**
+
+Product-account signers now use Extrinsic V5 on dual V4/V5 runtimes only when metadata's version-zero transaction-extension pipeline declares `VerifyMultiSignature`. When V5 has no host-signature slot, they use the runtime's advertised V4 signed envelope instead. V5-only runtimes continue to use V5, preserving explicit host capability errors and future authorization support.

--- a/product-sdk/pending-changesets/authorization-aware-tx-version.md
+++ b/product-sdk/pending-changesets/authorization-aware-tx-version.md
@@ -1,8 +1,0 @@
----
-"@parity/product-sdk-host": patch
-"@parity/product-sdk-terminal": patch
----
-
-**Select a transaction format the host can authorize.**
-
-Product-account signers now use Extrinsic V5 on dual V4/V5 runtimes only when metadata's version-zero transaction-extension pipeline declares `VerifyMultiSignature`. When V5 has no host-signature slot, they use the runtime's advertised V4 signed envelope instead. V5-only runtimes continue to use V5, preserving explicit host capability errors and future authorization support.

--- a/product-sdk/pending-changesets/host-v4-signing-fallback.md
+++ b/product-sdk/pending-changesets/host-v4-signing-fallback.md
@@ -1,0 +1,8 @@
+---
+"@parity/product-sdk-host": patch
+"@parity/product-sdk-terminal": patch
+---
+
+**Use the signed V4 envelope when a runtime also advertises V5.**
+
+Product-account signers now prefer an advertised Extrinsic V4 format because metadata alone cannot prove that the connected host implements a runtime's V5 authorization pipeline. V5-only runtimes continue to use V5, preserving explicit host capability errors and future authorization support.


### PR DESCRIPTION
## Summary

- prefer Extrinsic V4 whenever a runtime advertises it, so product-account signatures use the signed envelope
- retain the previous highest-version behavior for V5-only and unknown future runtimes
- apply the same policy to host and terminal product-account signers
- add focused version-selection regressions and a staged patch changeset

## Why

V5 General transactions have no envelope signature. Their authorization is defined by a runtime-specific transaction-extension pipeline, and runtime metadata does not describe whether the connected host can implement that pipeline.

Paseo Asset Hub advertises `[4, 5]`, but its V5 pipeline gives the current Epoca host no supported place to put a product-account signature. The previous `max(versions)` policy selected V5 and Epoca correctly rejected the transaction as unauthorized. Asset Hub still advertises and accepts V4, whose signed envelope carries the product-account signature.

The first revision attempted to infer host V5 support from a `VerifyMultiSignature` metadata entry. Review found that unsafe: the host encodes the highest transaction-extension pipeline version rather than necessarily version zero, and metadata presence alone does not prove how the host owns or supplies that authorization extension. This revision makes no capability inference. V5 capability negotiation belongs in the host protocol before dual-version runtimes select it here.

## Verification

- `@parity/product-sdk-host`: 19/19 files, 108/108 tests passed
- `@parity/product-sdk-terminal`: 12/12 files, 168/168 tests passed
- host and terminal typechecks passed
- host and terminal builds passed
- Biome and `git diff --check` passed
- live Paseo Asset Hub through Epoca light-client: 5/5 affected flows passed
  - `create-transaction`
  - `sign-batch-payload`
  - `contract-store-value`
  - `contract-store-value-if-person`
  - `contract-withdraw`

Latest live batch transaction: `0x2205febc276eae15c8fea270ad72299358ef90e4671d768375b4c83b6cdfe8ea`