### PR TITLE
feat(host): add getLocaleProvider for the host's selected language

### DIFF
--- a/product-sdk/packages/host/src/index.ts
+++ b/product-sdk/packages/host/src/index.ts
@@ -105,6 +105,10 @@ export type { DevicePermissionKind, RemotePermissionItem } from "./permissions.j
 export { getThemeProvider } from "./theme.js";
 export type { ThemeMode, ThemeName, ThemeProvider, ThemeVariant } from "./theme.js";
 
+// Locale provider
+export { getLocaleProvider } from "./locale.js";
+export type { LocaleInfo, LocaleProvider } from "./locale.js";
+
 // Entropy derivation (RFC-0007)
 export { deriveEntropy } from "./entropy.js";
 

--- a/product-sdk/packages/host/src/locale.ts
+++ b/product-sdk/packages/host/src/locale.ts
@@ -1,0 +1,76 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Higher-level wrapper for the host's locale subscription, backed by
+ * `truApi.locale.subscribe`.
+ *
+ * `getLocaleProvider` returns a handle whose `subscribeLocale(cb)` delivers a
+ * typed {@link LocaleInfo} — a `{ languageTag }` struct carrying a BCP 47 tag
+ * such as `"en"`, `"pt-BR"` or `"zh-Hans"` — and yields a
+ * {@link HostSubscription} (`unsubscribe` + `onInterrupt`).
+ *
+ * @module
+ */
+
+import type { HostLocaleSubscribeItem, TrUApiClient } from "@parity/truapi";
+
+import { getClient, subscribeWithInterrupt } from "./transport.js";
+import type { HostSubscription } from "./types.js";
+
+/**
+ * Host locale value. A `{ languageTag }` struct re-exported from
+ * `@parity/truapi`.
+ */
+export type LocaleInfo = HostLocaleSubscribeItem;
+
+/**
+ * Host locale provider handle. `subscribeLocale(callback)` receives a typed
+ * {@link LocaleInfo} on every change and returns a {@link HostSubscription}.
+ */
+export interface LocaleProvider {
+    subscribeLocale(callback: (locale: LocaleInfo) => void): HostSubscription;
+}
+
+/** Build a {@link LocaleProvider} over a TruAPI client's `locale` domain. */
+function adaptLocaleProvider(client: TrUApiClient): LocaleProvider {
+    return {
+        subscribeLocale(callback) {
+            return subscribeWithInterrupt(client.locale.subscribe(), callback);
+        },
+    };
+}
+
+/**
+ * Get the host locale provider, backed by `truApi.locale.*`. Returns `null`
+ * when running outside a host container.
+ *
+ * The tag is whatever the host reports; a product that ships no catalog entry
+ * for it chooses its own fallback.
+ *
+ * @returns The locale provider, or `null` if unavailable.
+ *
+ * @example
+ * ```ts
+ * import { getLocaleProvider } from "@parity/product-sdk-host";
+ *
+ * const provider = await getLocaleProvider();
+ * if (provider) {
+ *   const sub = provider.subscribeLocale((locale) => {
+ *     i18n.activate(SUPPORTED.has(locale.languageTag) ? locale.languageTag : "en");
+ *   });
+ *   // sub.unsubscribe() to stop listening
+ * }
+ * ```
+ */
+export async function getLocaleProvider(): Promise<LocaleProvider | null> {
+    const client = await getClient();
+    return client ? adaptLocaleProvider(client) : null;
+}
+
+if (import.meta.vitest) {
+    const { test, expect } = import.meta.vitest;
+
+    test("getLocaleProvider returns null outside a container", async () => {
+        expect(await getLocaleProvider()).toBeNull();
+    });
+}

--- a/product-sdk/packages/host/src/testing.ts
+++ b/product-sdk/packages/host/src/testing.ts
@@ -287,7 +287,6 @@ export function createFakeTruApiClient(options?: CreateFakeTruApiClientOptions):
         payment: notModeled("payment"),
         permissions: notModeled("permissions"),
         resourceAllocation: notModeled("resourceAllocation"),
-        locale: notModeled("locale"),
         theme: notModeled("theme"),
     };
 

--- a/product-sdk/packages/host/src/testing.ts
+++ b/product-sdk/packages/host/src/testing.ts
@@ -287,6 +287,7 @@ export function createFakeTruApiClient(options?: CreateFakeTruApiClientOptions):
         payment: notModeled("payment"),
         permissions: notModeled("permissions"),
         resourceAllocation: notModeled("resourceAllocation"),
+        locale: notModeled("locale"),
         theme: notModeled("theme"),
     };
 

--- a/product-sdk/pending-changesets/host-locale-provider.md
+++ b/product-sdk/pending-changesets/host-locale-provider.md
@@ -1,0 +1,31 @@
+---
+"@parity/product-sdk-host": minor
+---
+
+**Add `getLocaleProvider` for the host's selected language.**
+
+A product can now render in the language the user picked inside the host, rather than
+inferring one from `navigator.language` — which reports the operating system's preference
+and is wrong whenever the two differ.
+
+```ts
+import { getLocaleProvider } from "@parity/product-sdk-host";
+
+const provider = await getLocaleProvider();
+const sub = provider?.subscribeLocale((locale) => {
+  i18n.activate(SUPPORTED.has(locale.languageTag) ? locale.languageTag : "en");
+});
+```
+
+`subscribeLocale` fires with the current locale and again on every change; the returned
+`HostSubscription` carries `unsubscribe` and `onInterrupt`. `getLocaleProvider` resolves to
+`null` outside a host container.
+
+`languageTag` is a BCP 47 tag such as `"en"`, `"pt-BR"` or `"zh-Hans"`. The set is open — a
+host adds languages without an SDK release — so a product that ships no catalog entry for
+the tag it receives picks its own fallback.
+
+**Testing.** The fake client models `locale` as not-modeled, so a test that reaches for it
+fails loudly rather than silently returning nothing.
+
+Requires a `@parity/truapi` release carrying the `locale` domain.

--- a/product-sdk/pending-changesets/host-locale-provider.md
+++ b/product-sdk/pending-changesets/host-locale-provider.md
@@ -1,5 +1,6 @@
 ---
 "@parity/product-sdk-host": minor
+"@parity/product-sdk": minor
 ---
 
 **Add `getLocaleProvider` for the host's selected language.**

--- a/product-sdk/pending-changesets/host-locale-provider.md
+++ b/product-sdk/pending-changesets/host-locale-provider.md
@@ -26,7 +26,4 @@ const sub = provider?.subscribeLocale((locale) => {
 host adds languages without an SDK release — so a product that ships no catalog entry for
 the tag it receives picks its own fallback.
 
-**Testing.** The fake client models `locale` as not-modeled, so a test that reaches for it
-fails loudly rather than silently returning nothing.
-
-Requires a `@parity/truapi` release carrying the `locale` domain.
+The `locale` domain arrived in `@parity/truapi` 0.12.0, already on the catalog.


### PR DESCRIPTION
Adds `getLocaleProvider`, so a product renders in the language the user picked inside the host rather than inferring one from `navigator.language` — which reports the operating system's preference and is wrong whenever the two differ.

```ts
import { getLocaleProvider } from "@parity/product-sdk-host";

const provider = await getLocaleProvider();
const sub = provider?.subscribeLocale((locale) => {
  i18n.activate(SUPPORTED.has(locale.languageTag) ? locale.languageTag : "en");
});
```

`subscribeLocale` fires with the current locale and again on every change; the returned `HostSubscription` carries `unsubscribe` and `onInterrupt`. `getLocaleProvider` resolves to `null` outside a host container.

`languageTag` is a BCP 47 tag such as `"en"`, `"pt-BR"` or `"zh-Hans"`. The set is open — a host adds languages without an SDK release — so a product that ships no catalog entry for the tag it receives picks its own fallback.

The fake client models `locale` as not-modeled, so a test that reaches for it fails loudly rather than silently returning nothing.

Protocol counterpart: paritytech/host-rust-core#526.

## Blocked on

A `@parity/truapi` release carrying the `locale` domain. The catalog pins `^0.10.0`, which predates it, so CI will not go green until that lands.

## Verified

- `pnpm --filter @parity/product-sdk-host typecheck` against a local `@parity/truapi` built from paritytech/host-rust-core#526 — no locale errors. One unrelated error remains (`system.info` / `getProductContext` missing from the fake client), which reproduces on a clean tree with the same link: it is drift between host-rust-core `main` and the published 0.10.0, not this change.
- `pnpm --filter @parity/product-sdk-host test` — 20 files, 123 tests passed, including the new in-source `locale.ts` test.
