### PR TITLE
ci(docs): fix the Bulletin deploy domain

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -116,7 +116,7 @@ jobs:
               with:
                   timeout_minutes: 10
                   max_attempts: 3
-                  command: cd docs && bulletin-deploy ./out product-sdk.dot --js-merkle
+                  command: cd docs && bulletin-deploy ./out product-sdk --js-merkle
 
             - name: Rebuild static site for GitHub Pages
               if: steps.gate.outputs.skip != 'true'

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -108,7 +108,8 @@ jobs:
 
             - name: Install bulletin-deploy
               if: steps.gate.outputs.skip != 'true'
-              run: npm install -g bulletin-deploy
+              # Pinned: an upstream change would otherwise surface only on a release day.
+              run: npm install -g bulletin-deploy@0.15.2
 
             - name: Deploy to Bulletin Chain
               if: steps.gate.outputs.skip != 'true'

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -109,6 +109,7 @@ jobs:
             - name: Install bulletin-deploy
               if: steps.gate.outputs.skip != 'true'
               # Pinned: an upstream change would otherwise surface only on a release day.
+              # No automation bumps this, so check it if a release fails here.
               run: npm install -g bulletin-deploy@0.15.2
 
             - name: Deploy to Bulletin Chain
@@ -117,7 +118,7 @@ jobs:
               with:
                   timeout_minutes: 10
                   max_attempts: 3
-                  command: cd docs && bulletin-deploy ./out product-sdk --js-merkle
+                  command: cd docs && bulletin-deploy ./out product-sdk --env paseo-next-v2 --js-merkle
 
             - name: Rebuild static site for GitHub Pages
               if: steps.gate.outputs.skip != 'true'

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -7,12 +7,14 @@ on:
             - "product-sdk/**"
             - "docs/**"
             - ".github/workflows/docs-verify.yml"
+            - ".github/workflows/docs-deploy.yml"
     pull_request:
         branches: [main]
         paths:
             - "product-sdk/**"
             - "docs/**"
             - ".github/workflows/docs-verify.yml"
+            - ".github/workflows/docs-deploy.yml"
 
 # Read-only build: only needs to clone the repo to verify it builds.
 permissions:
@@ -66,3 +68,31 @@ jobs:
             - name: Build static site
               working-directory: docs
               run: pnpm build
+
+    bulletin-domain:
+        name: "docs: Bulletin deploy guard"
+        runs-on: parity-default
+        steps:
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  persist-credentials: false
+
+            - name: Check the deploy domain and the install pin
+              run: |
+                  wf=.github/workflows/docs-deploy.yml
+                  rc=0
+
+                  # bulletin-deploy resolves the TLD from the target environment,
+                  # so a literal one breaks on every other. Only release days run it.
+                  if grep -nE 'bulletin-deploy .*\.(dot|paseo|test)([[:space:]]|$)' "$wf"; then
+                    echo "::error file=$wf,title=Deploy domain carries a TLD::Pass the bare label. The environment decides the suffix."
+                    rc=1
+                  fi
+
+                  # Unpinned, an upstream release changes this workflow with no commit here.
+                  if grep -nE 'npm install -g @?[^@[:space:]]+[[:space:]]*$' "$wf"; then
+                    echo "::error file=$wf,title=Global install is unpinned::Pin the version."
+                    rc=1
+                  fi
+
+                  exit $rc

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -1,6 +1,8 @@
 name: "docs: Verify Build"
 
 on:
+    # docs-deploy.yml is in both filters for the guard job below. Filters are
+    # workflow-level, so the build job runs on it too.
     push:
         branches: [main]
         paths:
@@ -82,16 +84,24 @@ jobs:
                   wf=.github/workflows/docs-deploy.yml
                   rc=0
 
+                  # grep exits 2 on a missing file, which reads as "no match",
+                  # so without this the guard passes while checking nothing.
+                  if [ ! -f "$wf" ]; then
+                    echo "::error::$wf not found. If the deploy workflow moved, point this guard at it."
+                    exit 1
+                  fi
+
                   # bulletin-deploy resolves the TLD from the target environment,
                   # so a literal one breaks on every other. Only release days run it.
-                  if grep -nE 'bulletin-deploy .*\.(dot|paseo|test)([[:space:]]|$)' "$wf"; then
+                  if grep -nE 'bulletin-deploy .*\.(dot|paseo|test)\b' "$wf"; then
                     echo "::error file=$wf,title=Deploy domain carries a TLD::Pass the bare label. The environment decides the suffix."
                     rc=1
                   fi
 
-                  # Unpinned, an upstream release changes this workflow with no commit here.
-                  if grep -nE 'npm install -g @?[^@[:space:]]+[[:space:]]*$' "$wf"; then
-                    echo "::error file=$wf,title=Global install is unpinned::Pin the version."
+                  # Unpinned, an upstream release changes this workflow with no
+                  # commit here. A tag such as @latest is not a pin.
+                  if grep -nE 'npm (install|i) (-g|--global) [^[:space:]]+' "$wf" | grep -vE '@[0-9]'; then
+                    echo "::error file=$wf,title=Global install is unpinned::Pin to a version, not a tag."
                     rc=1
                   fi
 


### PR DESCRIPTION
### Description

The docs Bulletin deploy fails on every release day. It passes a hardcoded `product-sdk.dot`, and `bulletin-deploy` now takes the suffix from the target environment, which uses `.paseo` names. Every step is gated on an umbrella tag at HEAD, so ordinary runs skip everything and report success, which hid it until `0.23.0`.

### Changes

- Pass the bare label `product-sdk` with `--env paseo-next-v2`, so the tool resolves the suffix and a moved default fails instead of publishing somewhere else.
- Pin the install to `bulletin-deploy@0.15.2`. Nothing bumps that automatically, which the comment records.
- Add a `bulletin-domain` job to `docs-verify.yml` that rejects a literal suffix or an install without a version, and add `docs-deploy.yml` to the path filters.

The published name changes from `product-sdk.dot` to `product-sdk.paseo`, at `product-sdk.paseo.li`. Nothing in the repo links to the old one. The first deploy registers the new name and pays its storage deposit.

No changeset. `RELEASES.md` exempts CI changes under `.github/`.

### Testing

The guard is the regression test: exit 1 on `main`, 0 here. The first commit adds it before the fix, so it is red on its own.

```bash
grep -nE 'bulletin-deploy .*\.(dot|paseo|test)\b' .github/workflows/docs-deploy.yml
grep -nE 'npm (install|i) (-g|--global) [^[:space:]]+' .github/workflows/docs-deploy.yml | grep -vE '@[0-9]'
```

Both are silent here. On `main` they print lines 119 and 111. The domain was checked against the tool's own `parseDomainName` from `0.15.2`: `product-sdk.dot` throws the error CI reported, `product-sdk` resolves to `product-sdk.paseo`.