### PR TITLE
fix(signing): derive txExtVersion from formats

### DIFF
--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -371,57 +371,32 @@ export interface AccountsProvider {
     ): HostSubscription;
 }
 
-/** The transaction-extension version used by V5 general transactions. */
-const GENERAL_TX_EXT_VERSION = 5;
+const V5_FORMAT_SELECTOR = 5;
 
 /**
- * Choose the wire `txExtVersion` — the **transaction-extension** version the
- * host must assemble under, which is distinct from the extrinsic *format*
- * version (4 / 5).
- *
- * - `formatVersions` — `metadata.extrinsic.version`, the extrinsic *formats* the
- *   runtime accepts (e.g. `[4]`, `[5]`, `[4, 5]`).
- * - `txExtVersions` — the keys of `metadata.extrinsic.signedExtensions`, the
- *   transaction-extension versions the runtime supports (its v16
- *   `transactionExtensionsByVersion`; always includes `0`).
- *
- * A V4 signed extrinsic always uses transaction-extension version `0` (a fixed
- * sentinel, independent of what the extension map contains). Prefer V4 while it
- * is offered — it carries the account signature in its envelope, and the host
- * can build it. Only when V4 is absent do we fall to a V5 general transaction,
- * whose transaction-extension version is `5` (the key the runtime and host
- * agree on for the general format); require it to actually be present in the
- * map rather than assuming it.
- *
- * Passing the extrinsic *format* number here was the bug (host-rust-core#528):
- * `5` is both a format version and the general extension version, so it looked
- * right, but the two are unrelated in general and the host decodes extension
- * values by this number.
+ * Pick the `txExtVersion` for the host's `create_transaction` from the extrinsic formats
+ * the runtime offers. The host treats the field as a format switch: `0` builds V4, `5`
+ * builds a V5 general transaction, anything else is `NotSupported`. Prefer V4 while
+ * offered, since it carries the account signature in its envelope. The host derives the
+ * transaction-extension version from the metadata itself.
  */
-function selectHostTxExtVersion(
-    formatVersions: readonly number[],
-    txExtVersions: readonly number[],
-): number {
+function selectHostTxExtVersion(formatVersions: readonly number[]): number {
     if (formatVersions.length === 0) {
         throw new Error("No extrinsic version found in metadata");
     }
     if (formatVersions.includes(4)) {
         return 0;
     }
-    if (txExtVersions.includes(GENERAL_TX_EXT_VERSION)) {
-        return GENERAL_TX_EXT_VERSION;
+    if (formatVersions.includes(5)) {
+        return V5_FORMAT_SELECTOR;
     }
     throw new Error(
-        `Runtime offers no V4 extrinsic and no transaction-extension version ${GENERAL_TX_EXT_VERSION} ` +
-            `(supported: ${txExtVersions.join(", ") || "none"}); cannot select a txExtVersion the host can assemble.`,
+        `Runtime offers no extrinsic format 4 or 5 (offers: ${formatVersions.join(", ")}); the host protocol has no txExtVersion for it.`,
     );
 }
 
-/** Derive the host's transaction-extension version from SCALE metadata. */
 function deriveTxExtVersion(metadata: Uint8Array): number {
-    const extrinsic = unifyMetadata(decAnyMetadata(metadata)).extrinsic;
-    const txExtVersions = Object.keys(extrinsic.signedExtensions).map(Number);
-    return selectHostTxExtVersion(extrinsic.version, txExtVersions);
+    return selectHostTxExtVersion(unifyMetadata(decAnyMetadata(metadata)).extrinsic.version);
 }
 
 /** Internal seam so `import.meta.vitest` can stub the metadata decode. @internal */

--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -709,7 +709,7 @@ if (import.meta.vitest) {
         const dir = new URL("../../descriptors/.papi/metadata/", import.meta.url);
         const blobs = readdirSync(dir).filter((name) => name.endsWith(".scale"));
 
-        expect(blobs).toHaveLength(11);
+        expect(blobs.length, "raise when a chain is added").toBeGreaterThanOrEqual(11);
         // Every deployed runtime still offers format 4, so V4 wins. Fails the day one drops it.
         for (const name of blobs) {
             const metadata = new Uint8Array(readFileSync(new URL(name, dir)));

--- a/product-sdk/packages/host/src/accounts.ts
+++ b/product-sdk/packages/host/src/accounts.ts
@@ -705,30 +705,41 @@ if (import.meta.vitest) {
     const { test, expect, vi, describe } = import.meta.vitest;
 
     test("host signing prefers V4 (tx-ext version 0) on a dual V4/V5 runtime", () => {
-        // txExtVersion 0 regardless of what the extension map lists.
-        expect(selectHostTxExtVersion([4, 5], [0])).toBe(0);
+        expect(selectHostTxExtVersion([4, 5])).toBe(0);
     });
 
-    test("host signing uses the general tx-ext version 5 when V4 is unavailable", () => {
-        // The value comes from the extension-version map, not the format list.
-        expect(selectHostTxExtVersion([5], [0, 5])).toBe(5);
+    test("host signing uses the V5 selector when the runtime offers no V4", () => {
+        expect(selectHostTxExtVersion([5])).toBe(5);
     });
 
     test("host signing maps a V4-only runtime to the wire sentinel", () => {
-        expect(selectHostTxExtVersion([4], [0])).toBe(0);
+        expect(selectHostTxExtVersion([4])).toBe(0);
     });
 
-    test("host signing does not confuse extrinsic format 5 with a tx-ext version", () => {
-        // V5-only runtime that only supports tx-ext version 0 (no general
-        // extension set): the old code returned 5 (the format number); now this
-        // must throw rather than send an unsupported txExtVersion.
-        expect(() => selectHostTxExtVersion([5], [0])).toThrow(/no.*version 5/i);
+    test("host signing prefers V5 over a format it does not know", () => {
+        // max(formats) would send 6, which no host accepts.
+        expect(selectHostTxExtVersion([5, 6])).toBe(5);
+    });
+
+    test("host signing rejects a runtime offering neither format 4 nor 5", () => {
+        expect(() => selectHostTxExtVersion([6])).toThrow(/no extrinsic format 4 or 5/i);
     });
 
     test("host signing rejects metadata with no extrinsic version", () => {
-        expect(() => selectHostTxExtVersion([], [0])).toThrow(
-            "No extrinsic version found in metadata",
-        );
+        expect(() => selectHostTxExtVersion([])).toThrow("No extrinsic version found in metadata");
+    });
+
+    test("deriveTxExtVersion reads the format list out of every tracked chain's metadata", async () => {
+        const { readFileSync, readdirSync } = await import("node:fs");
+        const dir = new URL("../../descriptors/.papi/metadata/", import.meta.url);
+        const blobs = readdirSync(dir).filter((name) => name.endsWith(".scale"));
+
+        expect(blobs).toHaveLength(11);
+        // Every deployed runtime still offers format 4, so V4 wins. Fails the day one drops it.
+        for (const name of blobs) {
+            const metadata = new Uint8Array(readFileSync(new URL(name, dir)));
+            expect(deriveTxExtVersion(metadata), name).toBe(0);
+        }
     });
 
     /** Minimal fake of the truapi account/signing domains used to test the adapter. */

--- a/product-sdk/packages/terminal/src/signer.ts
+++ b/product-sdk/packages/terminal/src/signer.ts
@@ -593,13 +593,15 @@ if (import.meta.vitest) {
 
         test("txExtVersionFromMetadata reads the format list out of every tracked chain's metadata", async () => {
             const { readFileSync, readdirSync } = await import("node:fs");
-            const dir = new URL("../../descriptors/.papi/metadata/", import.meta.url);
+            const { join } = await import("node:path");
+            // Not new URL(): without treeshake the literal reaches dist, and bundlers resolve it.
+            const dir = join(import.meta.dirname, "..", "..", "descriptors", ".papi", "metadata");
             const blobs = readdirSync(dir).filter((name) => name.endsWith(".scale"));
 
-            expect(blobs).toHaveLength(11);
+            expect(blobs.length, "raise when a chain is added").toBeGreaterThanOrEqual(11);
             // Every deployed runtime still offers format 4, so V4 wins. Fails the day one drops it.
             for (const name of blobs) {
-                const metadata = new Uint8Array(readFileSync(new URL(name, dir)));
+                const metadata = new Uint8Array(readFileSync(join(dir, name)));
                 expect(txExtVersionFromMetadata(metadata), name).toBe(0);
             }
         });

--- a/product-sdk/packages/terminal/src/signer.ts
+++ b/product-sdk/packages/terminal/src/signer.ts
@@ -590,25 +590,41 @@ if (import.meta.vitest) {
         // a real phone.
 
         test("prefers V4 (tx-ext version 0) on a dual V4/V5 runtime", () => {
-            expect(selectTxExtVersion([4, 5], [0])).toBe(0);
+            expect(selectTxExtVersion([4, 5])).toBe(0);
         });
 
-        test("uses the general tx-ext version 5 when no V4 fallback exists", () => {
-            expect(selectTxExtVersion([5], [0, 5])).toBe(5);
+        test("uses the V5 selector when the runtime offers no V4", () => {
+            expect(selectTxExtVersion([5])).toBe(5);
         });
 
         test("maps a V4-only runtime to the wire sentinel", () => {
-            expect(selectTxExtVersion([4], [0])).toBe(0);
+            expect(selectTxExtVersion([4])).toBe(0);
         });
 
-        test("does not confuse extrinsic format 5 with a tx-ext version", () => {
-            expect(() => selectTxExtVersion([5], [0])).toThrow(/no.*version 5/i);
+        test("prefers V5 over a format it does not know", () => {
+            // max(formats) would send 6, which no host accepts.
+            expect(selectTxExtVersion([5, 6])).toBe(5);
+        });
+
+        test("rejects a runtime offering neither format 4 nor 5", () => {
+            expect(() => selectTxExtVersion([6])).toThrow(/no extrinsic format 4 or 5/i);
         });
 
         test("rejects metadata with no extrinsic version", () => {
-            expect(() => selectTxExtVersion([], [0])).toThrow(
-                "No extrinsic version found in metadata",
-            );
+            expect(() => selectTxExtVersion([])).toThrow("No extrinsic version found in metadata");
+        });
+
+        test("txExtVersionFromMetadata reads the format list out of every tracked chain's metadata", async () => {
+            const { readFileSync, readdirSync } = await import("node:fs");
+            const dir = new URL("../../descriptors/.papi/metadata/", import.meta.url);
+            const blobs = readdirSync(dir).filter((name) => name.endsWith(".scale"));
+
+            expect(blobs).toHaveLength(11);
+            // Every deployed runtime still offers format 4, so V4 wins. Fails the day one drops it.
+            for (const name of blobs) {
+                const metadata = new Uint8Array(readFileSync(new URL(name, dir)));
+                expect(txExtVersionFromMetadata(metadata), name).toBe(0);
+            }
         });
 
         const checkGenesis = ext("CheckGenesis", [], [0x11, 0x22, 0x33]);

--- a/product-sdk/packages/terminal/src/signer.ts
+++ b/product-sdk/packages/terminal/src/signer.ts
@@ -177,55 +177,32 @@ function buildCreateTransactionRequest(
     };
 }
 
-/** The transaction-extension version used by V5 general transactions. */
-const GENERAL_TX_EXT_VERSION = 5;
+const V5_FORMAT_SELECTOR = 5;
 
 /**
- * Choose the wire `txExtVersion` — the **transaction-extension** version the
- * paired host must assemble under, which is distinct from the extrinsic
- * *format* version (4 / 5).
- *
- * - `formatVersions` — `metadata.extrinsic.version`, the extrinsic *formats* the
- *   runtime accepts (e.g. `[4]`, `[5]`, `[4, 5]`).
- * - `txExtVersions` — the keys of `metadata.extrinsic.signedExtensions`, the
- *   transaction-extension versions the runtime supports (its v16
- *   `transactionExtensionsByVersion`; always includes `0`).
- *
- * A V4 signed extrinsic always uses transaction-extension version `0` (a fixed
- * sentinel). Prefer V4 while it is offered — it carries the account signature
- * in its envelope and the host can build it. Only when V4 is absent do we fall
- * to a V5 general transaction, whose transaction-extension version is `5` (the
- * key the runtime and host agree on for the general format); require it to be
- * present in the map rather than assuming it.
- *
- * Passing the extrinsic *format* number here was the bug (host-rust-core#528):
- * `5` is both a format version and the general extension version, so it looked
- * right, but the two are unrelated in general and the host decodes extension
- * values by this number.
+ * Pick the `txExtVersion` for the paired host's `createTransaction` from the extrinsic
+ * formats the runtime offers. The host treats the field as a format switch: `0` builds
+ * V4, `5` builds a V5 general transaction, anything else is `NotSupported`. Prefer V4
+ * while offered, since it carries the account signature in its envelope. The host
+ * derives the transaction-extension version from the metadata itself.
  */
-function selectTxExtVersion(
-    formatVersions: readonly number[],
-    txExtVersions: readonly number[],
-): number {
+function selectTxExtVersion(formatVersions: readonly number[]): number {
     if (formatVersions.length === 0) {
         throw new Error("No extrinsic version found in metadata");
     }
     if (formatVersions.includes(4)) {
         return 0;
     }
-    if (txExtVersions.includes(GENERAL_TX_EXT_VERSION)) {
-        return GENERAL_TX_EXT_VERSION;
+    if (formatVersions.includes(5)) {
+        return V5_FORMAT_SELECTOR;
     }
     throw new Error(
-        `Runtime offers no V4 extrinsic and no transaction-extension version ${GENERAL_TX_EXT_VERSION} ` +
-            `(supported: ${txExtVersions.join(", ") || "none"}); cannot select a txExtVersion the host can assemble.`,
+        `Runtime offers no extrinsic format 4 or 5 (offers: ${formatVersions.join(", ")}); the host protocol has no txExtVersion for it.`,
     );
 }
 
 function txExtVersionFromMetadata(metadata: Uint8Array): number {
-    const extrinsic = unifyMetadata(decAnyMetadata(metadata)).extrinsic;
-    const txExtVersions = Object.keys(extrinsic.signedExtensions).map(Number);
-    return selectTxExtVersion(extrinsic.version, txExtVersions);
+    return selectTxExtVersion(unifyMetadata(decAnyMetadata(metadata)).extrinsic.version);
 }
 
 /**

--- a/product-sdk/pending-changesets/txextversion-from-formats.md
+++ b/product-sdk/pending-changesets/txextversion-from-formats.md
@@ -1,0 +1,14 @@
+---
+"@parity/product-sdk-host": patch
+"@parity/product-sdk-terminal": patch
+---
+
+**Derive `txExtVersion` from the extrinsic format list, so a V5-only runtime can be signed again.**
+
+The signer factories fill the truapi `create_transaction` field `txExtVersion`. Since host `0.18.0` and terminal `0.8.0` the V5 value was gated on the runtime's transaction-extension version map (surfaced by PAPI as the keys of `metadata.extrinsic.signedExtensions`) containing `5`. No runtime declares extension version `5`, every deployed runtime declares only `0`, so that branch was unreachable and signing threw on any runtime offering extrinsic format 5 without format 4.
+
+Both `@parity/product-sdk-host`'s `getAccountsProvider` signers and `@parity/product-sdk-terminal`'s session signers now read `metadata.extrinsic.version` alone: format 4 gives `0`, otherwise format 5 gives `5`, otherwise a throw naming the formats the runtime offers. That restores the behaviour published in host `0.17.0` and terminal `0.7.4`, and keeps the explicit rejection `0.18.0` added for a runtime offering neither format, where earlier versions sent the highest format number to a host that cannot use it. Both packages now also decode the tracked chain metadata under test, which is the check that would have caught this.
+
+`0` and `5` are the values host-rust-core's `build_local_transaction` accepts, and that is the host iOS and dot.li run. What the field means is still open in product-sdk#339: the truapi protocol documents it as a transaction-extension version and the Android host reads it that way, so `5` is not universally correct. This release does not settle that.
+
+No behaviour change on any chain the SDK ships against. They all offer extrinsic format 4, so `txExtVersion` was and remains `0`.


### PR DESCRIPTION
Related to #339

### Description

When the SDK asks a host to sign, it has to say which extrinsic format to build: `0` means V4, `5` means V5. Since #337 the SDK only sends `5` if the runtime lists `5` in its transaction-extension version map, and no runtime does, so a runtime offering only format 5 cannot be signed at all. This PR picks the value from the extrinsic formats the runtime publishes instead: format 4 gives `0`, format 5 gives `5`, anything else throws with the formats named. No chain in use is affected, since all 11 offer format 4 and the value stays `0`.

### Changes

- The selector in `packages/host/src/accounts.ts` and `packages/terminal/src/signer.ts` drops its second parameter and the `extrinsic.signedExtensions` read. The `[6]` rejection #337 added is kept.
- Both packages now decode the tracked chain metadata under test. Neither did before, which is why a claim about metadata shape survived #325 and #337.

### Scope

This PR does not settle what `txExtVersion` means, so please do not read it as closing #339. `0` and `5` are what host-rust-core's `build_local_transaction` accepts, which is the host iOS and dot.li run, while the truapi crate documents the field as a runtime-supported extension version and the Android host validates it that way. Nothing is reachable today either way.

### Testing

On `main`, a runtime offering only extrinsic format 5 cannot be signed:

```
Error: Runtime offers no V4 extrinsic and no transaction-extension version 5 (supported: 0)
```

It now returns `5`, checked against a V5-only runtime built by re-encoding `paseo_asset_hub.scale` with `extrinsic.version = [5]`.

From `product-sdk/`:

```bash
pnpm build && pnpm typecheck && pnpm test && pnpm check
```

All pass: host 137 tests, terminal 179, 20 packages, biome clean over 337 files.
