### PR TITLE
chore(host): bump @parity/truapi to 0.12.0

### DIFF
--- a/product-sdk/packages/host/src/testing.ts
+++ b/product-sdk/packages/host/src/testing.ts
@@ -14,8 +14,9 @@
  * (and `getChainAPI()` on top of it) resolves in tests; see the `chainInfo`
  * option. Not modeled: the rest of the PAPI `chain` JSON-RPC surface behind
  * `getHostProvider()` — there's no chain-read fake, by design; the host owns RPC
- * selection — and the `chat` / `coinPayment` / `entropy` / `notifications` /
- * `payment` / `permissions` / `resourceAllocation` / `theme` domains. Touching
+ * selection — the `system` domain's `info` / `getProductContext`, and the
+ * `chat` / `coinPayment` / `entropy` / `locale` / `notifications` / `payment` /
+ * `permissions` / `resourceAllocation` / `theme` domains. Touching
  * an unmodeled domain throws a descriptive error rather than failing with
  * `undefined is not a function`.
  *
@@ -249,11 +250,12 @@ export function createFakeTruApiClient(options?: CreateFakeTruApiClientOptions):
                 okAsync({ proof: { tag: "Sr25519", value: { signature, signer: publicKey } } }),
             submit: () => okAsync(undefined),
         },
-        system: {
+        // `info` and `getProductContext` are not modeled; they still throw.
+        system: notModeled("system", {
             handshake: () => okAsync(undefined),
             featureSupported: () => okAsync({ supported: chainSupported }),
             navigateTo: () => okAsync(undefined),
-        },
+        }),
         preimage: {
             lookupSubscribe: ({ request: { key } }) =>
                 oneShotObservable({ value: preimages.get(key) }),
@@ -280,6 +282,7 @@ export function createFakeTruApiClient(options?: CreateFakeTruApiClientOptions):
         chat: notModeled("chat"),
         coinPayment: notModeled("coinPayment"),
         entropy: notModeled("entropy"),
+        locale: notModeled("locale"),
         notifications: notModeled("notifications"),
         payment: notModeled("payment"),
         permissions: notModeled("permissions"),

--- a/product-sdk/pending-changesets/truapi-0.12.0.md
+++ b/product-sdk/pending-changesets/truapi-0.12.0.md
@@ -1,0 +1,14 @@
+---
+"@parity/product-sdk-host": patch
+---
+
+Update `@parity/truapi` to 0.12.0. No SDK API changes: the bump is additive on
+truapi's side and nothing in `@parity/product-sdk-host` consumes the new surface
+yet. 0.12.0 adds the `locale` domain (`locale.subscribe`, the host's selected
+language as a BCP 47 tag), `system.info` / `system.getProductContext`, and
+`development_createAccountProof` for raw proof contexts. The testing fake tracks
+the new surface: the `locale` domain is not modeled, and the `system` domain
+still models `handshake` / `featureSupported` / `navigateTo` while the new
+`info` and `getProductContext` throw the descriptive not-modeled error instead
+of an `undefined is not a function`. Bumping keeps the catalog current with the
+latest published client and unblocks the upcoming locale provider.

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^0.12.1
       version: 0.12.1
     '@parity/truapi':
-      specifier: ^0.10.0
-      version: 0.10.0
+      specifier: ^0.12.0
+      version: 0.12.0
     '@playwright/test':
       specifier: ^1.60.0
       version: 1.60.0
@@ -538,7 +538,7 @@ importers:
         version: link:../result
       '@parity/truapi':
         specifier: 'catalog:'
-        version: 0.10.0
+        version: 0.12.0
       '@polkadot-api/json-rpc-provider':
         specifier: ^0.2.0
         version: 0.2.0
@@ -1694,8 +1694,8 @@ packages:
       '@playwright/test':
         optional: true
 
-  '@parity/truapi@0.10.0':
-    resolution: {integrity: sha512-Kwuvj4jd67NfSB4g+4MVlMGKGFH7HfMXJESscRA0u+KpknsWUE+OV8jzYh1TyAnbSVAIq/sarQK8sSBHvUZKXw==}
+  '@parity/truapi@0.12.0':
+    resolution: {integrity: sha512-1Aei18qkPWNYgLfmmZ0ETpYHFqjcd2yOJe36jErI/9T1+M19Ovuh35Rma+dTIFYY2rMxVbF/h1D06W9E9RY/2g==}
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -3945,7 +3945,7 @@ snapshots:
     optionalDependencies:
       '@playwright/test': 1.60.0
 
-  '@parity/truapi@0.10.0':
+  '@parity/truapi@0.12.0':
     dependencies:
       '@noble/hashes': 2.2.0
       neverthrow: 8.2.0

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   "@parity/host-api-test-sdk": ^0.12.1
-  "@parity/truapi": ^0.10.0
+  "@parity/truapi": ^0.12.0
   "@playwright/test": ^1.60.0
   "@polkadot-api/json-rpc-provider": ^0.2.0
   "@polkadot-api/metadata-builders": ^0.14.3
@@ -36,4 +36,4 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - '@parity/host-api-test-sdk@0.12.1'
-  - '@parity/truapi@0.10.0'
+  - '@parity/truapi@0.12.0'


### PR DESCRIPTION
Closes #351.

## What

Bump the `@parity/truapi` catalog pin from `^0.10.0` to `^0.12.0` (caret on 0.x only allows patch, so the pin must move to pick up the new minor). 0.12.0 adds the **locale** domain, `system.info` / `system.getProductContext`, and `development_createAccountProof`; nothing in the SDK consumes the new surface yet, so this is a host patch.

## What changed

- `pnpm-workspace.yaml`: catalog `^0.10.0` to `^0.12.0`, `minimumReleaseAgeExclude` entry updated to `@parity/truapi@0.12.0`.
- `packages/host/src/testing.ts`: the fake client now declares `locale` as not modeled, and `system` keeps `handshake` / `featureSupported` / `navigateTo` modeled while the new `info` / `getProductContext` throw the descriptive not-modeled error.
- `pending-changesets/truapi-0.12.0.md`: patch changeset for `@parity/product-sdk-host`.

Unblocks #333, which needs the `locale` domain to typecheck.
