### PR TITLE
chore(host): bump @parity/truapi to 0.13.1

### DIFF
--- a/product-sdk/pending-changesets/truapi-0.13.1.md
+++ b/product-sdk/pending-changesets/truapi-0.13.1.md
@@ -1,0 +1,10 @@
+---
+"@parity/product-sdk-host": patch
+---
+
+Update `@parity/truapi` to 0.13.1. No SDK API changes: the client's domain
+surface (`client.d.ts`) is identical to 0.12.0, so nothing in
+`@parity/product-sdk-*` changes and the host testing fake needs no new modeling.
+The only differing type files are truapi's own explorer / playground codegen and
+`well-known-chains`, none of which the SDK imports. Bumping keeps the catalog
+current with the latest published client (closes the release-bot bump issue).

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^0.12.1
       version: 0.12.1
     '@parity/truapi':
-      specifier: ^0.12.0
-      version: 0.12.0
+      specifier: ^0.13.1
+      version: 0.13.1
     '@playwright/test':
       specifier: ^1.60.0
       version: 1.60.0
@@ -538,7 +538,7 @@ importers:
         version: link:../result
       '@parity/truapi':
         specifier: 'catalog:'
-        version: 0.12.0
+        version: 0.13.1
       '@polkadot-api/json-rpc-provider':
         specifier: ^0.2.0
         version: 0.2.0
@@ -1694,8 +1694,8 @@ packages:
       '@playwright/test':
         optional: true
 
-  '@parity/truapi@0.12.0':
-    resolution: {integrity: sha512-1Aei18qkPWNYgLfmmZ0ETpYHFqjcd2yOJe36jErI/9T1+M19Ovuh35Rma+dTIFYY2rMxVbF/h1D06W9E9RY/2g==}
+  '@parity/truapi@0.13.1':
+    resolution: {integrity: sha512-6gkfHskN8I7H5DwB7j96wRusVx7xuGzu1YGWLBLPCD1RtBSnkPaQq/8Ac3MwudNz8kYqKZ5kZao3EkJ4PN4nCg==}
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -3945,7 +3945,7 @@ snapshots:
     optionalDependencies:
       '@playwright/test': 1.60.0
 
-  '@parity/truapi@0.12.0':
+  '@parity/truapi@0.13.1':
     dependencies:
       '@noble/hashes': 2.2.0
       neverthrow: 8.2.0

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   "@parity/host-api-test-sdk": ^0.12.1
-  "@parity/truapi": ^0.12.0
+  "@parity/truapi": ^0.13.1
   "@playwright/test": ^1.60.0
   "@polkadot-api/json-rpc-provider": ^0.2.0
   "@polkadot-api/metadata-builders": ^0.14.3
@@ -36,4 +36,4 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - '@parity/host-api-test-sdk@0.12.1'
-  - '@parity/truapi@0.12.0'
+  - '@parity/truapi@0.13.1'


### PR DESCRIPTION
Update the catalog pin and minimumReleaseAgeExclude to 0.13.1 and refresh the lockfile. The client domain surface is identical to 0.12.0, no SDK API change, no testing-fake change. 

closes: #357