### PR TITLE
docs(chain-client): the host decides reachability

### DIFF
--- a/product-sdk/packages/chain-client/src/index.ts
+++ b/product-sdk/packages/chain-client/src/index.ts
@@ -10,6 +10,11 @@
  * `createChainClient` is the bring-your-own-descriptors path for custom or
  * pre-release chains.
  *
+ * **A descriptor is not a transport.** Both paths connect through the host
+ * provider, keyed by the descriptor's genesis, with no WebSocket fallback, so a
+ * chain is reachable only if the active host routes it. Check first with
+ * `isChainSupported(genesisHash)` from `@parity/product-sdk-host`. See #94, #102.
+ *
  * @packageDocumentation
  */
 

--- a/product-sdk/packages/chain-client/src/types.ts
+++ b/product-sdk/packages/chain-client/src/types.ts
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ChainDefinition, PolkadotClient, TypedApi } from "polkadot-api";
 
-/** Supported chain environments for the Polkadot ecosystem. */
-export type Environment = "polkadot" | "kusama" | "paseo" | "devnet" | "local" | "westend";
-
 /**
  * Configuration for {@link createChainClient}.
  *

--- a/product-sdk/packages/chain-client/src/types.ts
+++ b/product-sdk/packages/chain-client/src/types.ts
@@ -6,7 +6,8 @@ import type { ChainDefinition, PolkadotClient, TypedApi } from "polkadot-api";
  * Configuration for {@link createChainClient}.
  *
  * Provide named chain descriptors. The SDK routes all connections through the
- * host provider, so no RPC endpoints are required.
+ * host provider, so no RPC endpoints are required, and only chains the host routes
+ * are reachable.
  *
  * @typeParam TChains - Record mapping user-chosen chain names to PAPI descriptors.
  *

--- a/product-sdk/packages/sdk/src/identity/dotns-namehash.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns-namehash.ts
@@ -13,8 +13,8 @@
  *   node("bob.alice.paseo") = node(node(tldNode, "alice"), "bob")
  *
  * The root is **per network**, not a constant. `DotnsProtocolRegistry.initialize`
- * fixes it once from a deploy-time label — `.dot` on Paseo Asset Hub Previewnet,
- * `.paseo` on Next V2 — and publishes it as `tld()` / `tldNode()`. Hashing under
+ * fixes it once from a deploy-time label — `.paseo` on Paseo Asset Hub Next V2,
+ * `.test` on Previewnet — and publishes it as `tld()` / `tldNode()`. Hashing under
  * the wrong root yields a node the chain has never written to, so every lookup
  * reports "unregistered" with no error anywhere. That is why {@link namehash}
  * takes the root rather than assuming one; `resolveTld` in `./dotns-registry.js`

--- a/product-sdk/packages/sdk/src/identity/dotns.ts
+++ b/product-sdk/packages/sdk/src/identity/dotns.ts
@@ -75,8 +75,8 @@ export type PeopleUsernameQueryApi = {
  * Whether `name` is a single registrable label under `suffix`.
  *
  * `suffix` is the deployment's own TLD, including its leading dot, as
- * `resolveTld` reports it — `".dot"` on Paseo Asset Hub Previewnet, `".paseo"`
- * on Next V2. It is required rather than defaulted, because a name is only
+ * `resolveTld` reports it — `".paseo"` on Paseo Asset Hub Next V2, `".test"`
+ * on Previewnet. It is required rather than defaulted, because a name is only
  * valid *relative to a deployment*: `alice.dot` is registrable on one network
  * and meaningless on the other, and a default would silently pick one.
  *

--- a/product-sdk/pending-changesets/chain-client-host-dependency.md
+++ b/product-sdk/pending-changesets/chain-client-host-dependency.md
@@ -1,0 +1,14 @@
+---
+"@parity/product-sdk-chain-client": patch
+"@parity/product-sdk": patch
+---
+
+**Say that createChainClient depends on the host, and correct two stale docs.**
+
+`createChainClient` accepts any PAPI descriptor, but every connection goes through the host provider keyed by that descriptor's genesis, with no WebSocket fallback. A chain is therefore reachable only if the active host routes it, which the package docs did not say while offering the path for "custom or pre-release chains". They now say it, and point at `isChainSupported` from `@parity/product-sdk-host` for checking before connecting. See #94 and #102 for the missing standalone path.
+
+Also removes a dead `Environment` union in `chain-client`'s `types.ts` that listed "local" and "westend", neither of which exists. Nothing imported it and the package exports only its root entry, so no consumer saw it.
+
+Also corrects the Previewnet DotNS TLD in two `identity/` comments, from `.dot` to `.test`, matching `dotns-abis.ts` which records verification on both networks.
+
+Docs, comments, and one unreachable type. No behaviour change.

--- a/product-sdk/skills/product-sdk-chain-connection/SKILL.md
+++ b/product-sdk/skills/product-sdk-chain-connection/SKILL.md
@@ -54,7 +54,7 @@ client.destroy();
 
 | | `getChainAPI` (Preset) | `createChainClient` (BYOD) |
 |---|---|---|
-| **When** | Known environments (paseo, devnet; polkadot and kusama reserved), or whatever the host reports when called with no argument | Custom chains or a subset of chains |
+| **When** | Known environments (paseo, devnet; polkadot and kusama reserved), or whatever the host reports when called with no argument | Custom chains or a subset of chains, as long as the host routes them |
 | **Descriptors** | Built-in, lazy-loaded | You import and provide them |
 | **Chains** | Always assetHub + bulletin + individuality | Any combination you choose |
 | **Bundle size** | Slightly larger (~6.3 MB for all 3 chains) | Minimal (only what you import) |
@@ -63,8 +63,11 @@ client.destroy();
 
 **Use `createChainClient`** when you need:
 - Only one chain (e.g., just Asset Hub for contracts)
-- Chains not in the preset list
+- Chains not in the preset list, and the host routes them
 - Minimal bundle size
+
+**Descriptors decide what is typed, the host decides what is reachable.** There is no
+WebSocket fallback, so check with `isChainSupported(genesisHash)` from `@parity/product-sdk-host`.
 
 ## Querying Chain State
 
@@ -168,7 +171,7 @@ destroyAll();
 
 2. **Using unavailable environments** — Only `"paseo"` and `"devnet"` work. `"polkadot"` and `"kusama"` throw.
 
-3. **Not cleaning up** — Call `client.destroy()` when done to close WebSocket connections.
+3. **Not cleaning up** — Call `client.destroy()` when done to close the host provider connections.
 
 4. **Barrel importing descriptors** — Use subpath imports: `@parity/product-sdk-descriptors/paseo-bulletin`, NOT `@parity/product-sdk-descriptors`.
 


### PR DESCRIPTION
Related to #94, #102

### Description
`createChainClient` takes any PAPI descriptor, but every connection goes through the host provider keyed by that descriptor's genesis, with no WebSocket fallback. The docs offered it for "custom or pre-release chains" without saying so, so "bring your own descriptor" got read as "use any environment". This states the constraint and points at `isChainSupported`, which already exists for checking first.

### Changes
- `chain-client/src/index.ts`, `types.ts`, and the chain-connection skill: descriptors decide what is typed, the host decides what is reachable. The skill also claimed `destroy()` closes WebSocket connections, there is no direct WebSocket path.
- Drops a dead `Environment` union in `types.ts` listing "local" and "westend". Nothing imported it and the package exports only its root entry.
- `identity/dotns.ts`, `dotns-namehash.ts`: Previewnet issues `.test` names, not `.dot`.

No behaviour change.

### Testing
```
pnpm -r build && pnpm typecheck && pnpm check
pnpm --filter @parity/product-sdk-chain-client --filter @parity/product-sdk test
```
All pass: 219 tests, biome clean, build and typecheck exit 0.