### PR TITLE
feat(individuality): product proof contexts and personhood ring locations

### DIFF
--- a/product-sdk/packages/individuality/src/contexts.ts
+++ b/product-sdk/packages/individuality/src/contexts.ts
@@ -125,6 +125,9 @@ export const PERSONHOOD_CONTEXT_INDEX = {
 
 export type PersonhoodContextName = keyof typeof PERSONHOOD_CONTEXT_INDEX;
 
+/** `indiv_support::context::MAX_NETWORK_SUFFIX_LENGTH`. */
+const MAX_TLD_BYTES = 16;
+
 /**
  * The personhood product's context for `name` on the network issuing `.<tld>`
  * names: `productContext("peopl.<tld>", Index(PERSONHOOD_CONTEXT_INDEX[name]))`.
@@ -133,13 +136,18 @@ export type PersonhoodContextName = keyof typeof PERSONHOOD_CONTEXT_INDEX;
  * paseo networks), so the same context name on two networks is two different
  * values — which is why it is a parameter and never a default.
  *
- * @param tld - a single DotNS label, without the leading dot.
- * @throws ProductIndividualityError on a TLD that is empty or not a single
- *   label: `"peopl" + ".te.st"` and `"peopl.te" + ".st"` would collide, so a
- *   composite here is always a caller bug.
+ * @param tld - a single lower-case DotNS label, without the leading dot.
+ * @throws ProductIndividualityError on a tld the runtime cannot represent, or a
+ *   composite one: `"peopl" + ".te.st"` and `"peopl.te" + ".st"` would collide.
  */
 export function personhoodContext(tld: string, name: PersonhoodContextName): Uint8Array {
-    if (tld.length === 0 || tld.includes(".") || tld.includes("/")) {
+    if (
+        tld.length === 0 ||
+        tld.includes(".") ||
+        tld.includes("/") ||
+        tld !== tld.toLowerCase() ||
+        utf8ToBytes(tld).length > MAX_TLD_BYTES
+    ) {
         throw new ProductIndividualityError("personhood context tld must be a single dotns label");
     }
     return productContext(`${PERSONHOOD_PRODUCT_NAME}.${tld}`, {
@@ -251,8 +259,12 @@ if (import.meta.vitest) {
             expect(contexts.size).toBe(tlds.length);
         });
 
-        test.each(["", "te.st", "te/st"])("rejects the tld %j", (tld) => {
+        test.each(["", "te.st", "te/st", "TEST", "a".repeat(17)])("rejects the tld %j", (tld) => {
             expect(() => personhoodContext(tld, "score")).toThrow(ProductIndividualityError);
+        });
+
+        test("accepts a tld at the 16-byte bound", () => {
+            expect(() => personhoodContext("a".repeat(16), "score")).not.toThrow();
         });
     });
 }

--- a/product-sdk/packages/individuality/src/contexts.ts
+++ b/product-sdk/packages/individuality/src/contexts.ts
@@ -1,0 +1,258 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Product-scoped ring-VRF proof contexts (RFC-0004 / RFC-0022 / RFC-0024).
+ *
+ * A host never lets a product choose its proof context: it derives it from the
+ * product's identity, so a product can prove personhood only in its own
+ * namespace. Since individuality `0fec7071` ("Use product-owned personhood
+ * contexts") the chain derives its own contexts the same way — every context a
+ * runtime accepts is
+ *
+ * ```
+ * context = blake2b-256("product/" ++ product_id ++ "/" ++ suffix_bytes)
+ * ```
+ *
+ * where `suffix_bytes` expands the RFC-0024 `Index`/`Raw` selector:
+ *
+ * ```
+ * Index(n)   -> n as u32 LE ++ blake2b-256("product-account-index")[..28]
+ * Raw(bytes) -> the 32 bytes verbatim
+ * ```
+ *
+ * Everything here is pure computation, so a product can *predict* the context a
+ * host will use, compare it against what `createAccountProof` actually returns,
+ * and hand the constant to off-chain verifiers. The `product_id` is always a
+ * full DotNS id (`"peopl.test"`, `"dim2.dot"`): the TLD belongs to the network,
+ * and the same name on two networks is two different 32-byte contexts.
+ *
+ * The personhood product's own contexts are enumerated too, because two of the
+ * five never reach metadata (`resources` and `dotnsGateway` are plain `impl`
+ * fns, not `#[pallet::extra_constants]`) and so can only be derived
+ * client-side. `readScoreContext` in `rings.ts` is the read that checks this
+ * derivation against a published constant before anything trusts it.
+ */
+import { blake2b256, concatBytes, utf8ToBytes } from "@parity/product-sdk-utils";
+import { ProductIndividualityError } from "./errors.js";
+
+/**
+ * The RFC-0024 context-suffix selector: a plain index, or 32 raw bytes.
+ *
+ * Structurally the shape of truapi's `DerivationIndex` except that `Raw`
+ * carries bytes rather than `0x` hex, because everything in this module is
+ * byte-level. Wrap with your transport's hex conversion at the wire boundary.
+ */
+export type ContextSuffix = { tag: "Index"; value: number } | { tag: "Raw"; value: Uint8Array };
+
+/** Every expanded suffix, and every derived context, is 32 bytes. */
+const SUFFIX_BYTES = 32;
+
+/**
+ * `blake2b-256("product-account-index")[..28]`, the trailing marker of an
+ * expanded `Index` suffix per RFC-0022. A domain-separation constant, not
+ * entropy: it keeps a plain index from colliding with a `Raw` payload that
+ * happens to start with the same four bytes. Computed rather than pasted so the
+ * definition, not a magic array, is what this module asserts.
+ */
+const INDEX_MAGIC = blake2b256(utf8ToBytes("product-account-index")).subarray(0, SUFFIX_BYTES - 4);
+
+const U32_MAX = 0xff_ff_ff_ff;
+
+/**
+ * Expand a {@link ContextSuffix} to the 32 bytes the context hash consumes,
+ * mirroring `ProductContextSuffix::bytes()` in `individuality/support`.
+ *
+ * @throws ProductIndividualityError on an index outside `u32`, or `Raw` bytes
+ *   that are not exactly 32.
+ */
+export function contextSuffixBytes(suffix: ContextSuffix): Uint8Array {
+    if (suffix.tag === "Raw") {
+        if (suffix.value.length !== SUFFIX_BYTES) {
+            throw new ProductIndividualityError("raw context suffix must be 32 bytes");
+        }
+        return suffix.value.slice();
+    }
+    if (!Number.isInteger(suffix.value) || suffix.value < 0 || suffix.value > U32_MAX) {
+        throw new ProductIndividualityError("context suffix index is out of range");
+    }
+    const bytes = new Uint8Array(SUFFIX_BYTES);
+    new DataView(bytes.buffer).setUint32(0, suffix.value, true);
+    bytes.set(INDEX_MAGIC, 4);
+    return bytes;
+}
+
+/**
+ * The 32-byte proof context of `{ productId, suffix }`, mirroring
+ * `indiv_support::context::build_product_context`.
+ *
+ * This is the value that must equal `contextualAlias.context` in every
+ * `createAccountProof` / `getAccountAlias` response for that product account,
+ * and the value of the on-chain context constants (`Score.score_context` and
+ * friends) on a runtime that derives them the product way.
+ *
+ * @param productId - the full DotNS id, TLD included (`"dim2.dot"`,
+ *   `"peopl.test"`). Never assemble it from a hardcoded TLD: the network
+ *   decides the TLD, so take it from configuration or from the chain.
+ * @throws ProductIndividualityError via {@link contextSuffixBytes}.
+ */
+export function productContext(productId: string, suffix: ContextSuffix): Uint8Array {
+    return blake2b256(
+        concatBytes(utf8ToBytes(`product/${productId}/`), contextSuffixBytes(suffix)),
+    );
+}
+
+/**
+ * `personhood::PRODUCT_NAME` — the DotNS name (TLD excluded) the personhood
+ * product's contexts derive from, shared by every network.
+ */
+export const PERSONHOOD_PRODUCT_NAME = "peopl";
+
+/**
+ * The context suffix indices the personhood product owns, mirroring
+ * `personhood` in `individuality/support/src/context.rs`.
+ *
+ * Only `score`, `peopleLiteAuth` and `peopleAirdrops` are published as runtime
+ * constants; `resources` and `dotnsGateway` exist solely as this derivation, so
+ * pinning the published three pins the derivation that produces the other two.
+ */
+export const PERSONHOOD_CONTEXT_INDEX = {
+    score: 0,
+    resources: 1,
+    peopleLiteAuth: 2,
+    dotnsGateway: 3,
+    peopleAirdrops: 4,
+} as const;
+
+export type PersonhoodContextName = keyof typeof PERSONHOOD_CONTEXT_INDEX;
+
+/**
+ * The personhood product's context for `name` on the network issuing `.<tld>`
+ * names: `productContext("peopl.<tld>", Index(PERSONHOOD_CONTEXT_INDEX[name]))`.
+ *
+ * The TLD belongs to the network (`"test"` on previewnet, `"paseo"` on the
+ * paseo networks), so the same context name on two networks is two different
+ * values — which is why it is a parameter and never a default.
+ *
+ * @param tld - a single DotNS label, without the leading dot.
+ * @throws ProductIndividualityError on a TLD that is empty or not a single
+ *   label: `"peopl" + ".te.st"` and `"peopl.te" + ".st"` would collide, so a
+ *   composite here is always a caller bug.
+ */
+export function personhoodContext(tld: string, name: PersonhoodContextName): Uint8Array {
+    if (tld.length === 0 || tld.includes(".") || tld.includes("/")) {
+        throw new ProductIndividualityError("personhood context tld must be a single dotns label");
+    }
+    return productContext(`${PERSONHOOD_PRODUCT_NAME}.${tld}`, {
+        tag: "Index",
+        value: PERSONHOOD_CONTEXT_INDEX[name],
+    });
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    /** Hex of bytes, computed here so vectors share no encoder with the code under test. */
+    const hex = (bytes: Uint8Array): string =>
+        `0x${[...bytes].map((b) => b.toString(16).padStart(2, "0")).join("")}`;
+
+    /** `Index(0)` expanded — the `<idx0>` constant quoted in dim2-spa#97. */
+    const IDX0 = "0x0000000012e86013736c5498f050b03cdc16957dff0e422fb92ca77ec3ab168f";
+
+    describe("contextSuffixBytes", () => {
+        test("expands Index(0) to the pinned <idx0> constant", () => {
+            expect(hex(contextSuffixBytes({ tag: "Index", value: 0 }))).toBe(IDX0);
+        });
+
+        test("encodes the index little-endian in the first four bytes", () => {
+            const bytes = contextSuffixBytes({ tag: "Index", value: 0x01_02_03_04 });
+            expect(hex(bytes.subarray(0, 4))).toBe("0x04030201");
+            // The domain-separation tail is index-independent.
+            expect(hex(bytes.subarray(4))).toBe(
+                hex(contextSuffixBytes({ tag: "Index", value: 0 }).subarray(4)),
+            );
+        });
+
+        test("passes Raw bytes through unchanged, as a copy", () => {
+            const raw = new Uint8Array(32).fill(7);
+            const expanded = contextSuffixBytes({ tag: "Raw", value: raw });
+            expect(expanded).toEqual(raw);
+            expanded[0] = 0xff;
+            expect(raw[0]).toBe(7);
+        });
+
+        test.each([31, 33])("rejects %i Raw bytes", (length) => {
+            expect(() => contextSuffixBytes({ tag: "Raw", value: new Uint8Array(length) })).toThrow(
+                ProductIndividualityError,
+            );
+        });
+
+        test.each([-1, 1.5, 2 ** 32, Number.NaN])("rejects the index %s", (value) => {
+            expect(() => contextSuffixBytes({ tag: "Index", value })).toThrow(
+                ProductIndividualityError,
+            );
+        });
+    });
+
+    describe("productContext", () => {
+        // Pinned in dim2-spa's proofContext tests against the values in the man
+        // chapter /docs/personhood-binding/proofs-from-a-product.
+        test.each([
+            ["game.dot", "0xca025e3e4a39ed98ed7b0a4d953a1986c172cc8724a56ca504ced5a85cd4b01a"],
+            ["dim2.dot", "0x80eb3c1756f471aba0d30cdaca899993588fa4fab2f98c2431c619b6bb418fbb"],
+        ])("matches the pinned %s / Index(0) constant", (productId, pinned) => {
+            expect(hex(productContext(productId, { tag: "Index", value: 0 }))).toBe(pinned);
+        });
+
+        test("gives distinct products distinct contexts", () => {
+            const suffix: ContextSuffix = { tag: "Index", value: 0 };
+            expect(hex(productContext("dim2.dot", suffix))).not.toBe(
+                hex(productContext("dim2.test", suffix)),
+            );
+        });
+    });
+
+    describe("personhoodContext", () => {
+        // Read from previewnet's People chain (spec 1000036) as the runtime
+        // constants Score.score_context, PeopleLite.auth_context and
+        // PeopleAirdrops.people_airdrops_context. Pinning the three that are
+        // published pins the derivation that produces the unpublished two.
+        test.each([
+            ["score", "0xa02ef8d90148203d1b7573e28c044c7b46e42793766bf6d7687ef5da86024a8e"],
+            [
+                "peopleLiteAuth",
+                "0xb2f3d012bd825090725ace97002be3357db3ff42aa4414e4f5bcd751abc8de90",
+            ],
+            [
+                "peopleAirdrops",
+                "0xeee07f0e4030bb780f4eb72ecc4f724a522919fb487d58fe9cad4ed69125911f",
+            ],
+        ] as const)("derives the %s context previewnet publishes", (name, onChain) => {
+            expect(hex(personhoodContext("test", name))).toBe(onChain);
+        });
+
+        test("derives the Resources context previewnet expects", () => {
+            // Not readable from metadata; produced by the derivation the cases
+            // above prove, at personhood::RESOURCES (index 1). Pinned in
+            // humanity-spa's personhood-context tests.
+            expect(hex(personhoodContext("test", "resources"))).toBe(
+                "0xa1863952733a5e745cf5691f9a01b0b737ad04c00234784d84064f487973620d",
+            );
+        });
+
+        test("gives every context name its own value", () => {
+            const names = Object.keys(PERSONHOOD_CONTEXT_INDEX) as PersonhoodContextName[];
+            const contexts = new Set(names.map((name) => hex(personhoodContext("test", name))));
+            expect(contexts.size).toBe(names.length);
+        });
+
+        test("gives every network its own value", () => {
+            const tlds = ["dot", "test", "paseo"];
+            const contexts = new Set(tlds.map((tld) => hex(personhoodContext(tld, "score"))));
+            expect(contexts.size).toBe(tlds.length);
+        });
+
+        test.each(["", "te.st", "te/st"])("rejects the tld %j", (tld) => {
+            expect(() => personhoodContext(tld, "score")).toThrow(ProductIndividualityError);
+        });
+    });
+}

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -296,12 +296,24 @@ export type { ContextSuffix, PersonhoodContextName } from "./contexts.js";
 
 // Where the two personhood rings live, and the one context read: a lite proof
 // must be minted in `Score.score_context`, and `readScoreContext` checks that
-// constant is the product derivation of `peopl.<Score.Suffix>/Index(0)` — the
-// only kind of context a stock host can mint. A runtime still publishing a
-// literal answers `NotProductDerived` on the ok channel, and every
-// proof-building flow must treat that as a hard stop.
-export { litePeopleRing, peopleRing, readScoreContext, ringCollectionId } from "./rings.js";
+// constant is the product derivation of `peopl.<network suffix>/Index(0)` — the
+// only kind of context a stock host can mint. A runtime publishing a literal
+// answers `NotProductDerived` on the ok channel, and every proof-building flow
+// must treat that as a hard stop.
+//
+// The suffix contracts are separate rather than one interface with optional
+// members, because an optional member constrains nothing structurally and the
+// umbrella guard would stop telling the environments apart.
+export {
+    litePeopleRing,
+    peopleRing,
+    readScoreContext,
+    ringCollectionId,
+    runScoreContextRead,
+} from "./rings.js";
 export type {
+    LegacySuffixChain,
+    NetworkSuffixChain,
     ReadScoreContextOptions,
     RingLocation,
     ScoreContext,

--- a/product-sdk/packages/individuality/src/index.ts
+++ b/product-sdk/packages/individuality/src/index.ts
@@ -279,6 +279,35 @@ export type {
     ReadClaimEligibilityOptions,
 } from "./claim.js";
 
+// Proof contexts, derived offline. Everything a host signs under is
+// `blake2b-256("product/" ++ productId ++ "/" ++ suffix)`, so a product can
+// predict the context a host will use and compare it against what the chain
+// wants. The personhood product's own contexts are enumerated because two of
+// the five never reach metadata. Product ids are always full DotNS ids — the
+// TLD belongs to the network, and no default is offered on purpose.
+export {
+    PERSONHOOD_CONTEXT_INDEX,
+    PERSONHOOD_PRODUCT_NAME,
+    contextSuffixBytes,
+    personhoodContext,
+    productContext,
+} from "./contexts.js";
+export type { ContextSuffix, PersonhoodContextName } from "./contexts.js";
+
+// Where the two personhood rings live, and the one context read: a lite proof
+// must be minted in `Score.score_context`, and `readScoreContext` checks that
+// constant is the product derivation of `peopl.<Score.Suffix>/Index(0)` — the
+// only kind of context a stock host can mint. A runtime still publishing a
+// literal answers `NotProductDerived` on the ok channel, and every
+// proof-building flow must treat that as a hard stop.
+export { litePeopleRing, peopleRing, readScoreContext, ringCollectionId } from "./rings.js";
+export type {
+    ReadScoreContextOptions,
+    RingLocation,
+    ScoreContext,
+    ScoreContextChain,
+} from "./rings.js";
+
 // The write half: wrap a signer so the call runs under a person origin. Returns
 // a `PolkadotSigner`, so submission stays with `@parity/product-sdk-tx`.
 export { withAsPerson } from "./as-person-signer.js";

--- a/product-sdk/packages/individuality/src/rings.ts
+++ b/product-sdk/packages/individuality/src/rings.ts
@@ -280,7 +280,12 @@ async function resolveSuffix(
     }
     const stored = chain.individuality.query?.NetworkSuffix?.NetworkSuffix;
     if (stored !== undefined) {
-        // Only a NetworkSuffixChain reaches here, and it extends PinnedChain.
+        // runScoreContextRead is looser than the overloads, so `raw` can be missing.
+        if (chain.raw === undefined && pinned === undefined) {
+            throw new ProductIndividualityError(
+                "reading the suffix from storage needs a finalized block",
+            );
+        }
         const snapshot = await pinBlock(chain as PinnedChain, options.signal, pinned);
         return {
             tld: SUFFIX_DECODER.decode(await stored.getValue(readAt(snapshot, options.signal))),
@@ -517,6 +522,22 @@ if (import.meta.vitest) {
             const score = await runScoreContextRead(chain, {}, composed);
             expect(pinned).toBe(false);
             expect(score.at).toEqual(composed);
+        });
+
+        test("throws the package error when storage has no block source", async () => {
+            const chain = storageChain(PREVIEWNET_SCORE_CONTEXT);
+            const { raw: _raw, ...blockless } = chain;
+            await expect(runScoreContextRead(blockless as typeof chain)).rejects.toBeInstanceOf(
+                ProductIndividualityError,
+            );
+        });
+
+        test("a handed-in snapshot needs no block source", async () => {
+            const chain = storageChain(PREVIEWNET_SCORE_CONTEXT);
+            const { raw: _raw, ...blockless } = chain;
+            const composed = { blockHash: `0x${"99".repeat(32)}`, blockNumber: 7 };
+            const score = await runScoreContextRead(blockless as typeof chain, {}, composed);
+            expect(score.tag).toBe("ProductDerived");
         });
 
         test("throws when nothing can resolve the suffix", async () => {

--- a/product-sdk/packages/individuality/src/rings.ts
+++ b/product-sdk/packages/individuality/src/rings.ts
@@ -14,17 +14,24 @@
  * {@link readScoreContext} is the one read: the 32-byte context every lite
  * proof must be minted in is the runtime constant `Score.score_context`, and on
  * a runtime that derives its contexts the product way it equals
- * `productContext("peopl." ++ Score.Suffix, Index(0))` — a context any stock
- * host can mint. A runtime where the two disagree (nextv2's pre-#1300 `pop:`
- * literals) publishes a context no host will sign in, so the read reports that
- * as {@link ScoreContext} `NotProductDerived` and callers must not build a
+ * `personhoodContext(<network suffix>, "score")` — a context any stock host can
+ * mint.
+ *
+ * Where a runtime keeps that suffix is typed rather than probed: {@link
+ * NetworkSuffixChain}, {@link LegacySuffixChain}, or neither, and the caller says.
+ *
+ * A runtime whose published context is not that derivation (nextv2's pre-#1300
+ * `pop:` literals) publishes a context no host will sign in, so the read reports
+ * that as {@link ScoreContext} `NotProductDerived` and callers must not build a
  * proof leg — the chain would reject it as `InvalidTransaction::Call` with
  * nothing local to read.
  */
 import { err, normalizeError, ok, type Result } from "@parity/result";
 import { bytesToHex, hexToBytes, utf8ToBytes } from "@parity/product-sdk-utils";
-import { PERSONHOOD_CONTEXT_INDEX, PERSONHOOD_PRODUCT_NAME, productContext } from "./contexts.js";
+import { PERSONHOOD_PRODUCT_NAME, personhoodContext } from "./contexts.js";
 import { IndividualityDecodeError, ProductIndividualityError } from "./errors.js";
+import { pinBlock, readAt, type PinnedChain, type ReadAt } from "./pinned.js";
+import type { FinalizedSnapshot } from "./types.js";
 
 /** `0x`-prefixed hex, as truapi's wire types spell it. */
 type Hex = `0x${string}`;
@@ -86,15 +93,15 @@ export function litePeopleRing(genesisHash: Hex): RingLocation {
 }
 
 /**
- * The two constants {@link readScoreContext} reads. Constants are served from
- * the client's runtime rather than a block, so this does not extend
- * `PinnedChain`.
+ * The published context every score proof must be minted in.
+ *
+ * Separate from the suffix contracts because merging them needs optional
+ * members, which constrain nothing structurally and blind the umbrella guard.
  *
  * Matched by hand against the previewnet descriptors on 2026-08-31:
  *
  * ```
  * Score.score_context: PlainDescriptor<SizedHex<32>>
- * Score.Suffix:        PlainDescriptor<Uint8Array>
  * ```
  */
 export interface ScoreContextChain {
@@ -103,8 +110,63 @@ export interface ScoreContextChain {
             Score: {
                 /** The 32-byte context scores are proven in, as `0x` hex. */
                 score_context(): Promise<string>;
+            };
+        };
+    };
+}
+
+/**
+ * The network suffix since individuality-community #20. Root can move it between
+ * blocks, so it is read at a pinned one. The pallet is testnet-only upstream, so
+ * production has neither this nor {@link LegacySuffixChain} and the caller says.
+ *
+ * ```
+ * NetworkSuffix.NetworkSuffix: StorageDescriptor<[], Uint8Array, false, never>
+ * ```
+ */
+export interface NetworkSuffixChain extends PinnedChain {
+    individuality: {
+        query: {
+            NetworkSuffix: {
+                NetworkSuffix: {
+                    getValue(options: ReadAt): Promise<Uint8Array>;
+                };
+            };
+        };
+    };
+}
+
+/**
+ * The network suffix before #20. Previewnet only, and gone on its next upgrade.
+ *
+ * ```
+ * Score.Suffix: PlainDescriptor<Uint8Array>
+ * ```
+ */
+export interface LegacySuffixChain {
+    individuality: {
+        constants: {
+            Score: {
                 /** The network's DotNS TLD, as UTF-8 bytes (`"test"`, `"paseo"`). */
                 Suffix(): Promise<Uint8Array>;
+            };
+        };
+    };
+}
+
+/** Private: the overloads are what make the suffix source a checked fact. */
+interface AnyScoreContextChain extends ScoreContextChain {
+    raw?: PinnedChain["raw"];
+    individuality: {
+        constants: {
+            Score: {
+                score_context(): Promise<string>;
+                Suffix?(): Promise<Uint8Array>;
+            };
+        };
+        query?: {
+            NetworkSuffix?: {
+                NetworkSuffix: { getValue(options: ReadAt): Promise<Uint8Array> };
             };
         };
     };
@@ -116,71 +178,123 @@ export interface ScoreContextChain {
  * `NotProductDerived` is an answer, not a failure — it is the state nextv2 is
  * in — so it travels on the `ok` channel, like `UsernameUnowned` does. Every
  * proof-building flow must treat it as a hard stop.
+ *
+ * A chain that will not say what its suffix is has no variant here; it is
+ * rejected at compile time.
  */
-export type ScoreContext =
-    | {
-          tag: "ProductDerived";
-          /** The 32-byte constant, equal to `productContext(productId, Index(0))`. */
-          context: Uint8Array;
-          /** `peopl.<Score.Suffix>` — the product id hosts mint this context under. */
-          productId: string;
-          /** The network's DotNS TLD, decoded from `Score.Suffix`. */
-          tld: string;
-      }
-    | {
-          tag: "NotProductDerived";
-          /** The 32-byte constant the chain actually published. */
-          context: Uint8Array;
-          /** The product id whose `Index(0)` context it was expected to be. */
-          productId: string;
-      };
+export type ScoreContext = {
+    tag: "ProductDerived" | "NotProductDerived";
+    context: Uint8Array;
+    /** `peopl.<tld>`, the id hosts mint this context under. */
+    productId: string;
+    tld: string;
+    /** Absent unless the suffix came from storage; nothing else pins. */
+    at?: FinalizedSnapshot;
+};
 
 /** Options for {@link readScoreContext}. */
 export interface ReadScoreContextOptions {
     signal?: AbortSignal;
+    /** Required when the chain publishes no suffix, and wins when it does. */
+    tld?: string;
 }
 
 const CONTEXT_HEX = /^0x[0-9a-fA-F]{64}$/;
 
+/** Fatal, so bad bytes fail the read rather than becoming U+FFFD in a product id. */
+const SUFFIX_DECODER = new TextDecoder("utf-8", { fatal: true });
+
 /**
- * Read `Score.score_context` and the product id it should derive from, and
- * check the two agree.
+ * Read `Score.score_context` and check it is the product derivation of
+ * `peopl.<tld>/Index(0)` — the only kind of context a stock host can mint.
+ *
+ * A chain's suffix source is fixed by its type, so one with none is a compile
+ * error rather than a runtime disappointment.
  *
  * ```ts
- * const score = await readScoreContext(chain);
+ * const score = await readScoreContext(chain, { tld: "paseo" });
  * if (score.ok && score.value.tag === "ProductDerived") {
  *     // mint proofs in { productId: score.value.productId, suffix: Index(0) }
  * }
  * ```
  */
 export async function readScoreContext(
+    chain: ScoreContextChain & NetworkSuffixChain,
+    options?: ReadScoreContextOptions,
+): Promise<Result<ScoreContext, ProductIndividualityError>>;
+export async function readScoreContext(
+    chain: ScoreContextChain & LegacySuffixChain,
+    options?: ReadScoreContextOptions,
+): Promise<Result<ScoreContext, ProductIndividualityError>>;
+export async function readScoreContext(
     chain: ScoreContextChain,
+    options: ReadScoreContextOptions & { tld: string },
+): Promise<Result<ScoreContext, ProductIndividualityError>>;
+export async function readScoreContext(
+    chain: AnyScoreContextChain,
     options: ReadScoreContextOptions = {},
 ): Promise<Result<ScoreContext, ProductIndividualityError>> {
     try {
-        options.signal?.throwIfAborted();
-        const constants = chain.individuality.constants.Score;
-        const [constant, suffix] = await Promise.all([
-            constants.score_context(),
-            constants.Suffix(),
-        ]);
-        if (!CONTEXT_HEX.test(constant)) {
-            throw new IndividualityDecodeError("score context constant is not 32 bytes of hex");
-        }
-        const context = hexToBytes(constant.slice(2));
-        const tld = new TextDecoder().decode(suffix);
-        const productId = `${PERSONHOOD_PRODUCT_NAME}.${tld}`;
-        const derived = productContext(productId, {
-            tag: "Index",
-            value: PERSONHOOD_CONTEXT_INDEX.score,
-        });
-        if (bytesToHex(derived) === bytesToHex(context)) {
-            return ok({ tag: "ProductDerived", context, productId, tld });
-        }
-        return ok({ tag: "NotProductDerived", context, productId });
+        return ok(await runScoreContextRead(chain, options));
     } catch (cause) {
         return err(normalizeError(cause, ProductIndividualityError));
     }
+}
+
+/**
+ * Throws; {@link readScoreContext} owns the `Result` boundary. Exported so a
+ * composing read can run it against a block it already pinned, like
+ * `prize-status.ts` runs `runDrawRead`, rather than pinning a second.
+ */
+export async function runScoreContextRead(
+    chain: AnyScoreContextChain,
+    options: ReadScoreContextOptions = {},
+    pinned?: FinalizedSnapshot,
+): Promise<ScoreContext> {
+    options.signal?.throwIfAborted();
+    const [constant, resolved] = await Promise.all([
+        chain.individuality.constants.Score.score_context(),
+        resolveSuffix(chain, options, pinned),
+    ]);
+    if (!CONTEXT_HEX.test(constant)) {
+        throw new IndividualityDecodeError("score context constant is not 32 bytes of hex");
+    }
+    const context = hexToBytes(constant.slice(2));
+    const { tld, at } = resolved;
+    const derived = personhoodContext(tld, "score");
+    const productId = `${PERSONHOOD_PRODUCT_NAME}.${tld}`;
+    const tag = derived.every((byte, index) => byte === context[index])
+        ? "ProductDerived"
+        : "NotProductDerived";
+    return at === undefined
+        ? { tag, context, productId, tld }
+        : { tag, context, productId, tld, at };
+}
+
+/** Storage beats the constant: Root can move it under a chain whose constant is stale. */
+async function resolveSuffix(
+    chain: AnyScoreContextChain,
+    options: ReadScoreContextOptions,
+    pinned: FinalizedSnapshot | undefined,
+): Promise<{ tld: string; at?: FinalizedSnapshot }> {
+    if (options.tld !== undefined) {
+        return { tld: options.tld };
+    }
+    const stored = chain.individuality.query?.NetworkSuffix?.NetworkSuffix;
+    if (stored !== undefined) {
+        // Only a NetworkSuffixChain reaches here, and it extends PinnedChain.
+        const snapshot = await pinBlock(chain as PinnedChain, options.signal, pinned);
+        return {
+            tld: SUFFIX_DECODER.decode(await stored.getValue(readAt(snapshot, options.signal))),
+            at: snapshot,
+        };
+    }
+    const constant = chain.individuality.constants.Score.Suffix;
+    if (constant !== undefined) {
+        return { tld: SUFFIX_DECODER.decode(await constant()) };
+    }
+    // Unreachable through the overloads; runScoreContextRead is not as strict.
+    throw new ProductIndividualityError("chain publishes no network suffix and none was supplied");
 }
 
 if (import.meta.vitest) {
@@ -193,13 +307,58 @@ if (import.meta.vitest) {
     const PREVIEWNET_SCORE_CONTEXT =
         "0xa02ef8d90148203d1b7573e28c044c7b46e42793766bf6d7687ef5da86024a8e";
 
-    function fakeChain(scoreContext: string | Promise<string>, suffix = "test"): ScoreContextChain {
+    /** A pre-#1300 ASCII literal: valid hex, not a product derivation. */
+    const LITERAL = hex(utf8ToBytes("pop:polkadot.network/score      "));
+
+    const BLOCK = { hash: `0x${"77".repeat(32)}`, number: 42 };
+    const SNAPSHOT = { blockHash: BLOCK.hash, blockNumber: BLOCK.number };
+
+    /** Production, and paseo today. */
+    function bareChain(scoreContext: string | Promise<string>): ScoreContextChain {
+        return {
+            individuality: {
+                constants: { Score: { score_context: () => Promise.resolve(scoreContext) } },
+            },
+        };
+    }
+
+    /** Previewnet today. */
+    function legacyChain(
+        scoreContext: string | Promise<string>,
+        suffix: Uint8Array = utf8ToBytes("test"),
+    ): ScoreContextChain & LegacySuffixChain {
         return {
             individuality: {
                 constants: {
                     Score: {
                         score_context: () => Promise.resolve(scoreContext),
-                        Suffix: () => Promise.resolve(utf8ToBytes(suffix)),
+                        Suffix: () => Promise.resolve(suffix),
+                    },
+                },
+            },
+        };
+    }
+
+    /** Post-#20, and nothing yet. */
+    function storageChain(
+        scoreContext: string | Promise<string>,
+        suffix = "test",
+        onPin?: () => void,
+    ): ScoreContextChain & NetworkSuffixChain {
+        return {
+            raw: {
+                individuality: {
+                    getFinalizedBlock: () => {
+                        onPin?.();
+                        return Promise.resolve(BLOCK);
+                    },
+                },
+            },
+            individuality: {
+                constants: { Score: { score_context: () => Promise.resolve(scoreContext) } },
+                query: {
+                    NetworkSuffix: {
+                        NetworkSuffix: { getValue: () => Promise.resolve(utf8ToBytes(suffix)) },
                     },
                 },
             },
@@ -242,8 +401,8 @@ if (import.meta.vitest) {
     });
 
     describe("readScoreContext", () => {
-        test("answers ProductDerived for previewnet's published constant", async () => {
-            const result = await readScoreContext(fakeChain(PREVIEWNET_SCORE_CONTEXT));
+        test("answers ProductDerived from the legacy constant", async () => {
+            const result = await readScoreContext(legacyChain(PREVIEWNET_SCORE_CONTEXT));
             expect(result).toEqual(
                 ok({
                     tag: "ProductDerived",
@@ -256,26 +415,59 @@ if (import.meta.vitest) {
 
         test("accepts upper-case constant hex", async () => {
             const shouting = `0x${PREVIEWNET_SCORE_CONTEXT.slice(2).toUpperCase()}`;
-            const result = await readScoreContext(fakeChain(shouting));
+            const result = await readScoreContext(legacyChain(shouting));
             expect(result.ok && result.value.tag).toBe("ProductDerived");
         });
 
-        test("answers NotProductDerived for a literal context, on the ok channel", async () => {
-            // The nextv2 shape: a pre-#1300 ASCII literal, valid hex but not the
-            // product derivation of peopl.<Suffix>/Index(0).
-            const literal = hex(utf8ToBytes("pop:polkadot.network/score      "));
-            const result = await readScoreContext(fakeChain(literal, "paseo"));
+        test("resolves the suffix from storage, and reports the block it read at", async () => {
+            const result = await readScoreContext(storageChain(PREVIEWNET_SCORE_CONTEXT));
             expect(result).toEqual(
                 ok({
-                    tag: "NotProductDerived",
-                    context: hexToBytes(literal.slice(2)),
-                    productId: "peopl.paseo",
+                    tag: "ProductDerived",
+                    context: hexToBytes(PREVIEWNET_SCORE_CONTEXT.slice(2)),
+                    productId: "peopl.test",
+                    tld: "test",
+                    at: SNAPSHOT,
                 }),
             );
         });
 
+        test("an explicit tld overrides the chain and skips the lookup", async () => {
+            let pinned = false;
+            const chain = storageChain(PREVIEWNET_SCORE_CONTEXT, "test", () => {
+                pinned = true;
+            });
+            const result = await readScoreContext(chain, { tld: "paseo" });
+            expect(result.ok && result.value.tld).toBe("paseo");
+            expect(result.ok && result.value.tag).toBe("NotProductDerived");
+            expect(pinned).toBe(false);
+        });
+
+        test("answers NotProductDerived for a literal context, on the ok channel", async () => {
+            // A literal-publishing runtime has no suffix, so a caller-supplied
+            // tld is the only way this variant is reachable at all.
+            const result = await readScoreContext(bareChain(LITERAL), { tld: "paseo" });
+            expect(result).toEqual(
+                ok({
+                    tag: "NotProductDerived",
+                    context: hexToBytes(LITERAL.slice(2)),
+                    productId: "peopl.paseo",
+                    tld: "paseo",
+                }),
+            );
+        });
+
+        test("a suffix that is not UTF-8 is an error, not a mangled product id", async () => {
+            const chain = legacyChain(PREVIEWNET_SCORE_CONTEXT, new Uint8Array([0xff, 0xfe]));
+            const result = await readScoreContext(chain);
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error).toBeInstanceOf(ProductIndividualityError);
+            }
+        });
+
         test("a malformed constant is a decode error on the err channel", async () => {
-            const result = await readScoreContext(fakeChain("0xa02e"));
+            const result = await readScoreContext(legacyChain("0xa02e"));
             expect(result.ok).toBe(false);
             if (!result.ok) {
                 expect(result.error).toBeInstanceOf(IndividualityDecodeError);
@@ -284,7 +476,7 @@ if (import.meta.vitest) {
 
         test("a failing read arrives as the package error", async () => {
             const result = await readScoreContext(
-                fakeChain(Promise.reject(new Error("node unreachable"))),
+                legacyChain(Promise.reject(new Error("node unreachable"))),
             );
             expect(result.ok).toBe(false);
             if (!result.ok) {
@@ -294,7 +486,7 @@ if (import.meta.vitest) {
 
         test("an aborted signal throws before any round trip", async () => {
             let fetched = false;
-            const chain: ScoreContextChain = {
+            const chain: ScoreContextChain & LegacySuffixChain = {
                 individuality: {
                     constants: {
                         Score: {
@@ -315,6 +507,25 @@ if (import.meta.vitest) {
             const result = await readScoreContext(chain, { signal: controller.signal });
             expect(result.ok).toBe(false);
             expect(fetched).toBe(false);
+        });
+    });
+
+    describe("runScoreContextRead", () => {
+        test("reads at a snapshot it was handed, pinning no second block", async () => {
+            let pinned = false;
+            const chain = storageChain(PREVIEWNET_SCORE_CONTEXT, "test", () => {
+                pinned = true;
+            });
+            const composed = { blockHash: `0x${"99".repeat(32)}`, blockNumber: 7 };
+            const score = await runScoreContextRead(chain, {}, composed);
+            expect(pinned).toBe(false);
+            expect(score.at).toEqual(composed);
+        });
+
+        test("throws when nothing can resolve the suffix", async () => {
+            await expect(runScoreContextRead(bareChain(LITERAL))).rejects.toBeInstanceOf(
+                ProductIndividualityError,
+            );
         });
     });
 }

--- a/product-sdk/packages/individuality/src/rings.ts
+++ b/product-sdk/packages/individuality/src/rings.ts
@@ -5,9 +5,9 @@
  *
  * Ring-VRF host calls (`registerRingVrfKey`, `listRingVrfKeys`,
  * `createAccountProof`) address a ring by a {@link RingLocation}. On the
- * individuality chain there are exactly two: the *people* ring (full persons,
- * member-key index 0) and the *people-lite* ring (lite persons, index 1),
- * differing only in their `CollectionId` junction. {@link peopleRing} and
+ * individuality chain there are exactly two, the *people* ring for full persons
+ * and the *people-lite* ring for lite persons, differing only in their
+ * `CollectionId` junction. {@link peopleRing} and
  * {@link litePeopleRing} build them from a genesis hash; nothing here talks to
  * a host.
  *
@@ -76,17 +76,15 @@ function personhoodRing(genesisHash: Hex, name: "people" | "people-lite"): RingL
 }
 
 /**
- * The *people* ring (full persons, member-key index 0) on the chain with
- * genesis `genesisHash`. The host resolves the `Members` pallet by name, so no
- * `PalletInstance` junction is needed.
+ * The *people* ring on the chain with genesis `genesisHash`. The host resolves
+ * the `Members` pallet by name, so no `PalletInstance` junction is needed.
  */
 export function peopleRing(genesisHash: Hex): RingLocation {
     return personhoodRing(genesisHash, "people");
 }
 
 /**
- * The *people-lite* ring (lite persons, member-key index 1) on the chain with
- * genesis `genesisHash`.
+ * The *people-lite* ring on the chain with genesis `genesisHash`.
  */
 export function litePeopleRing(genesisHash: Hex): RingLocation {
     return personhoodRing(genesisHash, "people-lite");
@@ -300,8 +298,7 @@ async function resolveSuffix(
 if (import.meta.vitest) {
     const { describe, test, expect } = import.meta.vitest;
 
-    const hex = (bytes: Uint8Array): string =>
-        `0x${[...bytes].map((b) => b.toString(16).padStart(2, "0")).join("")}`;
+    const hex = (bytes: Uint8Array): string => `0x${bytesToHex(bytes)}`;
 
     /** Previewnet's published `Score.score_context` (spec 1000036). */
     const PREVIEWNET_SCORE_CONTEXT =

--- a/product-sdk/packages/individuality/src/rings.ts
+++ b/product-sdk/packages/individuality/src/rings.ts
@@ -1,0 +1,320 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Where the personhood rings live, and which context the chain scores in.
+ *
+ * Ring-VRF host calls (`registerRingVrfKey`, `listRingVrfKeys`,
+ * `createAccountProof`) address a ring by a {@link RingLocation}. On the
+ * individuality chain there are exactly two: the *people* ring (full persons,
+ * member-key index 0) and the *people-lite* ring (lite persons, index 1),
+ * differing only in their `CollectionId` junction. {@link peopleRing} and
+ * {@link litePeopleRing} build them from a genesis hash; nothing here talks to
+ * a host.
+ *
+ * {@link readScoreContext} is the one read: the 32-byte context every lite
+ * proof must be minted in is the runtime constant `Score.score_context`, and on
+ * a runtime that derives its contexts the product way it equals
+ * `productContext("peopl." ++ Score.Suffix, Index(0))` — a context any stock
+ * host can mint. A runtime where the two disagree (nextv2's pre-#1300 `pop:`
+ * literals) publishes a context no host will sign in, so the read reports that
+ * as {@link ScoreContext} `NotProductDerived` and callers must not build a
+ * proof leg — the chain would reject it as `InvalidTransaction::Call` with
+ * nothing local to read.
+ */
+import { err, normalizeError, ok, type Result } from "@parity/result";
+import { bytesToHex, hexToBytes, utf8ToBytes } from "@parity/product-sdk-utils";
+import { PERSONHOOD_CONTEXT_INDEX, PERSONHOOD_PRODUCT_NAME, productContext } from "./contexts.js";
+import { IndividualityDecodeError, ProductIndividualityError } from "./errors.js";
+
+/** `0x`-prefixed hex, as truapi's wire types spell it. */
+type Hex = `0x${string}`;
+
+/**
+ * Where a ring lives: a chain, and a junction path addressing the ring on it.
+ *
+ * Structurally compatible with the host's `RingLocation`, and declared here
+ * rather than imported so this package needs no dependency on
+ * `@parity/product-sdk-host`. Same approach as `RingVRFProof`.
+ */
+export interface RingLocation {
+    /** Genesis hash of the chain hosting the ring. */
+    chainId: Hex;
+    /** Path addressing the ring within the chain. */
+    junctions: Array<
+        { tag: "PalletInstance"; value: number } | { tag: "CollectionId"; value: Hex }
+    >;
+}
+
+/** `Members` keys collections by a 32-byte id. */
+const COLLECTION_ID_BYTES = 32;
+
+/**
+ * A personhood ring's collection identifier: the human-readable name,
+ * space-padded to the 32-byte `CollectionId` the `Members` pallet keys on.
+ * Lite and full personhood differ *only* in this junction.
+ */
+export function ringCollectionId(name: "people" | "people-lite"): Uint8Array {
+    const id = new Uint8Array(COLLECTION_ID_BYTES).fill(0x20);
+    id.set(utf8ToBytes(`pop:polkadot.network/${name}`));
+    return id;
+}
+
+function personhoodRing(genesisHash: Hex, name: "people" | "people-lite"): RingLocation {
+    return {
+        chainId: genesisHash,
+        junctions: [
+            { tag: "CollectionId", value: `0x${bytesToHex(ringCollectionId(name))}` as Hex },
+        ],
+    };
+}
+
+/**
+ * The *people* ring (full persons, member-key index 0) on the chain with
+ * genesis `genesisHash`. The host resolves the `Members` pallet by name, so no
+ * `PalletInstance` junction is needed.
+ */
+export function peopleRing(genesisHash: Hex): RingLocation {
+    return personhoodRing(genesisHash, "people");
+}
+
+/**
+ * The *people-lite* ring (lite persons, member-key index 1) on the chain with
+ * genesis `genesisHash`.
+ */
+export function litePeopleRing(genesisHash: Hex): RingLocation {
+    return personhoodRing(genesisHash, "people-lite");
+}
+
+/**
+ * The two constants {@link readScoreContext} reads. Constants are served from
+ * the client's runtime rather than a block, so this does not extend
+ * `PinnedChain`.
+ *
+ * Matched by hand against the previewnet descriptors on 2026-08-31:
+ *
+ * ```
+ * Score.score_context: PlainDescriptor<SizedHex<32>>
+ * Score.Suffix:        PlainDescriptor<Uint8Array>
+ * ```
+ */
+export interface ScoreContextChain {
+    individuality: {
+        constants: {
+            Score: {
+                /** The 32-byte context scores are proven in, as `0x` hex. */
+                score_context(): Promise<string>;
+                /** The network's DotNS TLD, as UTF-8 bytes (`"test"`, `"paseo"`). */
+                Suffix(): Promise<Uint8Array>;
+            };
+        };
+    };
+}
+
+/**
+ * The chain's score context, and whether a host can mint proofs in it.
+ *
+ * `NotProductDerived` is an answer, not a failure — it is the state nextv2 is
+ * in — so it travels on the `ok` channel, like `UsernameUnowned` does. Every
+ * proof-building flow must treat it as a hard stop.
+ */
+export type ScoreContext =
+    | {
+          tag: "ProductDerived";
+          /** The 32-byte constant, equal to `productContext(productId, Index(0))`. */
+          context: Uint8Array;
+          /** `peopl.<Score.Suffix>` — the product id hosts mint this context under. */
+          productId: string;
+          /** The network's DotNS TLD, decoded from `Score.Suffix`. */
+          tld: string;
+      }
+    | {
+          tag: "NotProductDerived";
+          /** The 32-byte constant the chain actually published. */
+          context: Uint8Array;
+          /** The product id whose `Index(0)` context it was expected to be. */
+          productId: string;
+      };
+
+/** Options for {@link readScoreContext}. */
+export interface ReadScoreContextOptions {
+    signal?: AbortSignal;
+}
+
+const CONTEXT_HEX = /^0x[0-9a-fA-F]{64}$/;
+
+/**
+ * Read `Score.score_context` and the product id it should derive from, and
+ * check the two agree.
+ *
+ * ```ts
+ * const score = await readScoreContext(chain);
+ * if (score.ok && score.value.tag === "ProductDerived") {
+ *     // mint proofs in { productId: score.value.productId, suffix: Index(0) }
+ * }
+ * ```
+ */
+export async function readScoreContext(
+    chain: ScoreContextChain,
+    options: ReadScoreContextOptions = {},
+): Promise<Result<ScoreContext, ProductIndividualityError>> {
+    try {
+        options.signal?.throwIfAborted();
+        const constants = chain.individuality.constants.Score;
+        const [constant, suffix] = await Promise.all([
+            constants.score_context(),
+            constants.Suffix(),
+        ]);
+        if (!CONTEXT_HEX.test(constant)) {
+            throw new IndividualityDecodeError("score context constant is not 32 bytes of hex");
+        }
+        const context = hexToBytes(constant.slice(2));
+        const tld = new TextDecoder().decode(suffix);
+        const productId = `${PERSONHOOD_PRODUCT_NAME}.${tld}`;
+        const derived = productContext(productId, {
+            tag: "Index",
+            value: PERSONHOOD_CONTEXT_INDEX.score,
+        });
+        if (bytesToHex(derived) === bytesToHex(context)) {
+            return ok({ tag: "ProductDerived", context, productId, tld });
+        }
+        return ok({ tag: "NotProductDerived", context, productId });
+    } catch (cause) {
+        return err(normalizeError(cause, ProductIndividualityError));
+    }
+}
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    const hex = (bytes: Uint8Array): string =>
+        `0x${[...bytes].map((b) => b.toString(16).padStart(2, "0")).join("")}`;
+
+    /** Previewnet's published `Score.score_context` (spec 1000036). */
+    const PREVIEWNET_SCORE_CONTEXT =
+        "0xa02ef8d90148203d1b7573e28c044c7b46e42793766bf6d7687ef5da86024a8e";
+
+    function fakeChain(scoreContext: string | Promise<string>, suffix = "test"): ScoreContextChain {
+        return {
+            individuality: {
+                constants: {
+                    Score: {
+                        score_context: () => Promise.resolve(scoreContext),
+                        Suffix: () => Promise.resolve(utf8ToBytes(suffix)),
+                    },
+                },
+            },
+        };
+    }
+
+    describe("ringCollectionId", () => {
+        test("pins both 32-byte, space-padded collection ids", () => {
+            expect(hex(ringCollectionId("people"))).toBe(
+                "0x706f703a706f6c6b61646f742e6e6574776f726b2f70656f706c652020202020",
+            );
+            expect(hex(ringCollectionId("people-lite"))).toBe(
+                "0x706f703a706f6c6b61646f742e6e6574776f726b2f70656f706c652d6c697465",
+            );
+        });
+    });
+
+    describe("peopleRing / litePeopleRing", () => {
+        test("address the collection on the given chain with no pallet junction", () => {
+            const genesis = `0x${"ab".repeat(32)}` as const;
+            expect(peopleRing(genesis)).toEqual({
+                chainId: genesis,
+                junctions: [
+                    {
+                        tag: "CollectionId",
+                        value: "0x706f703a706f6c6b61646f742e6e6574776f726b2f70656f706c652020202020",
+                    },
+                ],
+            });
+            expect(litePeopleRing(genesis)).toEqual({
+                chainId: genesis,
+                junctions: [
+                    {
+                        tag: "CollectionId",
+                        value: "0x706f703a706f6c6b61646f742e6e6574776f726b2f70656f706c652d6c697465",
+                    },
+                ],
+            });
+        });
+    });
+
+    describe("readScoreContext", () => {
+        test("answers ProductDerived for previewnet's published constant", async () => {
+            const result = await readScoreContext(fakeChain(PREVIEWNET_SCORE_CONTEXT));
+            expect(result).toEqual(
+                ok({
+                    tag: "ProductDerived",
+                    context: hexToBytes(PREVIEWNET_SCORE_CONTEXT.slice(2)),
+                    productId: "peopl.test",
+                    tld: "test",
+                }),
+            );
+        });
+
+        test("accepts upper-case constant hex", async () => {
+            const shouting = `0x${PREVIEWNET_SCORE_CONTEXT.slice(2).toUpperCase()}`;
+            const result = await readScoreContext(fakeChain(shouting));
+            expect(result.ok && result.value.tag).toBe("ProductDerived");
+        });
+
+        test("answers NotProductDerived for a literal context, on the ok channel", async () => {
+            // The nextv2 shape: a pre-#1300 ASCII literal, valid hex but not the
+            // product derivation of peopl.<Suffix>/Index(0).
+            const literal = hex(utf8ToBytes("pop:polkadot.network/score      "));
+            const result = await readScoreContext(fakeChain(literal, "paseo"));
+            expect(result).toEqual(
+                ok({
+                    tag: "NotProductDerived",
+                    context: hexToBytes(literal.slice(2)),
+                    productId: "peopl.paseo",
+                }),
+            );
+        });
+
+        test("a malformed constant is a decode error on the err channel", async () => {
+            const result = await readScoreContext(fakeChain("0xa02e"));
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error).toBeInstanceOf(IndividualityDecodeError);
+            }
+        });
+
+        test("a failing read arrives as the package error", async () => {
+            const result = await readScoreContext(
+                fakeChain(Promise.reject(new Error("node unreachable"))),
+            );
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error).toBeInstanceOf(ProductIndividualityError);
+            }
+        });
+
+        test("an aborted signal throws before any round trip", async () => {
+            let fetched = false;
+            const chain: ScoreContextChain = {
+                individuality: {
+                    constants: {
+                        Score: {
+                            score_context: () => {
+                                fetched = true;
+                                return Promise.resolve(PREVIEWNET_SCORE_CONTEXT);
+                            },
+                            Suffix: () => {
+                                fetched = true;
+                                return Promise.resolve(utf8ToBytes("test"));
+                            },
+                        },
+                    },
+                },
+            };
+            const controller = new AbortController();
+            controller.abort();
+            const result = await readScoreContext(chain, { signal: controller.signal });
+            expect(result.ok).toBe(false);
+            expect(fetched).toBe(false);
+        });
+    });
+}

--- a/product-sdk/packages/sdk/src/individuality/contract.test.ts
+++ b/product-sdk/packages/sdk/src/individuality/contract.test.ts
@@ -32,6 +32,7 @@
  */
 import type { getChainAPI } from "@parity/product-sdk-chain-client";
 import type {
+    RingLocation as HostRingLocation,
     RingVRFProof as HostRingVRFProof,
     VrfSignature as HostVrfSignature,
     VrfTranscriptItem as HostVrfTranscriptItem,
@@ -43,8 +44,12 @@ import type {
     GameChain,
     GamePlayersChain,
     IndividualityChain,
+    LegacySuffixChain,
+    NetworkSuffixChain,
     PapiIndividualityChain,
     PrizeStatusChain,
+    RingLocation as SdkRingLocation,
+    ScoreContextChain,
     SignUpChain,
     AccountVrfSignature,
     VrfTranscriptItem as IndividualityVrfTranscriptItem,
@@ -117,10 +122,35 @@ type FromPapiSatisfiesContracts = Assert<
     PapiIndividualityChain<PaseoClient["individuality"]> extends IndividualityChain &
         AirdropChain &
         GameChain &
-        GamePlayersChain
+        GamePlayersChain &
+        ScoreContextChain
         ? true
         : false
 >;
+
+type PaseoSatisfiesScoreContext = Assert<PaseoClient extends ScoreContextChain ? true : false>;
+type DevnetSatisfiesScoreContext = Assert<DevnetClient extends ScoreContextChain ? true : false>;
+type PreviewnetSatisfiesScoreContext = Assert<
+    PreviewnetClient extends ScoreContextChain ? true : false
+>;
+
+// Negative on purpose: a re-pin that flips either is the prompt to re-run the
+// read against that chain.
+type PreviewnetSatisfiesLegacySuffix = Assert<
+    PreviewnetClient extends LegacySuffixChain ? true : false
+>;
+type PaseoPredatesTheLegacySuffix = Assert<PaseoClient extends LegacySuffixChain ? false : true>;
+type DevnetPredatesTheLegacySuffix = Assert<DevnetClient extends LegacySuffixChain ? false : true>;
+type PreviewnetHasNoSuffixStorage = Assert<
+    PreviewnetClient extends NetworkSuffixChain ? false : true
+>;
+type PaseoHasNoSuffixStorage = Assert<PaseoClient extends NetworkSuffixChain ? false : true>;
+type DevnetHasNoSuffixStorage = Assert<DevnetClient extends NetworkSuffixChain ? false : true>;
+
+// The two are declared separately, so a rename on either side would go
+// unnoticed anywhere but here.
+type LocalRingLocationFitsHost = Assert<SdkRingLocation extends HostRingLocation ? true : false>;
+type HostRingLocationFitsLocal = Assert<HostRingLocation extends SdkRingLocation ? true : false>;
 
 // Negative control, kept type-only so it emits no runtime code. If
 // `IndividualityChain` ever stopped constraining, this flips to `false` and the

--- a/product-sdk/pending-changesets/individuality-lite-contexts.md
+++ b/product-sdk/pending-changesets/individuality-lite-contexts.md
@@ -1,0 +1,29 @@
+---
+"@parity/product-sdk-individuality": minor
+"@parity/product-sdk": minor
+---
+
+**Product-scoped proof contexts and personhood ring locations, as pure helpers.**
+
+Every context a host will sign under, and every context a product-derived runtime
+accepts, is `blake2b-256("product/" ++ productId ++ "/" ++ suffix)` with the
+RFC-0024 `Index`/`Raw` suffix expansion. `productContext(productId, suffix)`
+computes it offline, `contextSuffixBytes` exposes the expansion, and
+`personhoodContext(tld, name)` enumerates the five contexts the personhood
+product owns (`PERSONHOOD_CONTEXT_INDEX`) — needed because two of them never
+reach metadata. Product ids are always full DotNS ids (`"peopl.test"`,
+`"dim2.dot"`): the TLD belongs to the network and is never defaulted.
+
+`peopleRing(genesis)` and `litePeopleRing(genesis)` build the two personhood
+`RingLocation`s (the space-padded `CollectionId`s from `ringCollectionId`),
+structurally compatible with `@parity/product-sdk-host` without depending on it.
+
+`readScoreContext(chain)` reads `Score.score_context` and `Score.Suffix` and
+checks the constant equals `productContext("peopl." ++ suffix, Index(0))`. A
+runtime still publishing a literal context (which no stock host can mint) answers
+`NotProductDerived` on the ok channel, so proof-building flows stop before the
+chain rejects the transaction with nothing local to read.
+
+First piece of the lite-personhood sign-up flow (product-sdk#286): consolidates
+the derivations dim2 and humanity each hand-roll today, pinned by the same
+vectors (previewnet's published constants, both collection ids).

--- a/product-sdk/pending-changesets/individuality-lite-contexts.md
+++ b/product-sdk/pending-changesets/individuality-lite-contexts.md
@@ -18,11 +18,21 @@ reach metadata. Product ids are always full DotNS ids (`"peopl.test"`,
 `RingLocation`s (the space-padded `CollectionId`s from `ringCollectionId`),
 structurally compatible with `@parity/product-sdk-host` without depending on it.
 
-`readScoreContext(chain)` reads `Score.score_context` and `Score.Suffix` and
-checks the constant equals `productContext("peopl." ++ suffix, Index(0))`. A
-runtime still publishing a literal context (which no stock host can mint) answers
-`NotProductDerived` on the ok channel, so proof-building flows stop before the
-chain rejects the transaction with nothing local to read.
+`readScoreContext(chain)` reads `Score.score_context` and checks it equals
+`personhoodContext(<network suffix>, "score")`. A runtime publishing a literal
+context (which no stock host can mint) answers `NotProductDerived` on the ok
+channel, so proof-building flows stop before the chain rejects the transaction
+with nothing local to read.
+
+Where the network suffix comes from is part of the chain's type, not a runtime
+fallback: `NetworkSuffixChain` for the Root-settable `NetworkSuffix.NetworkSuffix`
+storage that individuality-community#20 introduced (read at a pinned block, since
+Root can move it), `LegacySuffixChain` for the `Score.Suffix` constant it
+replaced, and a `tld` option for a runtime with neither — which is every
+production runtime, since that pallet is testnet-only. A chain that can offer no
+suffix and no `tld` is a compile error rather than a runtime disappointment.
+`runScoreContextRead` is the throwing variant, so a composing read can run it
+against a block it already pinned instead of pinning a second one.
 
 First piece of the lite-personhood sign-up flow (product-sdk#286): consolidates
 the derivations dim2 and humanity each hand-roll today, pinned by the same

--- a/product-sdk/skills/product-sdk-individuality/SKILL.md
+++ b/product-sdk/skills/product-sdk-individuality/SKILL.md
@@ -12,7 +12,10 @@ description: >
   the RestrictOrigins requirement that otherwise fails every call. Also covers the game surface:
   reading the current game and its prize draws, whether you won one and claiming it, and signing
   up for a game with its airdrop VRFs, including which sign-up paths the chain and the hosts
-  cannot currently support.
+  cannot currently support. Also covers which 32-byte context a ring-VRF proof must be minted
+  in and which ring it comes from: productContext, personhoodContext and the five personhood
+  allocations, peopleRing and litePeopleRing, and readScoreContext for checking the chain
+  derives its contexts the product way before any proof is built.
 ---
 
 # Product SDK Individuality
@@ -410,6 +413,77 @@ The first four stop the extrinsic; the last four stop only the draw entry. `canS
 - **A rejected sign-up costs a fee.** `Pays::No` applies on success only, and the airdrop registration rides inside the same extrinsic, so one bad VRF entry loses the game sign-up too. Read the blockers before submitting.
 - **No local VRF verification exists.** One bad entry fails everything, but schnorrkel verification is not in this workspace. What it would catch is the wrong key, which the transcript already binds.
 
+## Proof Contexts and Ring Locations
+
+Before a product mints any ring-VRF proof it needs two things the chain will not hand it: the **32-byte context** the proof must be minted in, and the **ring** the proof comes from. Both are pure derivations — no client, no host, no round trip — so a product can predict them offline and compare against what the host actually returned.
+
+Every context a host will sign under, and every context a product-derived runtime accepts, is:
+
+```
+blake2b-256("product/" ++ productId ++ "/" ++ suffix_bytes)
+```
+
+where `suffix_bytes` expands the RFC-0024 selector: `Index(n)` becomes `n` as u32 LE followed by `blake2b-256("product-account-index")[..28]`, and `Raw(bytes)` is the 32 bytes verbatim.
+
+```ts
+import {
+  personhoodContext,
+  productContext,
+  contextSuffixBytes,
+  PERSONHOOD_CONTEXT_INDEX,
+} from "@parity/product-sdk-individuality";
+
+const context = productContext("dim2.dot", { tag: "Index", value: 0 });
+const scoreContext = personhoodContext("paseo", "score");
+```
+
+> **PRODUCT IDS ARE ALWAYS FULL DOTNS IDS, AND THERE IS NO DEFAULT TLD.** The TLD belongs to the network, so `peopl.test` and `peopl.paseo` are two different 32-byte contexts. Take it from configuration or from the chain — never hardcode it, and never assume `.dot`.
+
+The personhood product owns five context allocations. Only three of them are readable from metadata; `resources` and `dotnsGateway` exist as plain `impl` functions on the runtime, so `personhoodContext` is the only way to get them.
+
+| Name | Index | Published as a constant |
+|---|---|---|
+| `score` | 0 | `Score.score_context` |
+| `resources` | 1 | no |
+| `peopleLiteAuth` | 2 | `PeopleLite.auth_context` |
+| `dotnsGateway` | 3 | no |
+| `peopleAirdrops` | 4 | `PeopleAirdrops.people_airdrops_context` |
+
+### The two rings
+
+`peopleRing(genesisHash)` and `litePeopleRing(genesisHash)` build the `RingLocation` that `registerRingVrfKey`, `listRingVrfKeys` and `createAccountProof` address. They differ only in their `CollectionId` junction, which `ringCollectionId` builds as the human-readable name space-padded to 32 bytes.
+
+```ts
+import { peopleRing, litePeopleRing } from "@parity/product-sdk-individuality";
+
+const ring = litePeopleRing(genesisHash);
+```
+
+No `PalletInstance` junction is emitted, and that is deliberate: every host resolves the `Members` pallet by name, and treats the junction as an optional cross-check when present.
+
+### Checking the chain agrees
+
+`readScoreContext` reads `Score.score_context` and checks it is the product derivation of `peopl.<tld>/Index(0)`. A runtime publishing something else publishes a context no stock host can mint, and that arrives as `NotProductDerived` on the **ok** channel — an answer, not a failure.
+
+```ts
+const score = await readScoreContext(chain, { tld: "paseo" });
+if (score.ok && score.value.tag === "ProductDerived") {
+  // mint proofs in { productId: score.value.productId, suffix: Index(0) }
+}
+```
+
+> **`NotProductDerived` IS A HARD STOP.** Do not build the proof leg. The chain rejects it as `InvalidTransaction::Call` with nothing local to read.
+
+Where the TLD comes from is part of the chain's type, not a runtime fallback, so a chain that cannot supply one is a compile error rather than a surprise:
+
+| Contract | Suffix source | Which chains |
+|---|---|---|
+| `NetworkSuffixChain` | `NetworkSuffix.NetworkSuffix` storage, read at a pinned block | none yet; the pallet is testnet-only upstream |
+| `LegacySuffixChain` | the `Score.Suffix` constant | previewnet only, and gone on its next upgrade |
+| neither | the `tld` option | everything else, production included |
+
+Composing this with other reads? Use `runScoreContextRead(chain, options, snapshot)` and pass the block you already pinned, exactly as `readPrizeStatus` does with `runDrawRead`. Calling `readScoreContext` inside a composed read pins a second block, and the stored suffix can move between them.
+
 ## Acting As a Person (Write)
 
 `withAsPerson` wraps a signer so the call dispatches under a person origin. It returns a `PolkadotSigner`, so submission stays with `@parity/product-sdk-tx` and nothing about `submitAndWatch` changes.
@@ -496,3 +570,6 @@ Two things to know either way, because they are the traps that cost the most tim
 13. **Returning the host's `Result` straight out of `createProof`** — the callback must resolve to the proof object itself, so unwrap it first. Resolving with a `Result`, with `undefined`, or with a partial object throws `AsPersonError` and nothing is signed.
 14. **Reaching for `AliasWithProof` to bind an alias before paseo upgrades** — the chain fixes the allowed contexts as constants until `specVersion 1000035`, so it answers `Invalid.Call` however correct the bytes are.
 15. **Assuming `AliasWithAccount` works for a stale ring revision** — the chain answers `BadSigner`, and `AliasWithAccountRevised` is the variant that fixes it. It cannot be detected client-side without reading the ring root.
+16. **Hardcoding the TLD in a product id** — `peopl.test` and `peopl.paseo` are different 32-byte contexts, so a hardcoded `.dot` mints proofs no chain accepts. There is no default, on purpose.
+17. **Calling `readScoreContext` inside a composed read** — it pins its own block when the suffix comes from storage, and Root can move that value. Use `runScoreContextRead(chain, options, snapshot)` with the block you already pinned.
+18. **Treating `NotProductDerived` as retryable** — it is a hard stop on the ok channel, not a transport failure. Building the proof leg anyway costs a fee and returns `Invalid.Call`.


### PR DESCRIPTION
First piece of the lite-personhood sign-up flow (#354): pure helpers for the proof contexts and ring locations that dim2 and humanity each hand-roll today.

Why: every context a host signs under is blake2b-256("product/" ++ productId ++ "/" ++ suffix) with the RFC-0024 Index/Raw expansion, and two of the personhood product's five contexts never reach metadata, so consumers have to derive them client-side.

What: productContext / contextSuffixBytes / personhoodContext(tld, name) as pure functions; peopleRing / litePeopleRing build the two RingLocations, structurally compatible with product-sdk-host without depending on it; readScoreContext checks Score.score_context is the product derivation of peopl.<network suffix>/Index(0) and answers NotProductDerived on the ok channel, so proof flows stop before the chain rejects with nothing local to read. Product ids are always full DotNS ids with no TLD default; a tld must be a single lower-case label inside the runtime's 16-byte bound, and a suffix that is not valid UTF-8 errors instead of becoming replacement characters in a product id.

The suffix source is typed, not probed. individuality-community#20 deleted the Score.Suffix constant in favour of Root-settable NetworkSuffix.NetworkSuffix storage, and that pallet is testnet-only, so there are three narrow contracts: NetworkSuffixChain (storage, read at a pinned block), LegacySuffixChain (the constant, previewnet only), or neither, where the caller passes tld. readScoreContext is overloaded across them, so a chain that can resolve no suffix fails to compile rather than at runtime. Separate contracts rather than one with optional members, because an optional member constrains nothing structurally and the umbrella guard would stop separating environments. runScoreContextRead is the throwing variant, for a composed read that already pinned a block.

Tests pin previewnet's constants (spec 1000036), both collection ids and the Index(0) vector. contract.test.ts asserts the three contracts per environment and both RingLocation directions, with the negatives checked by flipping them. 424 package tests, umbrella typecheck and tests clean. The individuality skill documents the new surface.

Stack: #350 consumes ScoreContextChain and calls readScoreContext inside a composed read, so it needs a suffix contract (or a tld) and runScoreContextRead with its own snapshot. #352 references readScoreContext in JSDoc only.