### PR TITLE
feat(individuality): registration on readCurrentGame, fromPapi adapter

### DIFF
--- a/product-sdk/packages/individuality/src/chain.ts
+++ b/product-sdk/packages/individuality/src/chain.ts
@@ -1,0 +1,52 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Adapt a PAPI client the caller already holds to the chain shape every read in
+ * this package takes.
+ *
+ * The reads are typed against the `@parity/product-sdk-chain-client` convention —
+ * typed APIs keyed by chain name, raw clients under `raw` — so a product that
+ * resolves its own People-chain connection (its own provider, its own descriptors)
+ * would otherwise build that object by hand. `fromPapi` builds it, and nothing
+ * else: no connection is made and no descriptor is loaded.
+ *
+ * ```ts
+ * import { createClient } from "polkadot-api";
+ * import { fromPapi, readCurrentGame } from "@parity/product-sdk-individuality";
+ *
+ * const client = createClient(provider);
+ * const game = await readCurrentGame(fromPapi(client, client.getTypedApi(people)));
+ * ```
+ *
+ * The result is only as complete as `api`: a typed API generated from the
+ * individuality chain's metadata satisfies every `*Chain` interface here, and
+ * `tsc` checks each entry a read touches against it.
+ */
+
+/** The one raw-client method the pinned reads use. Structural, so `PolkadotClient` fits. */
+export interface FinalizedBlockSource {
+    getFinalizedBlock(): Promise<{ hash: string; number: number }>;
+}
+
+/** What {@link fromPapi} returns, with the typed API preserved. */
+export interface PapiIndividualityChain<Api> {
+    individuality: Api;
+    raw: { individuality: FinalizedBlockSource };
+}
+
+export function fromPapi<Api>(client: FinalizedBlockSource, api: Api): PapiIndividualityChain<Api> {
+    return { individuality: api, raw: { individuality: client } };
+}
+
+if (import.meta.vitest) {
+    const { expect, test } = import.meta.vitest;
+
+    test("fromPapi places the api and client where the reads look for them", async () => {
+        const block = { hash: "0x01", number: 7 };
+        const client = { getFinalizedBlock: async () => block };
+        const api = { query: {} };
+        const chain = fromPapi(client, api);
+        expect(chain.individuality).toBe(api);
+        await expect(chain.raw.individuality.getFinalizedBlock()).resolves.toEqual(block);
+    });
+}

--- a/product-sdk/packages/individuality/src/game-read.ts
+++ b/product-sdk/packages/individuality/src/game-read.ts
@@ -20,9 +20,11 @@ import {
     type RawGameSchedule,
     type RawPhaseDurations,
 } from "./game-decode.js";
-import type { CurrentGameResult, GamePhaseDurations } from "./game-types.js";
+import type { CurrentGameResult, GamePhaseDurations, PlayerRegistration } from "./game-types.js";
+import type { AirdropRegistrant } from "./airdrop-types.js";
 import { ProductIndividualityError } from "./errors.js";
 import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
+import { playerKey, type PlayerKey } from "./player-key.js";
 import type { FinalizedSnapshot } from "./types.js";
 
 /**
@@ -71,6 +73,31 @@ export interface GameChain extends PinnedChain {
     };
 }
 
+/**
+ * The registration entry, needed only when {@link ReadCurrentGameOptions.players}
+ * is given. Kept out of {@link GameChain} so a caller that never asks about a
+ * player, and every existing test double, keeps satisfying the narrower type.
+ *
+ * ```
+ * Game.Players: StorageDescriptor<[Key: AccountOrPerson], { registered: boolean }, true, never>
+ * ```
+ */
+export interface GamePlayersChain {
+    individuality: {
+        query: {
+            Game: {
+                /** Absent for a player who has never signed up. */
+                Players: {
+                    getValue: (
+                        key: PlayerKey,
+                        options: ReadAt,
+                    ) => Promise<{ registered: boolean } | undefined>;
+                };
+            };
+        };
+    };
+}
+
 /** Options for {@link readCurrentGame}. */
 export interface ReadCurrentGameOptions {
     /**
@@ -78,12 +105,27 @@ export interface ReadCurrentGameOptions {
      * batch. No deadline is applied here — that belongs to the caller.
      */
     signal?: AbortSignal;
+    /**
+     * Whose registration to read, at the same block as the game. One person is
+     * keyed twice on chain — by account and, once recognized, by alias — so pass
+     * every key the caller holds; any hit answers `Registered`. Requires a chain
+     * that also satisfies {@link GamePlayersChain}.
+     */
+    players?: readonly AirdropRegistrant[];
 }
 
 /**
  * **No game running is not a failure**, it is `BetweenGames` — the chain's normal
  * state, since one game exists at a time and each is killed when it ends.
  */
+export async function readCurrentGame(
+    chain: GameChain & GamePlayersChain,
+    options: ReadCurrentGameOptions & { players: readonly AirdropRegistrant[] },
+): Promise<Result<CurrentGameResult, ProductIndividualityError>>;
+export async function readCurrentGame(
+    chain: GameChain,
+    options?: Omit<ReadCurrentGameOptions, "players">,
+): Promise<Result<CurrentGameResult, ProductIndividualityError>>;
 export async function readCurrentGame(
     chain: GameChain,
     options: ReadCurrentGameOptions = {},
@@ -106,17 +148,18 @@ export async function runGameRead(
     options: ReadCurrentGameOptions,
     pinned?: FinalizedSnapshot,
 ): Promise<CurrentGameResult> {
-    const { signal } = options;
+    const { signal, players } = options;
     const query = chain.individuality.query.Game;
 
     const snapshot = await pinBlock(chain, signal, pinned);
     const at: ReadAt = readAt(snapshot, signal);
 
-    const [gameIndex, rawGame, rawSchedules, storedDurations] = await Promise.all([
+    const [gameIndex, rawGame, rawSchedules, storedDurations, registration] = await Promise.all([
         query.GameIndex.getValue(at),
         query.Game.getValue(at),
         query.GameSchedules.getValue(at),
         query.StoredPhaseDurations.getValue(at),
+        readRegistration(chain, players, at),
     ]);
 
     // The constant is only needed when governance has set no override, so it is
@@ -151,9 +194,39 @@ export async function runGameRead(
         // game runs, and the game's own copy is the one a prize claim is keyed
         // by.
         game: toCurrentGame(rawGame),
+        registration,
         upcoming,
         durations,
     };
+}
+
+/**
+ * The per-key `Game.Players` reads, settled rather than raced: one key failing
+ * must not fail the game read, and must not read as "not registered" either.
+ * `players` is only ever set through the overload that demands
+ * {@link GamePlayersChain}, which is what the cast relies on.
+ */
+async function readRegistration(
+    chain: GameChain,
+    players: readonly AirdropRegistrant[] | undefined,
+    at: ReadAt,
+): Promise<PlayerRegistration> {
+    if (players === undefined) {
+        return { tag: "Unchecked" };
+    }
+    const entry = (chain as GameChain & GamePlayersChain).individuality.query.Game.Players;
+    const reads = await Promise.allSettled(
+        players.map((player) => entry.getValue(playerKey(player), at)),
+    );
+    let failed = false;
+    for (const read of reads) {
+        if (read.status === "rejected") {
+            failed = true;
+        } else if (read.value?.registered === true) {
+            return { tag: "Registered" };
+        }
+    }
+    return failed ? { tag: "Unknown" } : { tag: "NotRegistered" };
 }
 
 if (import.meta.vitest) {
@@ -207,6 +280,8 @@ if (import.meta.vitest) {
         game?: RawGameInfo;
         schedules?: RawGameSchedule[];
         stored?: RawPhaseDurations;
+        /** `Game.Players` rows by key; a key with a thrower fails that read only. */
+        players?: Record<string, { registered: boolean } | undefined | (() => never)>;
         failOn?:
             | "GameIndex"
             | "Game"
@@ -231,7 +306,7 @@ if (import.meta.vitest) {
             calls.push({ entry, at: options.at });
         };
 
-        const chain: GameChain = {
+        const chain: GameChain & GamePlayersChain = {
             individuality: {
                 constants: {
                     Game: {
@@ -270,6 +345,13 @@ if (import.meta.vitest) {
                                 boom("StoredPhaseDurations");
                                 record("StoredPhaseDurations", options);
                                 return state.stored;
+                            },
+                        },
+                        Players: {
+                            getValue: async (key, options) => {
+                                record(`Players:${key.type}:${key.value}`, options);
+                                const row = state.players?.[`${key.type}:${key.value}`];
+                                return typeof row === "function" ? row() : row;
                             },
                         },
                     },
@@ -320,6 +402,87 @@ if (import.meta.vitest) {
             const result = unwrapOk(await readCurrentGame(chain));
             if (result.tag !== "Running") throw new Error("expected Running");
             expect(result.game.index).toBe(41);
+        });
+    });
+
+    describe("readCurrentGame, registration", () => {
+        const ACCOUNT = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+        const ALIAS = `0x${"ab".repeat(32)}`;
+        const players = [
+            { tag: "Account", accountAddress: ACCOUNT },
+            { tag: "Alias", alias: ALIAS },
+        ] as const;
+
+        test("is Unchecked when no players are given, and reads nothing for it", async () => {
+            const { chain, calls } = fakeChain({ game: rawGame(), stored: STORED });
+            const result = unwrapOk(await readCurrentGame(chain));
+            if (result.tag !== "Running") throw new Error("expected Running");
+            expect(result.registration).toEqual({ tag: "Unchecked" });
+            expect(calls.some((call) => call.entry.startsWith("Players:"))).toBe(false);
+        });
+
+        test("reads every key at the pinned block, under the pallet's own arm names", async () => {
+            const { chain, calls } = fakeChain({ game: rawGame(), stored: STORED });
+            await readCurrentGame(chain, { players });
+            const reads = calls.filter((call) => call.entry.startsWith("Players:"));
+            expect(reads.map((call) => call.entry)).toEqual([
+                `Players:Account:${ACCOUNT}`,
+                `Players:Person:${ALIAS}`,
+            ]);
+            expect(new Set(reads.map((call) => call.at))).toEqual(new Set([BLOCK.hash]));
+        });
+
+        test("one registered key is enough", async () => {
+            const { chain } = fakeChain({
+                game: rawGame(),
+                stored: STORED,
+                players: { [`Person:${ALIAS}`]: { registered: true } },
+            });
+            const result = unwrapOk(await readCurrentGame(chain, { players }));
+            if (result.tag !== "Running") throw new Error("expected Running");
+            expect(result.registration).toEqual({ tag: "Registered" });
+        });
+
+        test("no row and a registered:false row both mean NotRegistered", async () => {
+            const { chain } = fakeChain({
+                game: rawGame(),
+                stored: STORED,
+                players: { [`Account:${ACCOUNT}`]: { registered: false } },
+            });
+            const result = unwrapOk(await readCurrentGame(chain, { players }));
+            if (result.tag !== "Running") throw new Error("expected Running");
+            expect(result.registration).toEqual({ tag: "NotRegistered" });
+        });
+
+        test("a failed key read is Unknown, not NotRegistered, and does not fail the game", async () => {
+            const { chain } = fakeChain({
+                game: rawGame(),
+                stored: STORED,
+                players: {
+                    [`Account:${ACCOUNT}`]: () => {
+                        throw new Error("Players unreachable");
+                    },
+                },
+            });
+            const result = unwrapOk(await readCurrentGame(chain, { players }));
+            if (result.tag !== "Running") throw new Error("expected Running");
+            expect(result.registration).toEqual({ tag: "Unknown" });
+        });
+
+        test("a failed key read still loses to a registered one", async () => {
+            const { chain } = fakeChain({
+                game: rawGame(),
+                stored: STORED,
+                players: {
+                    [`Account:${ACCOUNT}`]: () => {
+                        throw new Error("Players unreachable");
+                    },
+                    [`Person:${ALIAS}`]: { registered: true },
+                },
+            });
+            const result = unwrapOk(await readCurrentGame(chain, { players }));
+            if (result.tag !== "Running") throw new Error("expected Running");
+            expect(result.registration).toEqual({ tag: "Registered" });
         });
     });
 

--- a/product-sdk/packages/individuality/src/game-types.ts
+++ b/product-sdk/packages/individuality/src/game-types.ts
@@ -143,12 +143,29 @@ export interface GameSchedulePreview {
  * Between games is not a failure and not an empty result: the chain was asked
  * and answered that no game is running, which is most of the time.
  */
+/**
+ * Whether the players named in `ReadCurrentGameOptions.players` are in the
+ * running game. One identity is keyed twice on chain (account and alias), so the
+ * question is asked per key and answered once: any hit is `Registered`.
+ *
+ * `Unknown` exists so a failed key read cannot be mistaken for "not registered"
+ * — a stale account miss must not hide a person-side registration. `Unchecked`
+ * exists so "we did not ask" cannot be mistaken for either.
+ */
+export type PlayerRegistration =
+    | { tag: "Registered" }
+    | { tag: "NotRegistered" }
+    | { tag: "Unknown" }
+    | { tag: "Unchecked" };
+
 export type CurrentGameResult =
     /** A game exists in `Game.Game`. */
     | {
           tag: "Running";
           at: FinalizedSnapshot;
           game: CurrentGame;
+          /** Read at the same block as the game; `Unchecked` unless players were given. */
+          registration: PlayerRegistration;
           /** Games after this one, chronologically. */
           upcoming: GameSchedulePreview[];
           /** The durations the {@link GameSchedulePreview} timelines were derived with. */

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -194,6 +194,7 @@ export type {
     GameScheduledAirdrop,
     GameSchedulePreview,
     GameTimeline,
+    PlayerRegistration,
 } from "./game-types.js";
 
 // Raw `Game` storage values to domain shapes, plus the phase-boundary
@@ -214,9 +215,16 @@ export type {
     RawPhaseDurations,
 } from "./game-decode.js";
 
-// The pinned current-game read.
+// The pinned current-game read. `players` asks about registration in the same
+// read; it needs the `Players` entry, which `GamePlayersChain` adds on top.
 export { readCurrentGame } from "./game-read.js";
-export type { GameChain, ReadCurrentGameOptions } from "./game-read.js";
+export type { GameChain, GamePlayersChain, ReadCurrentGameOptions } from "./game-read.js";
+export type { PlayerKey } from "./player-key.js";
+
+// For callers holding their own PAPI client: build the chain shape without
+// `@parity/product-sdk-chain-client`.
+export { fromPapi } from "./chain.js";
+export type { FinalizedBlockSource, PapiIndividualityChain } from "./chain.js";
 
 // Signing up for the game, and entering its prize draws in the same call. The
 // requirement read comes first because the event ids depend on the game index and

--- a/product-sdk/packages/individuality/src/player-key.ts
+++ b/product-sdk/packages/individuality/src/player-key.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The `AccountOrPerson` key the game and score reads take, and the one place
+ * an {@link AirdropRegistrant} is turned into it.
+ *
+ * Two things keep the umbrella contract test honest here, both verified by
+ * breaking them. The narrow type catches a descriptor re-pin that renames an arm.
+ * Property syntax on the `getValue`s that take it catches widening this back to
+ * `{ type: string }`, which method syntax would accept, since method parameters
+ * are bivariant. Without either, a renamed arm reads nothing and looks like an
+ * absent record.
+ */
+import { Enum } from "polkadot-api";
+import type { AirdropRegistrant } from "./airdrop-types.js";
+
+export type PlayerKey = { type: "Account"; value: string } | { type: "Person"; value: string };
+
+export function playerKey(registrant: AirdropRegistrant): PlayerKey {
+    // `AccountOrPerson` spells the alias arm `Person` where the airdrop pallet's
+    // registration entry spells it `Alias`. Same identity, two names, and the
+    // wrong one reads nothing rather than failing.
+    return registrant.tag === "Account"
+        ? Enum("Account", registrant.accountAddress)
+        : Enum("Person", registrant.alias);
+}

--- a/product-sdk/packages/individuality/src/signup.ts
+++ b/product-sdk/packages/individuality/src/signup.ts
@@ -50,7 +50,6 @@
  *
  * Only the `Account` variant is buildable. `signup-types.ts` says why.
  */
-import { Enum } from "polkadot-api";
 import { err, normalizeError, ok, type Result } from "@parity/result";
 import { bytesToHex } from "@parity/product-sdk-utils";
 import { gameAirdropEventIds } from "./airdrop-ids.js";
@@ -60,6 +59,7 @@ import { toPersonhoodParticipant, type RawParticipant } from "./decode.js";
 import { ProductIndividualityError } from "./errors.js";
 import { runGameRead, type GameChain } from "./game-read.js";
 import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
+import { playerKey, type PlayerKey } from "./player-key.js";
 import { airdropVrfTranscript, type VrfTranscriptItem } from "./signup-vrf.js";
 import type {
     AccountVrfSignature,
@@ -82,18 +82,6 @@ const DRAW_ONLY = {
     NoDrawsScheduled: true,
     NotSr25519: true,
 } satisfies Record<SignUpBlocker["tag"], boolean>;
-
-/**
- * The `AccountOrPerson` key both reads take.
- *
- * Two things keep the umbrella contract test honest here, both verified by
- * breaking them. The narrow type catches a descriptor re-pin that renames an arm.
- * Property syntax on the two `getValue`s catches widening this back to
- * `{ type: string }`, which method syntax would accept, since method parameters
- * are bivariant. Without either, a renamed arm reads nothing and looks like an
- * absent record.
- */
-type PlayerKey = { type: "Account"; value: string } | { type: "Person"; value: string };
 
 /** The chain's `AirdropVrfs`. `Alias` is never constructed, only declared. */
 type AirdropVrfsArg =
@@ -156,15 +144,6 @@ export interface ReadGameSignUpRequirementOptions {
     /** Unix **seconds**; defaults to the device clock. */
     now?: number;
     signal?: AbortSignal;
-}
-
-function playerKey(registrant: AirdropRegistrant): PlayerKey {
-    // `AccountOrPerson` spells the alias arm `Person` where the airdrop pallet's
-    // registration entry spells it `Alias`. Same identity, two names, and the
-    // wrong one reads nothing rather than failing.
-    return registrant.tag === "Account"
-        ? Enum("Account", registrant.accountAddress)
-        : Enum("Person", registrant.alias);
 }
 
 /**

--- a/product-sdk/packages/sdk/src/individuality/contract.test.ts
+++ b/product-sdk/packages/sdk/src/individuality/contract.test.ts
@@ -41,7 +41,9 @@ import type {
     ClaimChain,
     ConsumersChain,
     GameChain,
+    GamePlayersChain,
     IndividualityChain,
+    PapiIndividualityChain,
     PrizeStatusChain,
     SignUpChain,
     AccountVrfSignature,
@@ -100,6 +102,26 @@ type PreviewnetSatisfiesGameContract = Assert<PreviewnetClient extends GameChain
 // prompt to flip it positive and check the read against it.
 type DevnetPredatesTheGameContract = Assert<DevnetClient extends GameChain ? false : true>;
 
+// `GamePlayersChain` is the opt-in half of the game read (`players`), typed
+// separately so a caller who never asks about a player keeps the narrower
+// contract. Both game-capable chains carry `Game.Players`.
+type PaseoSatisfiesPlayersContract = Assert<PaseoClient extends GamePlayersChain ? true : false>;
+type PreviewnetSatisfiesPlayersContract = Assert<
+    PreviewnetClient extends GamePlayersChain ? true : false
+>;
+
+// `fromPapi` hands a caller's own typed API to the reads; it must land exactly
+// where the chain-client shape puts it, or every contract above would be
+// satisfied by `getChainAPI` and none by a self-connected product.
+type FromPapiSatisfiesContracts = Assert<
+    PapiIndividualityChain<PaseoClient["individuality"]> extends IndividualityChain &
+        AirdropChain &
+        GameChain &
+        GamePlayersChain
+        ? true
+        : false
+>;
+
 // Negative control, kept type-only so it emits no runtime code. If
 // `IndividualityChain` ever stopped constraining, this flips to `false` and the
 // file fails to typecheck, which is what keeps the assertions above honest.
@@ -115,6 +137,9 @@ type RejectsBogusAirdropClient = Assert<
     ClientWithoutIndividuality extends AirdropChain ? false : true
 >;
 type RejectsBogusGameClient = Assert<ClientWithoutIndividuality extends GameChain ? false : true>;
+type RejectsBogusPlayersClient = Assert<
+    ClientWithoutIndividuality extends GamePlayersChain ? false : true
+>;
 
 // `Game.Game` being optional is what makes "between games" representable at all,
 // and `GameIndex` / `GameSchedules` being `ValueQuery` is what lets the read treat

--- a/product-sdk/pending-changesets/individuality-players-and-from-papi.md
+++ b/product-sdk/pending-changesets/individuality-players-and-from-papi.md
@@ -1,0 +1,26 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk": minor
+---
+
+**`readCurrentGame` answers "is this player in?", and takes a PAPI client directly.**
+
+Pass `players` and the running game carries a `registration` read at the same pinned
+block. One person is keyed twice in `Game.Players` — by account and, once recognized,
+by alias — so every key the caller holds goes in and any hit is `Registered`. A key
+read that fails is `Unknown`, never `NotRegistered`, and does not fail the game read;
+leave `players` out and it is `Unchecked`. That path needs the new `GamePlayersChain`
+on top of `GameChain`; the existing call without `players` is unchanged.
+
+```ts
+const game = await readCurrentGame(chain, {
+  players: [{ tag: "Account", accountAddress }, { tag: "Alias", alias }],
+});
+if (game.ok && game.value.tag === "Running") {
+  game.value.registration.tag; // Registered | NotRegistered | Unknown | Unchecked
+}
+```
+
+`fromPapi(client, api)` builds the chain shape every read here takes from a
+`PolkadotClient` and typed API the caller already holds, for products that resolve
+their own connection instead of using `@parity/product-sdk-chain-client`.

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -56,7 +56,13 @@ if (!result.ok) {
 }
 ```
 
-This package does **not** resolve a chain. It takes an already-connected client, so the environment choice stays with you — see the `product-sdk-chain-connection` skill for `getChainAPI`.
+This package does **not** resolve a chain. It takes an already-connected client, so the environment choice stays with you — see the `product-sdk-chain-connection` skill for `getChainAPI`. Holding a PAPI client of your own instead? `fromPapi(client, api)` builds the same shape with no connection and no descriptor load:
+
+```ts
+import { fromPapi, readCurrentGame } from "@parity/product-sdk-individuality";
+
+const game = await readCurrentGame(fromPapi(client, client.getTypedApi(people)));
+```
 
 ## Two Ways In
 
@@ -254,9 +260,12 @@ Reading the game, its draws, and whether you won one. Every read pins a single f
 ```ts
 import { readCurrentGame, readPrizeStatus } from "@parity/product-sdk-individuality";
 
-const game = await readCurrentGame(chain);
+const game = await readCurrentGame(chain, {
+  players: [{ tag: "Account", accountAddress }, { tag: "Alias", alias }],
+});
 if (game.ok && game.value.tag === "Running") {
   console.log(game.value.game.phase, game.value.game.nextDeadline);
+  console.log(game.value.registration.tag); // Registered | NotRegistered | Unknown | Unchecked
 }
 
 const status = await readPrizeStatus(chain, {
@@ -270,6 +279,8 @@ if (status.ok && status.value.tag === "Draws") {
 ```
 
 > **PASEO ONLY.** The committed devnet metadata predates this work: one optional prize per schedule instead of a draw list, no `airdrops_scheduled`, and a 28-byte event-id base against paseo's 27. A devnet client fails `GameChain` and the umbrella contract test asserts that on purpose.
+
+> **REGISTRATION IS PER KEY, ANSWERED ONCE.** One person is keyed twice in `Game.Players` — by account and, once recognized, by alias — so pass every key you hold in `players`; any hit is `Registered`. A key read that fails is `Unknown`, never `NotRegistered`, and does not fail the game read. Leave `players` out and it is `Unchecked`; that path only needs `GameChain`, the other needs `GamePlayersChain` too.
 
 > **NO GAME RUNNING IS A SUCCESS VALUE.** One game exists at a time and each is killed when it ends, so `BetweenGames` and `NoGame` are the normal state, not errors. Both carry `lastGameIndex`, which is the index a late claim is keyed by.
 


### PR DESCRIPTION
Closes #340. `readCurrentGame` can now say whether a player is in the running game, and the reads accept a caller's own PAPI client.

**Why:** humanity-spa adopted `readCurrentGame` (paritytech/humanity-spa#58) and immediately had to do a second `Game.Players` read against `result.at` plus hand-build the chain object. Both are things every game UI needs.

**How:** `players?: AirdropRegistrant[]` on the read; the `Running` result carries `registration: Registered | NotRegistered | Unknown | Unchecked` read at the same pinned block. One person is keyed twice (account, alias) so any hit is `Registered`; a failed key read is `Unknown`, never `NotRegistered`, and doesn't fail the game read — the same rule humanity-spa applies today. The `Players` entry sits in a separate [`GamePlayersChain`](product-sdk/packages/individuality/src/game-read.ts) so the call without `players` keeps the narrower contract (overloads enforce it). [`fromPapi(client, api)`](product-sdk/packages/individuality/src/chain.ts) builds the chain-client shape without connecting or loading descriptors. `PlayerKey`/`playerKey` moved out of `signup.ts` into `player-key.ts`, shared by both reads.

Deliberately not done: the issue's point 3 (naming the variant in the decode error) — `game-decode.ts` has a test asserting chain data never reaches error messages, so that stays.

Changeset parked in `pending-changesets/` (individuality + umbrella minor). Umbrella contract test asserts paseo/previewnet satisfy `GamePlayersChain` and `fromPapi` satisfies every `*Chain`. Skill doc updated.