### PR TITLE
feat(individuality): decode draw event ids

### DIFF
--- a/product-sdk/packages/individuality/src/airdrop-ids.ts
+++ b/product-sdk/packages/individuality/src/airdrop-ids.ts
@@ -156,19 +156,20 @@ const PEOPLE_AIRDROPS_PREFIX_HEX = toEventId(
     baseBytes(PEOPLE_AIRDROPS_EVENT_ID_BASE, PEOPLE_AIRDROPS_BASE_BYTES),
 ).slice(2);
 
-/** One shape check for prefix, length and hex digits, so the three cannot disagree. */
-const EVENT_ID_PATTERN = new RegExp(`^0x[0-9a-f]{${EVENT_ID_BYTES * 2}}$`);
+const EVENT_ID_BODY_PATTERN = new RegExp(`^[0-9a-f]{${EVENT_ID_BYTES * 2}}$`);
 
 /**
  * The draw index inside a `PeopleAirdrops` event id, or `null` if it is not one.
  * `Airdrop.Events` holds both schedulers, so a foreign id is data, not a caller bug.
  */
 export function parsePeopleAirdropsEventId(eventId: string): bigint | null {
-    // Before the pattern, not after: `[0-9a-f]` would reject a valid upper-case id.
-    const lower = eventId.toLowerCase();
-    if (!EVENT_ID_PATTERN.test(lower)) return null;
+    // Reachable despite the type: ids arrive from storage sweeps through a cast.
+    if (typeof eventId !== "string") return null;
+    // PAPI's `fromHex` only accepts a lower-case `0x`, so `0X` must not decode here.
+    if (!eventId.startsWith("0x")) return null;
 
-    const body = lower.slice(2);
+    const body = eventId.slice(2).toLowerCase();
+    if (!EVENT_ID_BODY_PATTERN.test(body)) return null;
     if (!body.startsWith(PEOPLE_AIRDROPS_PREFIX_HEX)) return null;
     return BigInt(`0x${body.slice(PEOPLE_AIRDROPS_BASE_BYTES * 2)}`);
 }
@@ -515,9 +516,18 @@ if (import.meta.vitest) {
             [peopleAirdropsEventId(1n).slice(0, -2), "one byte short"],
             [`${peopleAirdropsEventId(1n)}00`, "one byte long"],
             [`0x${"z".repeat(64)}`, "non-hex digits"],
+            [`0X${peopleAirdropsEventId(1n).slice(2)}`, "0X prefix, which PAPI rejects"],
             [`${peopleAirdropsEventId(1n).slice(0, -2)}zz`, "non-hex digits in the index"],
         ])("returns null for %s (%s)", (eventId) => {
             expect(parsePeopleAirdropsEventId(eventId)).toBeNull();
+        });
+
+        test.each<[unknown, string]>([
+            [undefined, "undefined"],
+            [null, "null"],
+            [42, "a number"],
+        ])("returns null for %s, which only a JS caller or a cast can pass", (eventId) => {
+            expect(parsePeopleAirdropsEventId(eventId as string)).toBeNull();
         });
     });
 }

--- a/product-sdk/packages/individuality/src/airdrop-ids.ts
+++ b/product-sdk/packages/individuality/src/airdrop-ids.ts
@@ -151,6 +151,28 @@ export function peopleAirdropsEventId(drawIndex: number | bigint): string {
     return toEventId(id);
 }
 
+/** Hoisted: this compare runs on every entry of an `Airdrop.Events` sweep. */
+const PEOPLE_AIRDROPS_PREFIX_HEX = toEventId(
+    baseBytes(PEOPLE_AIRDROPS_EVENT_ID_BASE, PEOPLE_AIRDROPS_BASE_BYTES),
+).slice(2);
+
+/** One shape check for prefix, length and hex digits, so the three cannot disagree. */
+const EVENT_ID_PATTERN = new RegExp(`^0x[0-9a-f]{${EVENT_ID_BYTES * 2}}$`);
+
+/**
+ * The draw index inside a `PeopleAirdrops` event id, or `null` if it is not one.
+ * `Airdrop.Events` holds both schedulers, so a foreign id is data, not a caller bug.
+ */
+export function parsePeopleAirdropsEventId(eventId: string): bigint | null {
+    // Before the pattern, not after: `[0-9a-f]` would reject a valid upper-case id.
+    const lower = eventId.toLowerCase();
+    if (!EVENT_ID_PATTERN.test(lower)) return null;
+
+    const body = lower.slice(2);
+    if (!body.startsWith(PEOPLE_AIRDROPS_PREFIX_HEX)) return null;
+    return BigInt(`0x${body.slice(PEOPLE_AIRDROPS_BASE_BYTES * 2)}`);
+}
+
 /**
  * Every draw id of one game, in airdrop-index order. `airdropsScheduled` only
  * exists while that game is current, so a past game's count must have been

--- a/product-sdk/packages/individuality/src/airdrop-ids.ts
+++ b/product-sdk/packages/individuality/src/airdrop-ids.ts
@@ -429,4 +429,73 @@ if (import.meta.vitest) {
             ).toThrow(ProductIndividualityError);
         });
     });
+
+    describe("parsePeopleAirdropsEventId", () => {
+        test.each([0n, 1n, 7n, 0x01_02_03_04_05_06_07_08n, U64_MAX])(
+            "round-trips the draw index %s",
+            (drawIndex) => {
+                expect(parsePeopleAirdropsEventId(peopleAirdropsEventId(drawIndex))).toBe(
+                    drawIndex,
+                );
+            },
+        );
+
+        test("decodes a literal id this module did not build", () => {
+            // Hand-written in humanity-spa's stub backend, not derived here: a vector
+            // built with the encoder passes even if both directions drift together.
+            expect(
+                parsePeopleAirdropsEventId(
+                    "0x706f703a70656f706c652d61697264726f70733a202020200000000000000001",
+                ),
+            ).toBe(1n);
+        });
+
+        test("decodes a multi-byte index from a locally built literal", () => {
+            expect(
+                parsePeopleAirdropsEventId(
+                    `0x${asciiHex("pop:people-airdrops:    ")}0102030405060708`,
+                ),
+            ).toBe(0x01_02_03_04_05_06_07_08n);
+        });
+
+        test("returns null for a Game id, rather than throwing", () => {
+            // `Airdrop.Events` holds both schedulers, so a Game id is ordinary input.
+            expect(
+                parsePeopleAirdropsEventId(
+                    gameAirdropEventId({
+                        base: GAME_AIRDROP_EVENT_ID_BASE,
+                        gameIndex: 3,
+                        airdropIndex: 1,
+                    }),
+                ),
+            ).toBeNull();
+        });
+
+        test("decodes an upper-case id", () => {
+            // PAPI emits lower-case but accepts both, and ids reach us from elsewhere
+            // too. Dropping a valid id as `null` is the worse failure.
+            const id = peopleAirdropsEventId(7n);
+            expect(parsePeopleAirdropsEventId(`0x${id.slice(2).toUpperCase()}`)).toBe(7n);
+        });
+
+        test("returns null for a right-length id with a foreign base", () => {
+            expect(
+                parsePeopleAirdropsEventId(
+                    `0x${asciiHex("pop:people-airdropz:    ")}0000000000000001`,
+                ),
+            ).toBeNull();
+        });
+
+        test.each([
+            ["", "empty string"],
+            ["0x", "prefix only"],
+            [peopleAirdropsEventId(1n).slice(2), "no 0x prefix"],
+            [peopleAirdropsEventId(1n).slice(0, -2), "one byte short"],
+            [`${peopleAirdropsEventId(1n)}00`, "one byte long"],
+            [`0x${"z".repeat(64)}`, "non-hex digits"],
+            [`${peopleAirdropsEventId(1n).slice(0, -2)}zz`, "non-hex digits in the index"],
+        ])("returns null for %s (%s)", (eventId) => {
+            expect(parsePeopleAirdropsEventId(eventId)).toBeNull();
+        });
+    });
 }

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -128,7 +128,7 @@ export type {
     AirdropStatusTag,
 } from "./airdrop-types.js";
 
-// The derivations. Pure, so they work against an index you already hold. Prefer
+// Event ids, both directions, all pure. Prefer
 // `readGameAirdropEventIds` over the pinned base: the chain exposes `Game`'s base
 // as a constant, and a hardcoded copy would derive ids for draws that do not
 // exist if it ever moved. `PeopleAirdrops`' base is not exposed, so that one is
@@ -139,6 +139,7 @@ export {
     PEOPLE_AIRDROPS_EVENT_ID_BASE,
     gameAirdropEventId,
     gameAirdropEventIds,
+    parsePeopleAirdropsEventId,
     peopleAirdropsEventId,
 } from "./airdrop-ids.js";
 

--- a/product-sdk/pending-changesets/decode-airdrop-event-ids.md
+++ b/product-sdk/pending-changesets/decode-airdrop-event-ids.md
@@ -1,0 +1,10 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk": minor
+---
+
+**Decode a `PeopleAirdrops` draw event id back to its draw index.**
+
+`parsePeopleAirdropsEventId(eventId)` is the inverse of `peopleAirdropsEventId`. It returns the `u64` draw index, or `null` for anything that is not a `PeopleAirdrops` id — a `Game` id, a foreign base, a malformed string. `null` rather than a throw because `Airdrop.Events` holds both schedulers, so a caller sweeping it with `getEntries()` meets foreign ids as a matter of course.
+
+The package could previously only derive ids forward, from indices the caller already held. That holds for the `Game` path, which has a per-game count to enumerate from, but not for `PeopleAirdrops`, whose ids only arrive from that shared map.

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -286,6 +286,8 @@ if (status.ok && status.value.tag === "Draws") {
 
 > **A DRAW NOT IN STORAGE IS A SUCCESS VALUE TOO.** It arrives as `phase: "Gone"`, the steady state for every past draw once the lifecycle cleans it up. It is not evidence the draw existed: an id that was never scheduled answers identically.
 
+> **EVENT IDS GO BOTH WAYS, AND WHICH ONE YOU NEED DEPENDS ON HOW YOU GOT THE ID.** *Deriving* goes index → id and touches no chain — `gameAirdropEventIds` for a game's draws, `peopleAirdropsEventId` for a `PeopleAirdrops` draw. *Decoding* goes id → index, and is what you need when the id came out of `Airdrop.Events.getEntries()`: you never derived those, so you cannot re-derive them. `parsePeopleAirdropsEventId(eventId)` returns the draw index, or `null` for anything that is not a `PeopleAirdrops` id. Do not enumerate forward instead — `PeopleAirdrops.NextDrawIndex` is a monotonic high-water mark and finished draws are reaped, so building ids `0..next` costs one read per index ever scheduled, nearly all absent. And that map holds **both** schedulers, so a `Game` id reaching the parser is ordinary input: `null` is an answer, not a failure.
+
 ### Claiming a prize
 
 ```ts
@@ -403,7 +405,7 @@ The first four stop the extrinsic; the last four stop only the draw entry. `canS
 
 ### Sign-Up Gotchas
 
-- **Derive the event ids from one block.** An id built from one game's index and another's count addresses a draw that does not exist. Use the `eventIds` the read returns.
+- **Derive the event ids from one block.** An id built from one game's index and another's count addresses a draw that does not exist. Use the `eventIds` the read returns. Going the other way — an id you swept out of `Airdrop.Events` rather than derived — is `parsePeopleAirdropsEventId`, see [The Game and Its Prize Draws](#the-game-and-its-prize-draws).
 - **The entry count must equal `airdropsScheduled` exactly.** A mismatch fails the whole sign-up, deposit included. `Some([])` is not `None`: omit `airdrops` to enter no draw.
 - **Only sr25519 accounts can take the account path.** The pallet reinterprets the account id **as** the public key, and nothing on chain records the scheme, so the SDK cannot check it unless you pass `keyType`.
 - **The transcript binds the signing key.** The `signer` item must be the account that signs the sign-up, not another key the player holds.


### PR DESCRIPTION
Related to #286

### Description

Adds `parsePeopleAirdropsEventId(eventId)`. It returns the draw index inside a `PeopleAirdrops` event id, or `null` for anything else.

The package could build these ids but not read them back. Callers who list `Airdrop.Events` get ids they never built, from two schedulers mixed together, so they had to reimplement the 32 byte layout to tell them apart. humanity-spa does that today.

### Changes

The function sits in `airdrop-ids.ts` beside the encoder it inverts, so one test asserts they round-trip. Exported from the package index, with a note in `SKILL.md` on the two directions and which one a caller needs.

Two decisions worth flagging. It returns `null` rather than throwing, because `Airdrop.Events` is shared and a foreign id is ordinary input. And the `0x` prefix is matched case-sensitively while the body is not, which looks inconsistent but is deliberate: PAPI hands us the id and decodes it again on the next read, and it accepts either case in the body but only a lower-case `0x`. Lower-casing the whole string would accept `0X...` and report an index for an id that then reads back as different bytes.

### Testing

17 cases in the existing in-source block: round-trips through `u64::MAX`, a `Game` id and a foreign base returning `null`, an upper-case body decoding, and malformed inputs. One case is a bare hex literal, the same 32 bytes humanity-spa's stub backend already hardcodes, pasted in rather than derived. No dependency, just the value. A vector built with this module's own encoder would pass even if encode and decode drifted together, which is the failure this layout is exposed to since nothing in metadata describes it.

```bash
pnpm install && pnpm -r build && pnpm -r test && pnpm check
```

411 tests over 20 files in this package, zero typecheck errors, biome clean. Build the siblings first: without `pnpm -r build` the in-source tests cannot resolve `@parity/result`, on `main` as well as on this branch.