### PR TITLE
fix(sdk): remove localStorage.clear(), a silent no-op in production 

### DIFF
--- a/product-sdk/packages/sdk/src/core/createApp.ts
+++ b/product-sdk/packages/sdk/src/core/createApp.ts
@@ -16,6 +16,7 @@ import type {
     CloudStorageApi,
     LocalStorageApi,
 } from "./types.js";
+import { createLocalStorageApi } from "./local-storage-api.js";
 import { configure, createLogger } from "@parity/product-sdk-logger";
 import { createLocalKvStore } from "@parity/product-sdk-local-storage";
 import { SignerManager } from "@parity/product-sdk-signer";
@@ -124,14 +125,8 @@ export async function createApp(config: AppConfig): Promise<App> {
         log.debug("Cloud Storage client disabled");
     }
 
-    // Create storage API adapter
-    const localStorageApi: LocalStorageApi = {
-        get: (key) => localKvStore.get(key),
-        set: (key, value) => localKvStore.set(key, value),
-        getJSON: <T>(key: string) => localKvStore.getJSON<T>(key),
-        setJSON: <T>(key: string, value: T) => localKvStore.setJSON(key, value),
-        remove: (key) => localKvStore.remove(key),
-    };
+    // Storage API adapter — shared with `createFakeApp` so the two cannot drift.
+    const localStorageApi: LocalStorageApi = createLocalStorageApi(localKvStore);
 
     // Create wallet API adapter
     const walletApi = createWalletApi(signerManager);

--- a/product-sdk/packages/sdk/src/core/createApp.ts
+++ b/product-sdk/packages/sdk/src/core/createApp.ts
@@ -131,10 +131,6 @@ export async function createApp(config: AppConfig): Promise<App> {
         getJSON: <T>(key: string) => localKvStore.getJSON<T>(key),
         setJSON: <T>(key: string, value: T) => localKvStore.setJSON(key, value),
         remove: (key) => localKvStore.remove(key),
-        clear: async () => {
-            // LocalKvStore doesn't have clear - this is a no-op
-            log.debug("clear() is not supported in container storage mode");
-        },
     };
 
     // Create wallet API adapter

--- a/product-sdk/packages/sdk/src/core/local-storage-api.ts
+++ b/product-sdk/packages/sdk/src/core/local-storage-api.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The one adapter from a {@link LocalKvStore} to the SDK's {@link LocalStorageApi}.
+ *
+ * Both `createApp` (host-backed store) and `createFakeApp` (in-memory store)
+ * build their `localStorage` through here, so the shipped adapter and the test
+ * fake cannot drift — which is exactly how `clear()` came to be a no-op in
+ * production while the fake emptied (#344). The in-source test below drives one
+ * assertion set through this factory over an in-memory store; anything the fake
+ * exposes, the real path exposes the same way.
+ */
+import type { LocalKvStore } from "@parity/product-sdk-local-storage";
+import type { LocalStorageApi } from "./types.js";
+
+/** Wrap a {@link LocalKvStore} as the SDK's {@link LocalStorageApi}. */
+export function createLocalStorageApi(kv: LocalKvStore): LocalStorageApi {
+    return {
+        get: (key) => kv.get(key),
+        set: (key, value) => kv.set(key, value),
+        getJSON: <T>(key: string) => kv.getJSON<T>(key),
+        setJSON: <T>(key: string, value: T) => kv.setJSON(key, value),
+        remove: (key) => kv.remove(key),
+    };
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    /** A minimal in-memory {@link LocalKvStore}, string- and JSON-aware. */
+    function memoryKvStore(): LocalKvStore {
+        const store = new Map<string, string>();
+        return {
+            async get(key) {
+                return store.get(key) ?? null;
+            },
+            async set(key, value) {
+                store.set(key, value);
+            },
+            async remove(key) {
+                store.delete(key);
+            },
+            async getJSON<T>(key: string) {
+                const raw = store.get(key);
+                return raw === undefined ? null : (JSON.parse(raw) as T);
+            },
+            async setJSON(key, value) {
+                store.set(key, JSON.stringify(value));
+            },
+        };
+    }
+
+    describe("createLocalStorageApi", () => {
+        test("round-trips strings and JSON, and remove deletes one key", async () => {
+            const api = createLocalStorageApi(memoryKvStore());
+
+            await api.set("k", "v");
+            await api.setJSON("o", { n: 1 });
+            expect(await api.get("k")).toBe("v");
+            expect(await api.getJSON("o")).toEqual({ n: 1 });
+            expect(await api.get("missing")).toBeNull();
+
+            await api.remove("k");
+            expect(await api.get("k")).toBeNull();
+            // No clear-all: an untouched key stays.
+            expect(await api.getJSON("o")).toEqual({ n: 1 });
+        });
+
+        test("exposes exactly the LocalStorageApi surface — no clear()", () => {
+            const api = createLocalStorageApi(memoryKvStore());
+            expect(Object.keys(api).sort()).toEqual(["get", "getJSON", "remove", "set", "setJSON"]);
+        });
+    });
+}

--- a/product-sdk/packages/sdk/src/core/types.ts
+++ b/product-sdk/packages/sdk/src/core/types.ts
@@ -72,7 +72,14 @@ export interface WalletApi {
     createProof(message: Uint8Array): Promise<Uint8Array>;
 }
 
-/** Storage API exposed by the SDK */
+/**
+ * Storage API exposed by the SDK: per-key get / set / remove, string and JSON.
+ *
+ * There is no `clear()`. Host localStorage exposes no key enumeration (only
+ * per-key read / write / remove), so a clear-all cannot be implemented — it was
+ * a silent no-op in a host container. Remove keys individually with `remove`,
+ * or track the keys your app writes and remove them.
+ */
 export interface LocalStorageApi {
     /** Get a value by key */
     get(key: string): Promise<string | null>;
@@ -82,14 +89,7 @@ export interface LocalStorageApi {
     getJSON<T = unknown>(key: string): Promise<T | null>;
     /** Set a JSON value by key */
     setJSON<T = unknown>(key: string, value: T): Promise<void>;
-    /**
-     * Remove a value by key.
-     *
-     * There is no `clear()`: host localStorage exposes no key enumeration
-     * (only per-key read / write / remove), so a clear-all cannot be
-     * implemented — it was a silent no-op in a host container. Remove keys
-     * individually with {@link remove}.
-     */
+    /** Remove a value by key */
     remove(key: string): Promise<void>;
 }
 

--- a/product-sdk/packages/sdk/src/core/types.ts
+++ b/product-sdk/packages/sdk/src/core/types.ts
@@ -82,10 +82,15 @@ export interface LocalStorageApi {
     getJSON<T = unknown>(key: string): Promise<T | null>;
     /** Set a JSON value by key */
     setJSON<T = unknown>(key: string, value: T): Promise<void>;
-    /** Remove a value by key */
+    /**
+     * Remove a value by key.
+     *
+     * There is no `clear()`: host localStorage exposes no key enumeration
+     * (only per-key read / write / remove), so a clear-all cannot be
+     * implemented — it was a silent no-op in a host container. Remove keys
+     * individually with {@link remove}.
+     */
     remove(key: string): Promise<void>;
-    /** Clear all values */
-    clear(): Promise<void>;
 }
 
 /** Chain API exposed by the SDK */

--- a/product-sdk/packages/sdk/src/testing.ts
+++ b/product-sdk/packages/sdk/src/testing.ts
@@ -138,11 +138,6 @@ function makeFakeLocalStorage(): LocalStorageApi {
         async remove(key) {
             await host.clear(key);
         },
-        async clear() {
-            // Unlike the production adapter (a no-op in container mode), the fake
-            // actually empties, so tests get real isolation.
-            host.reset();
-        },
     };
 }
 
@@ -257,7 +252,7 @@ if (import.meta.vitest) {
             expect(accounts).toHaveLength(2);
         });
 
-        test("localStorage round-trips and clear empties it", async () => {
+        test("localStorage round-trips and remove deletes a key", async () => {
             const app = createFakeApp();
             await app.localStorage.set("k", "v");
             await app.localStorage.setJSON("o", { n: 1 });
@@ -265,8 +260,10 @@ if (import.meta.vitest) {
             expect(await app.localStorage.getJSON("o")).toEqual({ n: 1 });
             expect(await app.localStorage.get("missing")).toBeNull();
 
-            await app.localStorage.clear();
+            await app.localStorage.remove("k");
             expect(await app.localStorage.get("k")).toBeNull();
+            // Untouched keys stay — there is no clear-all.
+            expect(await app.localStorage.getJSON("o")).toEqual({ n: 1 });
         });
 
         test("cloudStorage round-trips upload -> fetch; computeCid matches upload", async () => {

--- a/product-sdk/packages/sdk/src/testing.ts
+++ b/product-sdk/packages/sdk/src/testing.ts
@@ -11,7 +11,9 @@
  * @packageDocumentation
  */
 import { ProductCloudStorageError } from "@parity/product-sdk-cloud-storage";
+import type { LocalKvStore } from "@parity/product-sdk-local-storage";
 import { createFakeHostLocalStorage } from "@parity/product-sdk-local-storage/testing";
+import { createLocalStorageApi } from "./core/local-storage-api.js";
 import { err, ok, unwrapErr, unwrapOk } from "@parity/result";
 
 import type {
@@ -119,10 +121,13 @@ function makeFakeWallet(options?: FakeWalletOptions): WalletApi {
 }
 
 function makeFakeLocalStorage(): LocalStorageApi {
-    // Compose the local-storage fake; mirror createApp's adapter semantics
-    // (get normalizes "" -> null, getJSON normalizes undefined -> null).
+    // Route through the *same* `createLocalStorageApi` factory `createApp` uses,
+    // so the fake and the shipped adapter cannot drift (#344). The fake's host
+    // is adapted to a `LocalKvStore` here rather than via the async
+    // `createLocalKvStore`, so `createFakeApp` stays synchronous; the semantics
+    // (get "" -> null, getJSON undefined -> null) match `createHostBackend`.
     const host = createFakeHostLocalStorage();
-    return {
+    const kv: LocalKvStore = {
         async get(key) {
             return (await host.readString(key)) || null;
         },
@@ -132,13 +137,14 @@ function makeFakeLocalStorage(): LocalStorageApi {
         async getJSON<T>(key: string) {
             return ((await host.readJSON(key)) ?? null) as T | null;
         },
-        async setJSON<T>(key: string, value: T) {
+        async setJSON(key, value) {
             await host.writeJSON(key, value);
         },
         async remove(key) {
             await host.clear(key);
         },
     };
+    return createLocalStorageApi(kv);
 }
 
 function makeFakeCloudStorage(): CloudStorageApi {

--- a/product-sdk/pending-changesets/remove-localstorage-clear.md
+++ b/product-sdk/pending-changesets/remove-localstorage-clear.md
@@ -6,6 +6,10 @@
 
 `createApp().localStorage.clear()` resolved successfully but did nothing in production (only logging at debug), while the `createFakeApp` test fake actually emptied — so a test asserting `clear()` wipes storage passed against code that no-ops for real users (#344).
 
-It can't be implemented: the host localStorage protocol exposes no key enumeration — only per-key `read` / `write` / `clear(key)` (a single-key remove) through `@parity/truapi` → `HostLocalStorage` → `LocalKvStore` — so there is nothing to iterate for a clear-all. Rather than keep a method that lies (or one that always throws), `clear()` is removed from `LocalStorageApi` and from the fake; the two now agree.
+It can't be implemented: the host localStorage protocol exposes no key enumeration — only per-key `read` / `write` / `clear(key)` (a single-key remove) through `@parity/truapi` → `HostLocalStorage` → `LocalKvStore` — so there is nothing to iterate for a clear-all. Rather than keep a method that lies (or one that always throws), `clear()` is removed from `LocalStorageApi` and from the fake; the two now build through one shared `createLocalStorageApi` adapter, so they can no longer drift.
 
 **Migration.** Use `remove(key)` — supported at every layer — to delete keys individually. There is no clear-all; if you need one, track the keys your app writes and remove them.
+
+**Breaking for callers.** `app.localStorage.clear()` no longer exists: an untyped call throws `TypeError: app.localStorage.clear is not a function` where it used to resolve.
+
+**Breaking for implementors.** `clear` is gone from the exported `LocalStorageApi` interface, so anyone writing one inline — for example the `localStorage` override passed to `createFakeApp` — must delete their `clear` to keep compiling.

--- a/product-sdk/pending-changesets/remove-localstorage-clear.md
+++ b/product-sdk/pending-changesets/remove-localstorage-clear.md
@@ -1,0 +1,11 @@
+---
+"@parity/product-sdk": minor
+---
+
+**Remove `localStorage.clear()` — it was a silent no-op in a host container.**
+
+`createApp().localStorage.clear()` resolved successfully but did nothing in production (only logging at debug), while the `createFakeApp` test fake actually emptied — so a test asserting `clear()` wipes storage passed against code that no-ops for real users (#344).
+
+It can't be implemented: the host localStorage protocol exposes no key enumeration — only per-key `read` / `write` / `clear(key)` (a single-key remove) through `@parity/truapi` → `HostLocalStorage` → `LocalKvStore` — so there is nothing to iterate for a clear-all. Rather than keep a method that lies (or one that always throws), `clear()` is removed from `LocalStorageApi` and from the fake; the two now agree.
+
+**Migration.** Use `remove(key)` — supported at every layer — to delete keys individually. There is no clear-all; if you need one, track the keys your app writes and remove them.


### PR DESCRIPTION
Closes #344

## Problem

`createApp().localStorage.clear()` resolves successfully but does nothing in a host container — it only logs at debug. The `createFakeApp` test fake actually empties, so a test asserting `clear()` wipes storage passes against code that no-ops for real users.

It also can't be implemented as-is: the host localStorage protocol exposes no key enumeration — only per-key `read` / `write` and a single-key `clear(key)` through `@parity/truapi` → `HostLocalStorage` → `LocalKvStore` — so there is nothing to iterate for a clear-all.

## Fix

Remove `clear()` from `LocalStorageApi`, the production adapter, and the fake, so the two agree. `remove(key)` already works at every layer and stays.

Both `createApp` and the fake now build their `localStorage` through one shared `createLocalStorageApi` adapter, so the shipped code and the test fake can no longer drift — which is what let `clear()` no-op in production while the fake emptied.

## Migration

Use `remove(key)` to delete keys individually. There is no clear-all; if you need one, track the keys your app writes and remove them.

**Breaking for callers:** an untyped `app.localStorage.clear()` now throws `TypeError: clear is not a function` where it used to resolve.

**Breaking for implementors:** `clear` is gone from the exported `LocalStorageApi`, so anyone writing one inline — e.g. the `localStorage` override to `createFakeApp` — must delete their `clear` to compile.