### PR TITLE
fix(terminal): pair with a 0.9.0+ host

### DIFF
--- a/product-sdk/packages/auth/src/allocations.test.ts
+++ b/product-sdk/packages/auth/src/allocations.test.ts
@@ -25,7 +25,7 @@ describe("summarizeOutcomes", () => {
     const resources: AllocatableResource[] = [
         { tag: "BulletInAllowance", value: undefined },
         { tag: "StatementStoreAllowance", value: undefined },
-        { tag: "SmartContractAllowance", value: 0 },
+        { tag: "SmartContractAllowance", value: { tag: "Index", value: 0 } },
     ];
 
     // A minimal valid `Allocated` payload. `summarizeOutcomes` only reads the

--- a/product-sdk/packages/auth/src/allocations.ts
+++ b/product-sdk/packages/auth/src/allocations.ts
@@ -57,8 +57,8 @@ export type ResourceTag = AllocatableResource["tag"];
 export const DEFAULT_RESOURCES: AllocatableResource[] = [
     { tag: "BulletInAllowance", value: undefined },
     { tag: "StatementStoreAllowance", value: undefined },
-    // derivation index 0 = the default product account.
-    { tag: "SmartContractAllowance", value: 0 },
+    // index 0 = the default product account.
+    { tag: "SmartContractAllowance", value: { tag: "Index", value: 0 } },
 ];
 
 /**

--- a/product-sdk/packages/terminal/README.md
+++ b/product-sdk/packages/terminal/README.md
@@ -102,7 +102,7 @@ const subSigner = createSessionSignerForAccount(session, {
 });
 ```
 
-> **Wire format note:** `@novasamatech/host-papp` 0.7 expects `productAccountId: [productId, derivationIndex]` in `SigningRawRequest`. Both functions above hide that tuple — pass an adapter for the default case or a named-fields object for the escape hatch.
+> **Wire format note:** `@novasamatech/host-papp` expects `productAccountId: [productId, { tag: "Index", value: derivationIndex }]` in `SigningRawRequest`. Both functions above hide that tuple — pass an adapter for the default case or a named-fields object for the escape hatch.
 
 ### `renderQrCode(data, options?): Promise<string>`
 
@@ -251,9 +251,9 @@ For consumers moving from `@polkadot-apps/terminal` v0.2.0 / v0.3.0. Existing se
 
 ### Why the signer API changed
 
-`@novasamatech/host-papp` 0.7 replaced `SigningRawRequest.address` with `productAccountId: [productId, derivationIndex]`. The wire format requires both fields, so a session-only argument is no longer enough — the signer needs to know *which sub-account of which product is asking*. We split that into two functions to keep the common case ergonomic:
+`@novasamatech/host-papp` 0.7 replaced `SigningRawRequest.address` with `productAccountId: [productId, derivationIndex]`, and 0.10 made the index a tagged `Index | Raw` selector. The wire format requires both fields, so a session-only argument is no longer enough — the signer needs to know *which sub-account of which product is asking*. We split that into two functions to keep the common case ergonomic:
 
-- `createSessionSigner(session, adapter)` for the default account (uses `[adapter.appId, 0]`)
+- `createSessionSigner(session, adapter)` for the default account (uses `[adapter.appId, { tag: "Index", value: 0 }]`)
 - `createSessionSignerForAccount(session, { productId, derivationIndex })` for everything else
 
 The single-argument `createSessionSigner(session)` from `@polkadot-apps/terminal` no longer works against host-papp 0.7 regardless of which package you use.

--- a/product-sdk/packages/terminal/package.json
+++ b/product-sdk/packages/terminal/package.json
@@ -36,9 +36,9 @@
         "@noble/ciphers": "^2.1.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.2.0",
-        "@novasamatech/host-papp": "^0.8.9",
-        "@novasamatech/statement-store": "^0.8.9",
-        "@novasamatech/storage-adapter": "^0.8.9",
+        "@novasamatech/host-papp": "0.10.0",
+        "@novasamatech/statement-store": "0.10.0",
+        "@novasamatech/storage-adapter": "0.10.0",
         "@parity/product-sdk-keys": "workspace:*",
         "@parity/product-sdk-logger": "workspace:*",
         "@parity/product-sdk-signer": "workspace:*",
@@ -53,7 +53,7 @@
         "scale-ts": "^1.6.1"
     },
     "devDependencies": {
-        "@novasamatech/substrate-slot-sr25519-wasm": "^0.8.9",
+        "@novasamatech/substrate-slot-sr25519-wasm": "0.10.0",
         "@types/qrcode": "^1.5.5",
         "tsup": "catalog:",
         "typescript": "catalog:",

--- a/product-sdk/packages/terminal/src/host-cache.ts
+++ b/product-sdk/packages/terminal/src/host-cache.ts
@@ -243,11 +243,41 @@ if (import.meta.vitest) {
         });
 
         test("disambiguates SmartContractAllowance by dest", () => {
-            expect(cacheKey({ tag: "SmartContractAllowance", value: 0 })).toBe(
-                "SmartContractAllowance::0",
-            );
-            expect(cacheKey({ tag: "SmartContractAllowance", value: 7 })).toBe(
-                "SmartContractAllowance::7",
+            expect(
+                cacheKey({ tag: "SmartContractAllowance", value: { tag: "Index", value: 0 } }),
+            ).toBe("SmartContractAllowance::Index::0");
+            expect(
+                cacheKey({ tag: "SmartContractAllowance", value: { tag: "Index", value: 7 } }),
+            ).toBe("SmartContractAllowance::Index::7");
+        });
+
+        // tsc misses this: a template literal accepts an object.
+        test("an Index and a Raw dest never share a cache key", () => {
+            const raw = new Uint8Array(32);
+            raw[0] = 7;
+            const indexKey = cacheKey({
+                tag: "SmartContractAllowance",
+                value: { tag: "Index", value: 7 },
+            });
+            const rawKey = cacheKey({
+                tag: "SmartContractAllowance",
+                value: { tag: "Raw", value: raw },
+            });
+
+            expect(rawKey).not.toBe(indexKey);
+            expect(rawKey).not.toContain("[object Object]");
+            expect(indexKey).not.toContain("[object Object]");
+        });
+
+        test("two different Raw dests get different keys", () => {
+            const a = new Uint8Array(32);
+            const b = new Uint8Array(32);
+            b[31] = 1;
+
+            expect(
+                cacheKey({ tag: "SmartContractAllowance", value: { tag: "Raw", value: a } }),
+            ).not.toBe(
+                cacheKey({ tag: "SmartContractAllowance", value: { tag: "Raw", value: b } }),
             );
         });
     });
@@ -255,12 +285,29 @@ if (import.meta.vitest) {
     describe("loadCache / saveCache round-trip", () => {
         test("loadCache on missing file returns empty cache, not an error", async () => {
             const cache = await loadCache("my-app", storageDir);
-            expect(cache).toEqual({ version: 1, entries: {} });
+            expect(cache).toEqual({ version: 2, entries: {} });
+        });
+
+        // v1 entries belong to sessions the x25519 change already invalidated.
+        test("a version 1 file on disk is dropped, not read", async () => {
+            const stale = {
+                version: 1,
+                entries: {
+                    BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0xdeadbeef" },
+                },
+            };
+            await mkdir(storageDir, { recursive: true });
+            await writeFile(
+                join(storageDir, "my-app_AllowanceKeys.json"),
+                JSON.stringify(stale, null, 2),
+            );
+
+            expect(await loadCache("my-app", storageDir)).toEqual({ version: 2, entries: {} });
         });
 
         test("saveCache then loadCache returns the same content", async () => {
-            const original: AllowanceCacheV1 = {
-                version: 1,
+            const original: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
                     BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0xdeadbeef" },
                 },
@@ -271,14 +318,14 @@ if (import.meta.vitest) {
         });
 
         test("two appIds in the same storageDir don't collide", async () => {
-            const a: AllowanceCacheV1 = {
-                version: 1,
+            const a: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
                     BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0x01" },
                 },
             };
-            const b: AllowanceCacheV1 = {
-                version: 1,
+            const b: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
                     BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0x02" },
                 },
@@ -295,7 +342,7 @@ if (import.meta.vitest) {
 
         test("appId with non-alphanumeric characters sanitizes to a safe path", async () => {
             // Verifies a path-traversal-style appId can't escape storageDir.
-            const cache: AllowanceCacheV1 = { version: 1, entries: {} };
+            const cache: AllowanceCacheV2 = { version: 2, entries: {} };
             await expect(saveCache("../escape", cache, storageDir)).resolves.toBeUndefined();
             const reloaded = await loadCache("../escape", storageDir);
             expect(reloaded).toEqual(cache);
@@ -304,7 +351,7 @@ if (import.meta.vitest) {
         test("malformed cache file is treated as empty, not thrown", async () => {
             await writeFile(cachePath("my-app", storageDir), "{ not valid json", "utf-8");
             const cache = await loadCache("my-app", storageDir);
-            expect(cache).toEqual({ version: 1, entries: {} });
+            expect(cache).toEqual({ version: 2, entries: {} });
         });
 
         test("version mismatch is treated as empty, not thrown", async () => {
@@ -314,12 +361,12 @@ if (import.meta.vitest) {
                 "utf-8",
             );
             const cache = await loadCache("my-app", storageDir);
-            expect(cache).toEqual({ version: 1, entries: {} });
+            expect(cache).toEqual({ version: 2, entries: {} });
         });
 
         test("file is written with 0o600 permissions (defense-in-depth)", async () => {
             const { stat } = await import("node:fs/promises");
-            const cache: AllowanceCacheV1 = { version: 1, entries: {} };
+            const cache: AllowanceCacheV2 = { version: 2, entries: {} };
             await saveCache("my-app", cache, storageDir);
             const s = await stat(cachePath("my-app", storageDir));
             // Mask to permission bits only — file type bits are above 0o777.
@@ -341,8 +388,8 @@ if (import.meta.vitest) {
         });
 
         test("all slot-table resources cached → Increase", () => {
-            const cache: AllowanceCacheV1 = {
-                version: 1,
+            const cache: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
                     BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0x01" },
                     StatementStoreAllowance: {
@@ -360,8 +407,8 @@ if (import.meta.vitest) {
         });
 
         test("mixed cached + uncached → Ignore (conservative)", () => {
-            const cache: AllowanceCacheV1 = {
-                version: 1,
+            const cache: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
                     BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0x01" },
                 },
@@ -375,12 +422,12 @@ if (import.meta.vitest) {
         });
 
         test("AutoSigning in the request → Ignore even if cached (not slot-additive)", () => {
-            const cache: AllowanceCacheV1 = {
-                version: 1,
+            const cache: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
                     AutoSigning: {
                         tag: "AutoSigning",
-                        productDerivationSecret: "x",
+                        ringVrfDomainEntropy: "0x01",
                         productRootPrivateKey: "0xaa",
                     },
                 },
@@ -391,15 +438,20 @@ if (import.meta.vitest) {
         });
 
         test("SC in the request → Ignore (not slot-additive; PGAS claim is per-call)", () => {
-            const cache: AllowanceCacheV1 = {
-                version: 1,
+            const cache: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
-                    "SmartContractAllowance::5": { tag: "SmartContractAllowance", dest: 5 },
+                    "SmartContractAllowance::Index::5": {
+                        tag: "SmartContractAllowance",
+                        dest: "Index::5",
+                    },
                 },
             };
-            expect(pickOnExistingPolicy(cache, [{ tag: "SmartContractAllowance", value: 5 }])).toBe(
-                "Ignore",
-            );
+            expect(
+                pickOnExistingPolicy(cache, [
+                    { tag: "SmartContractAllowance", value: { tag: "Index", value: 5 } },
+                ]),
+            ).toBe("Ignore");
         });
     });
 
@@ -441,7 +493,9 @@ if (import.meta.vitest) {
 
         test("stores SmartContractAllowance with dest from the request", () => {
             const cache = emptyCache();
-            const requested: AllocatableResource[] = [{ tag: "SmartContractAllowance", value: 7 }];
+            const requested: AllocatableResource[] = [
+                { tag: "SmartContractAllowance", value: { tag: "Index", value: 7 } },
+            ];
             const outcomes: ApAllocationOutcome[] = [
                 {
                     tag: "Allocated",
@@ -449,9 +503,9 @@ if (import.meta.vitest) {
                 },
             ];
             const merged = mergeOutcomes(cache, requested, outcomes);
-            expect(merged.entries["SmartContractAllowance::7"]).toEqual({
+            expect(merged.entries["SmartContractAllowance::Index::7"]).toEqual({
                 tag: "SmartContractAllowance",
-                dest: 7,
+                dest: "Index::7",
             });
         });
 
@@ -464,7 +518,7 @@ if (import.meta.vitest) {
                     value: {
                         tag: "AutoSigning",
                         value: {
-                            productDerivationSecret: "secret-hex",
+                            ringVrfDomainEntropy: new Uint8Array([0xef]),
                             productRootPrivateKey: new Uint8Array([0xab, 0xcd]),
                         },
                     },
@@ -473,15 +527,15 @@ if (import.meta.vitest) {
             const merged = mergeOutcomes(cache, requested, outcomes);
             expect(merged.entries.AutoSigning).toEqual({
                 tag: "AutoSigning",
-                productDerivationSecret: "secret-hex",
+                ringVrfDomainEntropy: "0xef",
                 productRootPrivateKey: "0xabcd",
             });
         });
 
         test("returns the same cache reference when no Allocated outcomes (no-op)", () => {
             // Lets callers gate disk writes on reference equality.
-            const cache: AllowanceCacheV1 = {
-                version: 1,
+            const cache: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
                     BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: "0xaa" },
                 },
@@ -552,8 +606,8 @@ if (import.meta.vitest) {
         });
 
         test("preserves existing entries when merging new ones", () => {
-            const cache: AllowanceCacheV1 = {
-                version: 1,
+            const cache: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
                     StatementStoreAllowance: {
                         tag: "StatementStoreAllowance",
@@ -587,21 +641,31 @@ if (import.meta.vitest) {
 
     describe("readCacheEntry", () => {
         test("returns the cached entry by resource discriminator", () => {
-            const cache: AllowanceCacheV1 = {
-                version: 1,
+            const cache: AllowanceCacheV2 = {
+                version: 2,
                 entries: {
-                    "SmartContractAllowance::5": {
+                    "SmartContractAllowance::Index::5": {
                         tag: "SmartContractAllowance",
-                        dest: 5,
+                        dest: "Index::5",
                     },
                 },
             };
-            expect(readCacheEntry(cache, { tag: "SmartContractAllowance", value: 5 })).toEqual({
+            expect(
+                readCacheEntry(cache, {
+                    tag: "SmartContractAllowance",
+                    value: { tag: "Index", value: 5 },
+                }),
+            ).toEqual({
                 tag: "SmartContractAllowance",
-                dest: 5,
+                dest: "Index::5",
             });
             // Different dest doesn't match.
-            expect(readCacheEntry(cache, { tag: "SmartContractAllowance", value: 6 })).toBeNull();
+            expect(
+                readCacheEntry(cache, {
+                    tag: "SmartContractAllowance",
+                    value: { tag: "Index", value: 6 },
+                }),
+            ).toBeNull();
         });
 
         test("returns null when nothing cached", () => {

--- a/product-sdk/packages/terminal/src/host-cache.ts
+++ b/product-sdk/packages/terminal/src/host-cache.ts
@@ -4,7 +4,7 @@
  * Persistent allowance-key cache. One JSON file per `appId`, 0o600.
  *
  * Cache key is the variant tag, except `SmartContractAllowance::{dest}`
- * which disambiguates per-derivation-index PGAS pre-warming.
+ * which disambiguates per-account PGAS pre-warming.
  *
  * @internal
  */
@@ -25,15 +25,15 @@ const CACHE_FILE_MODE = 0o600;
 export type CachedAllocation =
     | { tag: "BulletInAllowance"; slotAccountKey: string }
     | { tag: "StatementStoreAllowance"; slotAccountKey: string }
-    | { tag: "SmartContractAllowance"; dest: number }
+    | { tag: "SmartContractAllowance"; dest: string }
     | {
           tag: "AutoSigning";
-          productDerivationSecret: string;
+          ringVrfDomainEntropy: string;
           productRootPrivateKey: string;
       };
 
-interface AllowanceCacheV1 {
-    version: 1;
+interface AllowanceCacheV2 {
+    version: 2;
     entries: Record<string, CachedAllocation>;
 }
 
@@ -45,11 +45,11 @@ function cachePath(appId: string, storageDir?: string): string {
     return join(storageDir ?? DEFAULT_STORAGE_DIR, `${sanitizeAppId(appId)}_AllowanceKeys.json`);
 }
 
-function emptyCache(): AllowanceCacheV1 {
-    return { version: 1, entries: {} };
+function emptyCache(): AllowanceCacheV2 {
+    return { version: 2, entries: {} };
 }
 
-export async function loadCache(appId: string, storageDir?: string): Promise<AllowanceCacheV1> {
+export async function loadCache(appId: string, storageDir?: string): Promise<AllowanceCacheV2> {
     const path = cachePath(appId, storageDir);
     let raw: string;
     try {
@@ -59,9 +59,9 @@ export async function loadCache(appId: string, storageDir?: string): Promise<All
         throw e;
     }
     try {
-        const parsed = JSON.parse(raw) as AllowanceCacheV1;
+        const parsed = JSON.parse(raw) as AllowanceCacheV2;
         if (
-            parsed?.version !== 1 ||
+            parsed?.version !== 2 ||
             typeof parsed.entries !== "object" ||
             parsed.entries === null
         ) {
@@ -77,7 +77,7 @@ export async function loadCache(appId: string, storageDir?: string): Promise<All
 
 export async function saveCache(
     appId: string,
-    cache: AllowanceCacheV1,
+    cache: AllowanceCacheV2,
     storageDir?: string,
 ): Promise<void> {
     const path = cachePath(appId, storageDir);
@@ -91,9 +91,16 @@ export async function saveCache(
     await rename(tmp, path);
 }
 
+type SmartContractDest = Extract<AllocatableResource, { tag: "SmartContractAllowance" }>["value"];
+
+/** JSON-safe, so it doubles as the cached `dest`. */
+export function smartContractDest(dest: SmartContractDest): string {
+    return dest.tag === "Index" ? `Index::${dest.value}` : `Raw::${toHex(dest.value)}`;
+}
+
 export function cacheKey(resource: AllocatableResource): string {
     if (resource.tag === "SmartContractAllowance") {
-        return `${resource.tag}::${resource.value}`;
+        return `${resource.tag}::${smartContractDest(resource.value)}`;
     }
     return resource.tag;
 }
@@ -105,7 +112,7 @@ export function cacheKey(resource: AllocatableResource): string {
  * aren't slot-additive so they always force `Ignore`.
  */
 export function pickOnExistingPolicy(
-    cache: AllowanceCacheV1,
+    cache: AllowanceCacheV2,
     resources: AllocatableResource[],
 ): "Ignore" | "Increase" {
     if (resources.length === 0) return "Ignore";
@@ -127,10 +134,10 @@ export function pickOnExistingPolicy(
  * silently truncate.
  */
 export function mergeOutcomes(
-    cache: AllowanceCacheV1,
+    cache: AllowanceCacheV2,
     requested: AllocatableResource[],
     outcomes: ApAllocationOutcome[],
-): AllowanceCacheV1 {
+): AllowanceCacheV2 {
     if (requested.length !== outcomes.length) {
         throw new Error(
             `mergeOutcomes: length mismatch — requested ${requested.length}, got ${outcomes.length}`,
@@ -166,26 +173,29 @@ export function mergeOutcomes(
                 // Variant alignment is enforced above, so req.tag is guaranteed
                 // to be SmartContractAllowance here — the cast narrows it.
                 if (req.tag === "SmartContractAllowance") {
-                    entries[key] = { tag: "SmartContractAllowance", dest: req.value };
+                    entries[key] = {
+                        tag: "SmartContractAllowance",
+                        dest: smartContractDest(req.value),
+                    };
                     mutated = true;
                 }
                 break;
             case "AutoSigning":
                 entries[key] = {
                     tag: "AutoSigning",
-                    productDerivationSecret: inner.value.productDerivationSecret,
+                    ringVrfDomainEntropy: toHex(inner.value.ringVrfDomainEntropy),
                     productRootPrivateKey: toHex(inner.value.productRootPrivateKey),
                 };
                 mutated = true;
                 break;
         }
     }
-    return mutated ? { version: 1, entries } : cache;
+    return mutated ? { version: 2, entries } : cache;
 }
 
 /** Look up a single cached allocation, or `null` if absent. */
 export function readCacheEntry(
-    cache: AllowanceCacheV1,
+    cache: AllowanceCacheV2,
     resource: AllocatableResource,
 ): CachedAllocation | null {
     return cache.entries[cacheKey(resource)] ?? null;

--- a/product-sdk/packages/terminal/src/host-signer.ts
+++ b/product-sdk/packages/terminal/src/host-signer.ts
@@ -154,7 +154,7 @@ if (import.meta.vitest) {
             await saveCache(
                 "p",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: hex },
                     },
@@ -175,7 +175,7 @@ if (import.meta.vitest) {
             await saveCache(
                 "p",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: hex },
                     },
@@ -213,7 +213,7 @@ if (import.meta.vitest) {
             await saveCache(
                 "p",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         BulletInAllowance: {
                             tag: "BulletInAllowance",
@@ -252,7 +252,7 @@ if (import.meta.vitest) {
             await saveCache(
                 "p",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         StatementStoreAllowance: {
                             tag: "StatementStoreAllowance",
@@ -274,9 +274,12 @@ if (import.meta.vitest) {
             await saveCache(
                 "p",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
-                        "SmartContractAllowance::5": { tag: "SmartContractAllowance", dest: 5 },
+                        "SmartContractAllowance::Index::5": {
+                            tag: "SmartContractAllowance",
+                            dest: "Index::5",
+                        },
                     },
                 },
                 storageDir,
@@ -285,7 +288,7 @@ if (import.meta.vitest) {
             await expect(
                 createSlotAccountSigner(fakeAdapter("p"), {
                     tag: "SmartContractAllowance",
-                    value: 5,
+                    value: { tag: "Index", value: 5 },
                 }),
             ).rejects.toThrow(/SmartContractAllowance does not carry a slot account key/);
         });
@@ -294,11 +297,11 @@ if (import.meta.vitest) {
             await saveCache(
                 "p",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         AutoSigning: {
                             tag: "AutoSigning",
-                            productDerivationSecret: "secret",
+                            ringVrfDomainEntropy: "0xcd",
                             productRootPrivateKey: "0xabcd",
                         },
                     },
@@ -320,7 +323,7 @@ if (import.meta.vitest) {
             await saveCache(
                 "my-product.dot",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: hex },
                     },
@@ -358,7 +361,7 @@ if (import.meta.vitest) {
             await saveCache(
                 "app-a",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         BulletInAllowance: { tag: "BulletInAllowance", slotAccountKey: a.hex },
                     },
@@ -368,7 +371,7 @@ if (import.meta.vitest) {
             await saveCache(
                 "app-b",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         BulletInAllowance: {
                             tag: "BulletInAllowance",
@@ -398,7 +401,7 @@ if (import.meta.vitest) {
             await saveCache(
                 "p",
                 {
-                    version: 1,
+                    version: 2,
                     entries: {
                         BulletInAllowance: {
                             tag: "BulletInAllowance",

--- a/product-sdk/packages/terminal/src/host.ts
+++ b/product-sdk/packages/terminal/src/host.ts
@@ -408,13 +408,13 @@ if (import.meta.vitest) {
             });
 
             await requestResourceAllocation(session, fakeAdapter("p"), [
-                { tag: "SmartContractAllowance", value: 7 },
+                { tag: "SmartContractAllowance", value: { tag: "Index", value: 7 } },
             ]);
 
             const sent = captured[0].resources[0];
             expect(sent.tag).toBe("SmartContractAllowance");
             if (sent.tag === "SmartContractAllowance") {
-                expect(sent.value).toBe(7);
+                expect(sent.value).toEqual({ tag: "Index", value: 7 });
             }
         });
 
@@ -647,7 +647,7 @@ if (import.meta.vitest) {
                             value: {
                                 tag: "AutoSigning" as const,
                                 value: {
-                                    productDerivationSecret: "secret",
+                                    ringVrfDomainEntropy: new Uint8Array([0xcd]),
                                     productRootPrivateKey: new Uint8Array([0xab]),
                                 },
                             },
@@ -797,15 +797,21 @@ if (import.meta.vitest) {
             });
             const adapter = fakeAdapter("p");
             await requestResourceAllocation(session, adapter, [
-                { tag: "SmartContractAllowance", value: 5 },
+                { tag: "SmartContractAllowance", value: { tag: "Index", value: 5 } },
             ]);
 
             expect(
-                await getCachedAllocation(adapter, { tag: "SmartContractAllowance", value: 5 }),
-            ).toEqual({ tag: "SmartContractAllowance", dest: 5 });
+                await getCachedAllocation(adapter, {
+                    tag: "SmartContractAllowance",
+                    value: { tag: "Index", value: 5 },
+                }),
+            ).toEqual({ tag: "SmartContractAllowance", dest: "Index::5" });
             // Different dest doesn't match.
             expect(
-                await getCachedAllocation(adapter, { tag: "SmartContractAllowance", value: 6 }),
+                await getCachedAllocation(adapter, {
+                    tag: "SmartContractAllowance",
+                    value: { tag: "Index", value: 6 },
+                }),
             ).toBeNull();
         });
     });

--- a/product-sdk/packages/terminal/src/signer.ts
+++ b/product-sdk/packages/terminal/src/signer.ts
@@ -45,6 +45,7 @@ import { NoAllowanceError } from "@novasamatech/statement-store";
 import { decAnyMetadata, unifyMetadata } from "@polkadot-api/substrate-bindings";
 import { deriveProductAccountPublicKey } from "@parity/product-sdk-keys";
 import { AllowanceExpiredError } from "@parity/product-sdk-signer/errors";
+import { toHex } from "@polkadot-api/utils";
 import type { PolkadotSigner } from "polkadot-api";
 
 import type { TerminalAdapter } from "./adapter.js";
@@ -98,7 +99,7 @@ function toAllowanceExpiredError(error: unknown): AllowanceExpiredError | null {
 /**
  * Identifies which sub-account of a paired session should sign.
  *
- * Mirrors the `host-papp` wire format `productAccountId: [productId, derivationIndex]`:
+ * Mirrors the `host-papp` wire format `productAccountId: [productId, index]`:
  * `productId` is the dotNS-style identifier for the requesting product (matches
  * the adapter's `appId` in normal usage); `derivationIndex` is the BIP32-style
  * child-key index, where `0` is the session's default account.
@@ -125,6 +126,14 @@ export interface ProductAccountRef {
     publicKey?: Uint8Array;
 }
 
+/** Derived from the session so a codec change fails to compile here. */
+type ProductAccountId = Parameters<UserSession["signRaw"]>[0]["productAccountId"];
+
+/** `Raw` is a host capability the SDK does not expose. */
+function toProductAccountId(ref: ProductAccountRef): ProductAccountId {
+    return [ref.productId, { tag: "Index", value: ref.derivationIndex }];
+}
+
 /**
  * The `signedExtensions` map PAPI hands to `PolkadotSigner.signTx`: keyed by
  * extension identifier, each entry carries the SCALE-encoded `extra` (goes in
@@ -144,7 +153,7 @@ type PapiSignedExtensions = Parameters<PolkadotSigner["signTx"]>[1];
  * paired phone; the metadata decode + SSO round-trip live in {@link makeTxSignTx}.
  */
 function buildCreateTransactionRequest(
-    productAccountId: [string, number],
+    productAccountId: ProductAccountId,
     callData: Uint8Array,
     signedExtensions: PapiSignedExtensions,
     txExtVersion: number,
@@ -162,7 +171,8 @@ function buildCreateTransactionRequest(
             value: {
                 signer: productAccountId,
                 // CheckGenesis carries the genesis hash as its additionalSigned (implicit) data.
-                genesisHash: checkGenesis.additionalSigned,
+                // `toHex` is typed `string`; the codec wants the 0x literal type.
+                genesisHash: toHex(checkGenesis.additionalSigned) as `0x${string}`,
                 callData,
                 extensions: Object.values(signedExtensions).map(
                     ({ identifier, value, additionalSigned }) => ({
@@ -237,7 +247,7 @@ async function requestSignedTransaction(
  */
 function makeTxSignTx(
     session: UserSession,
-    productAccountId: [string, number],
+    productAccountId: ProductAccountId,
 ): PolkadotSigner["signTx"] {
     return async (callData, signedExtensions, metadata) =>
         requestSignedTransaction(
@@ -263,7 +273,7 @@ function makeTxSignTx(
  * funnel raw-bytes signing through the same `sign` callback as tx signing
  * — the wrong wire tag for arbitrary user data).
  */
-function makeRawBytesSignCallback(session: UserSession, productAccountId: [string, number]) {
+function makeRawBytesSignCallback(session: UserSession, productAccountId: ProductAccountId) {
     return async (data: Uint8Array): Promise<Uint8Array> => {
         const result = await session.signRaw({
             productAccountId,
@@ -326,7 +336,7 @@ export function deriveProductPublicKey(session: UserSession, ref: ProductAccount
 }
 
 function buildSessionSigner(session: UserSession, ref: ProductAccountRef): PolkadotSigner {
-    const productAccountId: [string, number] = [ref.productId, ref.derivationIndex];
+    const productAccountId = toProductAccountId(ref);
 
     // The signer's public key must be the *product* account's key — the one the
     // wallet signs with for [productId, derivationIndex] — not the wallet's
@@ -392,6 +402,9 @@ export function createSessionSignerForAccount(
 }
 
 if (import.meta.vitest) {
+    const pid = (productId: string, derivationIndex: number) =>
+        toProductAccountId({ productId, derivationIndex });
+
     const { describe, test, expect, vi } = import.meta.vitest;
     const { ok, err } = await import("neverthrow");
     const { seedToAccount } = await import("@parity/product-sdk-keys");
@@ -520,10 +533,10 @@ if (import.meta.vitest) {
             // Mobile applies the <Bytes>...</Bytes> envelope on its side.
             expect(captured).toHaveLength(1);
             const req = captured[0] as {
-                productAccountId: [string, { tag: "Index"; value: number }];
+                productAccountId: ProductAccountId;
                 data: { tag: string; value: Uint8Array };
             };
-            expect(req.productAccountId).toEqual(["test-app", { tag: "Index", value: 0 }]);
+            expect(req.productAccountId).toEqual(pid("test-app", 0));
             expect(req.data.tag).toBe("Bytes");
             expect(req.data.value).toEqual(new Uint8Array([1, 2, 3]));
         });
@@ -611,20 +624,20 @@ if (import.meta.vitest) {
         test("wraps the payload as v1 with signer, callData, and txExtVersion", () => {
             const callData = new Uint8Array([0xca, 0x11]);
             const req = buildCreateTransactionRequest(
-                ["my-app", { tag: "Index", value: 3 }],
+                pid("my-app", 3),
                 callData,
                 { CheckGenesis: checkGenesis },
                 5,
             );
             expect(req.payload.tag).toBe("v1");
-            expect(req.payload.value.signer).toEqual(["my-app", { tag: "Index", value: 3 }]);
+            expect(req.payload.value.signer).toEqual(pid("my-app", 3));
             expect(req.payload.value.callData).toEqual(callData);
             expect(req.payload.value.txExtVersion).toBe(5);
         });
 
         test("takes the genesis hash from CheckGenesis.additionalSigned", () => {
             const req = buildCreateTransactionRequest(
-                ["my-app", { tag: "Index", value: 0 }],
+                pid("my-app", 0),
                 new Uint8Array([0]),
                 { CheckGenesis: checkGenesis },
                 0,
@@ -634,7 +647,7 @@ if (import.meta.vitest) {
 
         test("maps every signed extension to { id, extra, additionalSigned }", () => {
             const req = buildCreateTransactionRequest(
-                ["my-app", { tag: "Index", value: 0 }],
+                pid("my-app", 0),
                 new Uint8Array([0]),
                 { CheckGenesis: checkGenesis, CheckNonce: ext("CheckNonce", [0x07], []) },
                 0,
@@ -657,7 +670,7 @@ if (import.meta.vitest) {
             // The whole reason for moving off PJS: an extension PAPI's PJS
             // adapter doesn't know must pass through untouched.
             const req = buildCreateTransactionRequest(
-                ["my-app", { tag: "Index", value: 0 }],
+                pid("my-app", 0),
                 new Uint8Array([0]),
                 { CheckGenesis: checkGenesis, AsPgas: ext("AsPgas", [0xde, 0xad], [0xbe, 0xef]) },
                 0,
@@ -671,19 +684,14 @@ if (import.meta.vitest) {
 
         test("throws a clear error when CheckGenesis is absent", () => {
             expect(() =>
-                buildCreateTransactionRequest(
-                    ["my-app", { tag: "Index", value: 0 }],
-                    new Uint8Array([0]),
-                    {},
-                    0,
-                ),
+                buildCreateTransactionRequest(pid("my-app", 0), new Uint8Array([0]), {}, 0),
             ).toThrow(/CheckGenesis/);
         });
     });
 
     describe("requestSignedTransaction — SSO round-trip", () => {
         const request = buildCreateTransactionRequest(
-            ["my-app", { tag: "Index", value: 0 }],
+            pid("my-app", 0),
             new Uint8Array([0]),
             { CheckGenesis: ext("CheckGenesis", [], [0x01]) },
             0,
@@ -810,10 +818,10 @@ if (import.meta.vitest) {
 
             expect(captured).toHaveLength(1);
             const req = captured[0] as {
-                productAccountId: [string, { tag: "Index"; value: number }];
+                productAccountId: ProductAccountId;
                 data: { tag: string; value: Uint8Array };
             };
-            expect(req.productAccountId).toEqual(["my-app", { tag: "Index", value: 5 }]);
+            expect(req.productAccountId).toEqual(pid("my-app", 5));
             expect(req.data.tag).toBe("Bytes");
             expect(Array.from(req.data.value)).toEqual([0xde, 0xad, 0xbe, 0xef]);
         });
@@ -885,10 +893,10 @@ if (import.meta.vitest) {
 
             expect(captured).toHaveLength(1);
             const req = captured[0] as {
-                productAccountId: [string, { tag: "Index"; value: number }];
+                productAccountId: ProductAccountId;
                 data: { tag: string; value: Uint8Array };
             };
-            expect(req.productAccountId).toEqual(["my-app", { tag: "Index", value: 7 }]);
+            expect(req.productAccountId).toEqual(pid("my-app", 7));
             expect(req.data.tag).toBe("Bytes");
             expect(req.data.value).toBeInstanceOf(Uint8Array);
         });
@@ -909,9 +917,9 @@ if (import.meta.vitest) {
             await signer.signBytes(new Uint8Array([1]));
 
             const req = captured[0] as {
-                productAccountId: [string, { tag: "Index"; value: number }];
+                productAccountId: ProductAccountId;
             };
-            expect(req.productAccountId).toEqual(["external-product", { tag: "Index", value: 0 }]);
+            expect(req.productAccountId).toEqual(pid("external-product", 0));
         });
     });
 }

--- a/product-sdk/packages/terminal/src/signer.ts
+++ b/product-sdk/packages/terminal/src/signer.ts
@@ -520,10 +520,10 @@ if (import.meta.vitest) {
             // Mobile applies the <Bytes>...</Bytes> envelope on its side.
             expect(captured).toHaveLength(1);
             const req = captured[0] as {
-                productAccountId: [string, number];
+                productAccountId: [string, { tag: "Index"; value: number }];
                 data: { tag: string; value: Uint8Array };
             };
-            expect(req.productAccountId).toEqual(["test-app", 0]);
+            expect(req.productAccountId).toEqual(["test-app", { tag: "Index", value: 0 }]);
             expect(req.data.tag).toBe("Bytes");
             expect(req.data.value).toEqual(new Uint8Array([1, 2, 3]));
         });
@@ -611,30 +611,30 @@ if (import.meta.vitest) {
         test("wraps the payload as v1 with signer, callData, and txExtVersion", () => {
             const callData = new Uint8Array([0xca, 0x11]);
             const req = buildCreateTransactionRequest(
-                ["my-app", 3],
+                ["my-app", { tag: "Index", value: 3 }],
                 callData,
                 { CheckGenesis: checkGenesis },
                 5,
             );
             expect(req.payload.tag).toBe("v1");
-            expect(req.payload.value.signer).toEqual(["my-app", 3]);
+            expect(req.payload.value.signer).toEqual(["my-app", { tag: "Index", value: 3 }]);
             expect(req.payload.value.callData).toEqual(callData);
             expect(req.payload.value.txExtVersion).toBe(5);
         });
 
         test("takes the genesis hash from CheckGenesis.additionalSigned", () => {
             const req = buildCreateTransactionRequest(
-                ["my-app", 0],
+                ["my-app", { tag: "Index", value: 0 }],
                 new Uint8Array([0]),
                 { CheckGenesis: checkGenesis },
                 0,
             );
-            expect(req.payload.value.genesisHash).toEqual(new Uint8Array([0x11, 0x22, 0x33]));
+            expect(req.payload.value.genesisHash).toBe("0x112233");
         });
 
         test("maps every signed extension to { id, extra, additionalSigned }", () => {
             const req = buildCreateTransactionRequest(
-                ["my-app", 0],
+                ["my-app", { tag: "Index", value: 0 }],
                 new Uint8Array([0]),
                 { CheckGenesis: checkGenesis, CheckNonce: ext("CheckNonce", [0x07], []) },
                 0,
@@ -657,7 +657,7 @@ if (import.meta.vitest) {
             // The whole reason for moving off PJS: an extension PAPI's PJS
             // adapter doesn't know must pass through untouched.
             const req = buildCreateTransactionRequest(
-                ["my-app", 0],
+                ["my-app", { tag: "Index", value: 0 }],
                 new Uint8Array([0]),
                 { CheckGenesis: checkGenesis, AsPgas: ext("AsPgas", [0xde, 0xad], [0xbe, 0xef]) },
                 0,
@@ -671,14 +671,19 @@ if (import.meta.vitest) {
 
         test("throws a clear error when CheckGenesis is absent", () => {
             expect(() =>
-                buildCreateTransactionRequest(["my-app", 0], new Uint8Array([0]), {}, 0),
+                buildCreateTransactionRequest(
+                    ["my-app", { tag: "Index", value: 0 }],
+                    new Uint8Array([0]),
+                    {},
+                    0,
+                ),
             ).toThrow(/CheckGenesis/);
         });
     });
 
     describe("requestSignedTransaction — SSO round-trip", () => {
         const request = buildCreateTransactionRequest(
-            ["my-app", 0],
+            ["my-app", { tag: "Index", value: 0 }],
             new Uint8Array([0]),
             { CheckGenesis: ext("CheckGenesis", [], [0x01]) },
             0,
@@ -797,15 +802,18 @@ if (import.meta.vitest) {
                 },
             });
 
-            const callback = makeRawBytesSignCallback(session, ["my-app", 5]);
+            const callback = makeRawBytesSignCallback(session, [
+                "my-app",
+                { tag: "Index", value: 5 },
+            ]);
             await callback(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
 
             expect(captured).toHaveLength(1);
             const req = captured[0] as {
-                productAccountId: [string, number];
+                productAccountId: [string, { tag: "Index"; value: number }];
                 data: { tag: string; value: Uint8Array };
             };
-            expect(req.productAccountId).toEqual(["my-app", 5]);
+            expect(req.productAccountId).toEqual(["my-app", { tag: "Index", value: 5 }]);
             expect(req.data.tag).toBe("Bytes");
             expect(Array.from(req.data.value)).toEqual([0xde, 0xad, 0xbe, 0xef]);
         });
@@ -816,7 +824,10 @@ if (import.meta.vitest) {
                 signRaw: async () => ok({ signature: sig }),
             });
 
-            const callback = makeRawBytesSignCallback(session, ["my-app", 0]);
+            const callback = makeRawBytesSignCallback(session, [
+                "my-app",
+                { tag: "Index", value: 0 },
+            ]);
             const out = await callback(new Uint8Array([0]));
 
             expect(out).toBe(sig);
@@ -828,7 +839,10 @@ if (import.meta.vitest) {
                 signRaw: async () => err(underlying),
             });
 
-            const callback = makeRawBytesSignCallback(session, ["my-app", 0]);
+            const callback = makeRawBytesSignCallback(session, [
+                "my-app",
+                { tag: "Index", value: 0 },
+            ]);
             await expect(callback(new Uint8Array([1]))).rejects.toBeInstanceOf(
                 AllowanceExpiredError,
             );
@@ -843,7 +857,10 @@ if (import.meta.vitest) {
                 signRaw: async () => err(new Error("user declined")),
             });
 
-            const callback = makeRawBytesSignCallback(session, ["my-app", 0]);
+            const callback = makeRawBytesSignCallback(session, [
+                "my-app",
+                { tag: "Index", value: 0 },
+            ]);
             await expect(callback(new Uint8Array([1]))).rejects.toThrow(
                 "Mobile signing rejected: user declined",
             );
@@ -868,10 +885,10 @@ if (import.meta.vitest) {
 
             expect(captured).toHaveLength(1);
             const req = captured[0] as {
-                productAccountId: [string, number];
+                productAccountId: [string, { tag: "Index"; value: number }];
                 data: { tag: string; value: Uint8Array };
             };
-            expect(req.productAccountId).toEqual(["my-app", 7]);
+            expect(req.productAccountId).toEqual(["my-app", { tag: "Index", value: 7 }]);
             expect(req.data.tag).toBe("Bytes");
             expect(req.data.value).toBeInstanceOf(Uint8Array);
         });
@@ -891,8 +908,10 @@ if (import.meta.vitest) {
             });
             await signer.signBytes(new Uint8Array([1]));
 
-            const req = captured[0] as { productAccountId: [string, number] };
-            expect(req.productAccountId).toEqual(["external-product", 0]);
+            const req = captured[0] as {
+                productAccountId: [string, { tag: "Index"; value: number }];
+            };
+            expect(req.productAccountId).toEqual(["external-product", { tag: "Index", value: 0 }]);
         });
     });
 }

--- a/product-sdk/packages/terminal/src/testing.ts
+++ b/product-sdk/packages/terminal/src/testing.ts
@@ -17,7 +17,7 @@
  * and fails if the upstream format ever drifts from our reproduction.
  */
 import { gcm } from "@noble/ciphers/aes.js";
-import { p256 } from "@noble/curves/nist.js";
+import { x25519 } from "@noble/curves/ed25519.js";
 import { blake2b } from "@noble/hashes/blake2.js";
 import {
     AccountIdCodec,
@@ -52,21 +52,23 @@ import { sanitizeKey } from "./node-storage.js";
 // three are now required — and appended `rootEntropySource: Bytes(32)`,
 // the layer-1 entropy the host consumes via `deriveProductEntropyFromSource`.
 //
-// host-papp 0.8.7-1 (PR #212) appended `deviceEncPubKey: Bytes(65)` — the
-// paired phone's long-lived ECDH key, lifted from `HandshakeResponseV2.
-// deviceEncPubKey`, used by the host's device-sync channel to address
-// the paired device. The storage key was renamed `SsoSessionsV2 → SsoSessionsV3`
-// in the same release; the old graceful-degrade for V2 blobs is gone.
+// host-papp 0.8.7-1 (PR #212) appended `deviceEncPubKey` — the paired phone's
+// long-lived ECDH key, lifted from `HandshakeResponseV2.deviceEncPubKey`, used
+// by the host's device-sync channel to address the paired device.
+//
+// host-papp 0.9.0 moved the encryption keys to 32-byte X25519 and bumped the
+// storage key to V4: fixed-size `Bytes` does not length-check, so a V3 blob
+// would decode misaligned into a session that looks valid.
 const storedUserSessionCodec = Struct({
     id: str,
     localAccount: LocalSessionAccountCodec,
     remoteAccount: RemoteSessionAccountCodec,
     rootAccountId: AccountIdCodec,
     identityAccountId: AccountIdCodec,
-    identityChatPublicKey: Bytes(65),
-    ssoEncPubKey: Bytes(65),
+    identityChatPublicKey: Bytes(32),
+    ssoEncPubKey: Bytes(32),
     rootEntropySource: Bytes(32),
-    deviceEncPubKey: Bytes(65),
+    deviceEncPubKey: Bytes(32),
 }) satisfies Codec<StoredUserSession>;
 const sessionsCodec = Vector(storedUserSessionCodec);
 
@@ -91,11 +93,9 @@ function encryptSecrets(appId: string, plaintext: Uint8Array): string {
     return toHex(gcm(key, nonce).encrypt(plaintext));
 }
 
-/** Mirrors host-papp's createEncrSecret: pad the mini-secret to 48 bytes and feed it to P256 keygen. */
-function p256SecretFromEntropy(entropy: Uint8Array): Uint8Array {
-    const seed = new Uint8Array(48);
-    seed.set(entropyToMiniSecret(entropy));
-    return p256.keygen(seed).secretKey;
+/** Mirrors host-papp's createEncrSecret: the mini-secret is the X25519 scalar. */
+function x25519SecretFromEntropy(entropy: Uint8Array): Uint8Array {
+    return entropyToMiniSecret(entropy);
 }
 
 export interface CreateTestSessionOptions {
@@ -167,9 +167,9 @@ export interface TestSession {
  *   tracked via on-chain attestation state. See above for how expiry-path
  *   tests still work in practice.
  * - **Corrupted-session cases** don't need a helper — write garbage to
- *   `<storageDir>/<appId>_SsoSessionsV3.json` with `fs.writeFile` directly.
+ *   `<storageDir>/<appId>_SsoSessionsV4.json` with `fs.writeFile` directly.
  * - **Repeated calls replace the session list.** Each call writes a fresh
- *   single-entry `SsoSessionsV3` file, so calling twice on the same
+ *   single-entry `SsoSessionsV4` file, so calling twice on the same
  *   `storageDir`+`appId` leaves only the second session on disk. Use a
  *   fresh `mkdtempSync` per test to keep cases isolated.
  *
@@ -197,20 +197,18 @@ export async function createTestSession(options: CreateTestSessionOptions): Prom
     const localEntropy = mnemonicToEntropy(localMnemonic);
     const localSecret = createSr25519Secret(localEntropy, localDerivation);
     const localPublicKey = deriveSr25519PublicKey(localSecret);
-    const localEncrSecret = p256SecretFromEntropy(localEntropy);
+    const localEncrSecret = x25519SecretFromEntropy(localEntropy);
 
     const remoteMnemonic = options.remoteMnemonic ?? generateMnemonic();
     const remoteDerivation = options.remoteDerivation ?? "";
     const remoteEntropy = mnemonicToEntropy(remoteMnemonic);
     const remoteSecret = createSr25519Secret(remoteEntropy, remoteDerivation);
     const remotePublicKey = deriveSr25519PublicKey(remoteSecret);
-    const remoteEncrPublicKey = p256.getPublicKey(p256SecretFromEntropy(remoteEntropy), false);
+    const remoteEncrPublicKey = x25519.getPublicKey(x25519SecretFromEntropy(remoteEntropy));
 
-    // In production, `remoteAccount.publicKey` is the ECDH shared secret
-    // between the host's P256 encryption key and the phone's P256 encryption
-    // key. We compute the same thing from two mnemonic-derived P256 keys so
-    // the synthesized session is cryptographically well-formed.
-    const sharedSecret = p256.getSharedSecret(localEncrSecret, remoteEncrPublicKey).slice(1, 33);
+    // In production this is a real ECDH secret, so derive it from two
+    // mnemonic-derived X25519 keys rather than inventing bytes.
+    const sharedSecret = x25519.getSharedSecret(localEncrSecret, remoteEncrPublicKey);
 
     const sessionId = options.sessionId ?? nanoid(12);
 
@@ -219,10 +217,8 @@ export async function createTestSession(options: CreateTestSessionOptions): Prom
     // persisted session. host-papp 0.8.7-1 added `deviceEncPubKey` (the
     // peer device's long-lived ECDH key). For a synthesized test session
     // we collapse the identity-side keys onto the remote account (the
-    // wallet doubles as identity), reuse the peer's P-256 encryption
-    // pubkey for chat, SSO, and the new device-sync transport, and use
-    // the remote entropy as the RFC-0007 root entropy source so the value
-    // is reproducible.
+    // wallet doubles as identity) and reuse the peer's X25519 encryption
+    // pubkey for chat, SSO, and device-sync.
     const session = {
         id: sessionId,
         localAccount: createLocalSessionAccount(createAccountId(localPublicKey), undefined),
@@ -235,12 +231,12 @@ export async function createTestSession(options: CreateTestSessionOptions): Prom
         identityAccountId: createAccountId(remotePublicKey),
         identityChatPublicKey: remoteEncrPublicKey,
         ssoEncPubKey: remoteEncrPublicKey,
-        rootEntropySource: remoteEntropy,
+        rootEntropySource: entropyToMiniSecret(remoteEntropy),
         deviceEncPubKey: remoteEncrPublicKey,
     };
 
     await writeFile(
-        join(options.storageDir, `${sanitizeKey(options.appId, "SsoSessionsV3")}.json`),
+        join(options.storageDir, `${sanitizeKey(options.appId, "SsoSessionsV4")}.json`),
         toHex(sessionsCodec.enc([session])),
         "utf-8",
     );
@@ -249,8 +245,8 @@ export async function createTestSession(options: CreateTestSessionOptions): Prom
     if (includeSecrets) {
         // host-papp 0.8.6 dropped `entropy` (now lives on the session as
         // `rootEntropySource`) and requires a 32-byte `identityChatPrivateKey`
-        // (V2 — P-256 raw scalar). Reuse the local P-256 encryption secret
-        // for both — same domain (P-256, 32-byte scalar).
+        // (V2 — raw scalar). Reuse the local encryption secret for both:
+        // same domain, 32-byte X25519 scalar.
         const encoded = storedUserSecretsCodec.enc({
             ssSecret: localSecret,
             encrSecret: localEncrSecret,
@@ -400,9 +396,9 @@ if (import.meta.vitest) {
 
             // Sr25519 secret is 64 bytes (32-byte secret + 32-byte nonce).
             expect(decoded.ssSecret).toHaveLength(64);
-            // P256 secret is 32 bytes.
+            // X25519 secret is 32 bytes.
             expect(decoded.encrSecret).toHaveLength(32);
-            // V2 chat private key (P-256 raw scalar) is 32 bytes.
+            // V2 chat private key is a 32-byte raw scalar.
             expect(decoded.identityChatPrivateKey).toHaveLength(32);
         });
 

--- a/product-sdk/packages/terminal/src/testing.ts
+++ b/product-sdk/packages/terminal/src/testing.ts
@@ -305,7 +305,7 @@ if (import.meta.vitest) {
     });
 
     describe("createTestSession", () => {
-        test("writes both SsoSessionsV3 and UserSecretsV2 files by default", async () => {
+        test("writes both SsoSessionsV4 and UserSecretsV2 files by default", async () => {
             const result = await createTestSession({
                 appId: "my-app",
                 storageDir,
@@ -313,7 +313,7 @@ if (import.meta.vitest) {
                 remoteMnemonic: REMOTE_MNEMONIC,
             });
 
-            const sessions = await readFile(join(storageDir, "my-app_SsoSessionsV3.json"), "utf-8");
+            const sessions = await readFile(join(storageDir, "my-app_SsoSessionsV4.json"), "utf-8");
             expect(sessions).toMatch(/^0x[0-9a-f]+$/);
 
             const secrets = await readFile(
@@ -333,7 +333,7 @@ if (import.meta.vitest) {
             });
 
             await expect(
-                readFile(join(storageDir, "my-app_SsoSessionsV3.json"), "utf-8"),
+                readFile(join(storageDir, "my-app_SsoSessionsV4.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
 
             await expect(
@@ -344,7 +344,7 @@ if (import.meta.vitest) {
             ).rejects.toThrow(/ENOENT/);
         });
 
-        test("SsoSessionsV3 file decodes with the host-papp session codec shape", async () => {
+        test("SsoSessionsV4 file decodes with the host-papp session codec shape", async () => {
             const result = await createTestSession({
                 appId: "my-app",
                 storageDir,
@@ -353,7 +353,7 @@ if (import.meta.vitest) {
                 sessionId: "stable-test-id",
             });
 
-            const hex = await readFile(join(storageDir, "my-app_SsoSessionsV3.json"), "utf-8");
+            const hex = await readFile(join(storageDir, "my-app_SsoSessionsV4.json"), "utf-8");
             const decoded = sessionsCodec.dec(fromHex(hex));
 
             expect(decoded).toHaveLength(1);
@@ -411,10 +411,10 @@ if (import.meta.vitest) {
             await createTestSession({ appId: "app-b", storageDir, sessionId: "id" });
 
             await expect(
-                readFile(join(storageDir, "app-a_SsoSessionsV3.json"), "utf-8"),
+                readFile(join(storageDir, "app-a_SsoSessionsV4.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
             await expect(
-                readFile(join(storageDir, "app-b_SsoSessionsV3.json"), "utf-8"),
+                readFile(join(storageDir, "app-b_SsoSessionsV4.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
         });
 
@@ -425,7 +425,7 @@ if (import.meta.vitest) {
                 sessionId: "id",
             });
             await expect(
-                readFile(join(storageDir, "app_with_spaces_SsoSessionsV3.json"), "utf-8"),
+                readFile(join(storageDir, "app_with_spaces_SsoSessionsV4.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
         });
 
@@ -433,7 +433,7 @@ if (import.meta.vitest) {
             const nested = join(storageDir, "does", "not", "exist");
             await createTestSession({ appId: "my-app", storageDir: nested });
             await expect(
-                readFile(join(nested, "my-app_SsoSessionsV3.json"), "utf-8"),
+                readFile(join(nested, "my-app_SsoSessionsV4.json"), "utf-8"),
             ).resolves.toMatch(/^0x/);
         });
 
@@ -487,7 +487,7 @@ if (import.meta.vitest) {
                 sessionId: "second",
             });
 
-            const hex = await readFile(join(storageDir, "my-app_SsoSessionsV3.json"), "utf-8");
+            const hex = await readFile(join(storageDir, "my-app_SsoSessionsV4.json"), "utf-8");
             const decoded = sessionsCodec.dec(fromHex(hex));
             expect(decoded).toHaveLength(1);
             expect(decoded[0].id).toBe("second");

--- a/product-sdk/pending-changesets/host-papp-0.10.0.md
+++ b/product-sdk/pending-changesets/host-papp-0.10.0.md
@@ -1,0 +1,24 @@
+---
+"@parity/product-sdk-terminal": minor
+"@parity/product-sdk-auth": minor
+---
+
+**Pair with a 0.9.0+ host.** `@novasamatech/host-papp` and its three lockstep siblings move from `^0.8.9` to `0.10.0`.
+
+The old caret admitted only `>=0.8.9 <0.9.0`. host-papp 0.9.0 changed the pairing envelope from P-256 / AES-GCM to X25519 / ChaCha20-Poly1305 and shrank the encryption keys from 65 bytes to 32, and the handshake codec is fixed-width SCALE, so an SDK on the old pin could not complete a handshake. Both shipping mobile hosts moved to the new envelope in mid-August 2026, so this has been broken in the field since then.
+
+**Existing paired sessions are invalidated. Users re-pair once.** The persisted session storage key moved `SsoSessionsV3` → `SsoSessionsV4`, so sessions written by an earlier CLI run are not read. `UserSecretsV2_<sessionId>.json` files are left behind but cause no errors, and the `DeviceIdentity` blob is unaffected. Same shape of break as the 0.8.7-1 bump.
+
+**The on-disk allowance cache is versioned 1 → 2 and stale files are dropped.** Its entries belong to sessions that can no longer exist, and two fields changed shape, so a v1 file is discarded rather than half-read. The first allocation after upgrading is one extra round trip.
+
+**Breaking, for anyone importing these types directly:**
+
+- `AllocatableResource` — `SmartContractAllowance`'s payload is now a tagged `{ tag: "Index"; value: number } | { tag: "Raw"; value: Uint8Array }` instead of a bare `number`.
+- `ApAllocationOutcome` — `AutoSigning` drops `productDerivationSecret` and gains `ringVrfDomainEntropy`.
+- `CachedAllocation` — `SmartContractAllowance.dest` is a string (`"Index::7"`, `"Raw::0x…"`), and the `AutoSigning` entry carries `ringVrfDomainEntropy`.
+
+`ProductAccountRef` is unchanged: the SDK still takes a plain `derivationIndex` and emits the `Index` variant for you.
+
+**Not taking 0.10.1 or newer.** They raise their `polkadot-api` floor to `>=3` and this workspace is on PAPI 2. 0.10.0 is wire-identical to 0.10.2 for pairing, handshake, signing and resource allocation, so nothing is lost by holding here. A `polkadot-api` override keeps host-papp's open `>=2` range from pulling a second PAPI copy into the graph.
+
+**This restores pairing, not phone-paired signing.** Product-account derivation in `@parity/product-sdk-keys` predates RFC-0022 and does not match any current host, so a signature still carries the wrong address. That is a separate, pre-existing defect, tracked on its own.

--- a/product-sdk/pnpm-lock.yaml
+++ b/product-sdk/pnpm-lock.yaml
@@ -27,9 +27,6 @@ catalogs:
     '@polkadot-labs/hdkd-helpers':
       specifier: ^0.0.30
       version: 0.0.30
-    polkadot-api:
-      specifier: ^2.1.6
-      version: 2.1.6
     tsup:
       specifier: ^8.5.1
       version: 8.5.1
@@ -47,6 +44,7 @@ catalogs:
       version: 3.2.6
 
 overrides:
+  polkadot-api: ^2.1.6
   '@polkadot-api/json-rpc-provider': ^0.2.0
   ws: ^8.21.0
 
@@ -85,7 +83,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/signer
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
@@ -116,7 +114,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/signer
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
@@ -147,7 +145,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/signer
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
@@ -219,7 +217,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/contracts
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
@@ -235,7 +233,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/signer
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
@@ -316,7 +314,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tx
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       '@parity/host-api-test-sdk':
@@ -363,7 +361,7 @@ importers:
         specifier: workspace:*
         version: link:../tx
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       tsup:
@@ -388,7 +386,7 @@ importers:
         specifier: workspace:*
         version: link:../logger
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       tsup:
@@ -431,7 +429,7 @@ importers:
         specifier: ^13.3.0
         version: 13.4.2
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       typescript:
@@ -468,7 +466,7 @@ importers:
         specifier: 'catalog:'
         version: 0.0.30
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
       viem:
         specifier: 'catalog:'
@@ -509,7 +507,7 @@ importers:
   packages/descriptors:
     dependencies:
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       typescript:
@@ -549,7 +547,7 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       tsup:
@@ -580,7 +578,7 @@ importers:
         specifier: 'catalog:'
         version: 0.20.3
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       '@parity/product-sdk-descriptors':
@@ -617,7 +615,7 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
       scale-ts:
         specifier: ^1.6.1
@@ -712,7 +710,7 @@ importers:
         specifier: workspace:*
         version: link:../result
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       '@types/node':
@@ -752,7 +750,7 @@ importers:
         specifier: workspace:*
         version: link:../result
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       tsup:
@@ -786,7 +784,7 @@ importers:
         specifier: 'catalog:'
         version: 0.7.0
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       tsup:
@@ -811,14 +809,14 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@novasamatech/host-papp':
-        specifier: ^0.8.9
-        version: 0.8.9(esbuild@0.28.1)
+        specifier: 0.10.0
+        version: 0.10.0(esbuild@0.28.1)
       '@novasamatech/statement-store':
-        specifier: ^0.8.9
-        version: 0.8.9(esbuild@0.28.1)(rxjs@7.8.2)
+        specifier: 0.10.0
+        version: 0.10.0(esbuild@0.28.1)(rxjs@7.8.2)
       '@novasamatech/storage-adapter':
-        specifier: ^0.8.9
-        version: 0.8.9
+        specifier: 0.10.0
+        version: 0.10.0
       '@parity/product-sdk-keys':
         specifier: workspace:*
         version: link:../keys
@@ -847,7 +845,7 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
       qrcode:
         specifier: ^1.5.4
@@ -857,8 +855,8 @@ importers:
         version: 1.6.1
     devDependencies:
       '@novasamatech/substrate-slot-sr25519-wasm':
-        specifier: ^0.8.9
-        version: 0.8.9
+        specifier: 0.10.0
+        version: 0.10.0
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.6
@@ -890,7 +888,7 @@ importers:
         specifier: 'catalog:'
         version: 0.0.30
       polkadot-api:
-        specifier: 'catalog:'
+        specifier: ^2.1.6
         version: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
     devDependencies:
       typescript:
@@ -1652,17 +1650,17 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@novasamatech/host-api@0.8.9':
-    resolution: {integrity: sha512-KPh81iVv3sQckq7/oyRpFF2uYBPXJD0+7cRuXO+lnWPAxQBXK1aNUQzSq+vJUHkcGRXJd0up/IlHJ4DMfQyUhQ==}
+  '@novasamatech/host-api@0.10.0':
+    resolution: {integrity: sha512-rDxroRcmXrGWE5sgwCcIak6SynwWDPHsjZzV00/kwMS/iFymqMB0mUqQPcU4p1yiatWqePHX4XoP3zh/qj608w==}
 
   '@novasamatech/host-api@0.9.4':
     resolution: {integrity: sha512-9yVjbyjUVfgDnNx3sJYlRW3kcpvBQv4F1LXqQZfJco/2Egcq8WM6Yplpnubfxhvj+IXl2gEEMQbX3thZms6LUQ==}
 
-  '@novasamatech/host-papp@0.8.9':
-    resolution: {integrity: sha512-Z1iENq/nn3e1P/4Mj0SS98yqO7tD8841G3xNGqO+O7tSnEjxDY4keS4uy4Rhx5hYIIRcUxe3xe1g/kUbJWVa+g==}
+  '@novasamatech/host-papp@0.10.0':
+    resolution: {integrity: sha512-uhcYMTCBgU37oIlUfDnXbs8VoSnrVff2N3xYq5fT9b+FDa9oP83ALb75xmxTo4rtR9C/UrXjzG2NvPtJNfjBIA==}
 
-  '@novasamatech/scale@0.8.9':
-    resolution: {integrity: sha512-/Gt0KwfdkQZGyqd7e8YApx/QPMj/WDFrFYYOW5qxNWlbDpSUmYqNX+D1LECSokXw1vqE2m+ydBmNsAwyhJCLuQ==}
+  '@novasamatech/scale@0.10.0':
+    resolution: {integrity: sha512-UJ1Jq0bUQ4p20BIuc079eZS7XouumNeheK1wojbiKNmoNQxFqsfRkJBYNQhIKWILKrI53FdP0D/uvby1Pl99Ew==}
 
   '@novasamatech/scale@0.9.4':
     resolution: {integrity: sha512-gUdY/KgWZAv5WUUeGmflo4bhTpfpbFMImtxN2VYfRarOQbbWOzKm7uelqgv8GAQUM85982wVhULPFRDA4b2qXA==}
@@ -1670,21 +1668,21 @@ packages:
   '@novasamatech/sdk-statement@0.6.0':
     resolution: {integrity: sha512-NTqM+yS45iHgy87lVSWIpFozrTfCUWb7r4ZpsDtN1eFnfixXpDKpPXDWQsvPs+nh18r/jmoMgtlTjUltrS6mYQ==}
 
-  '@novasamatech/statement-store@0.8.9':
-    resolution: {integrity: sha512-MCx9ah9vVoetU1+7BTU/85gUiUjirNqky4yy6ydKiYLgLAjMiRsGW02rjlngJ+4tnE0Xy3euuJcCI8FjOwMoSA==}
+  '@novasamatech/statement-store@0.10.0':
+    resolution: {integrity: sha512-+r+6Zw2xZHqEVc2F6Jn+i2fzPw7Nr0yqDV61Nodt2udL0suHPyEufZh9NUWZ45QcIiExYUgXxYyo5A4qEojqTg==}
 
-  '@novasamatech/storage-adapter@0.8.9':
-    resolution: {integrity: sha512-JXo6mfx0x9dZJzevKYD9MK6WxvlH5N9lBQegcSvWt3wpIniDriEUN8gmyJRkdbDdTZLwhmw1VM6mukM+RhJw1A==}
+  '@novasamatech/storage-adapter@0.10.0':
+    resolution: {integrity: sha512-De1TovvHX59YO4VUI9Vid0ikGkC3FPOq0sVU6JL4nEO7AExCbGcnPuR9Uyc52DtYexgI8Of3SbcTb+KHfW6Zvw==}
 
-  '@novasamatech/substrate-slot-sr25519-wasm@0.8.9':
-    resolution: {integrity: sha512-Y8tkYq7h9gGn0WwtxrdCjGBUdG+nVXEDzKDo+5WXe+MZI+kTc2zmhlaxXWe3f/gzqNktxKGEkJXyokB8b21buA==}
+  '@novasamatech/substrate-slot-sr25519-wasm@0.10.0':
+    resolution: {integrity: sha512-VZbHhRk7hDtkudefg0L23YijkrqVZHd139kZ+/KrBBTd7jUu19SRmQojGgu7nU2bz+fLRxTIUS4CTM/OOIc2Aw==}
 
   '@parity/bulletin-sdk@0.3.0':
     resolution: {integrity: sha512-sxVwBzyH/egXze1muPXbaGwQuOkP8efVB4Lxunshixf18gJ6WT2tedgUy08QOfQ1848BDQS4wVpRRQfPfb09/g==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       multiformats: ^13.4.1
-      polkadot-api: ^2.1.2
+      polkadot-api: ^2.1.6
 
   '@parity/host-api-test-sdk@0.12.1':
     resolution: {integrity: sha512-VprtVqoLhZfs8W5CcD8hu6xoJ9gPxDzSzEmsH5cTecceH7NCvcuJTKHpTq9J2mLvdy+TBmK6mMkeTyMCqZVzYw==}
@@ -1791,6 +1789,9 @@ packages:
 
   '@polkadot-labs/hdkd-helpers@0.0.30':
     resolution: {integrity: sha512-qWmmD6ayj14RenDuDFfjF3sHS7ObqPzwIIMPcSVoDeKFSeQV7RY0HwyhC5CG4i6FoguMzak2dbtjYpNN5XQiwQ==}
+
+  '@polkadot-labs/hdkd-helpers@0.0.31':
+    resolution: {integrity: sha512-BjunfAAlR/sGmBUVIZxgHYTA712oD2YPQhKRRxb45BtGfxdKBjs10hZWqOFxZbq9N4pICXp/1oosGe04znyhvw==}
 
   '@polkadot-labs/hdkd@0.0.28':
     resolution: {integrity: sha512-LpdqtQRpcgZQ5Mr8J0ddMA5ZufsbI4W3KuJkVdoYMnSmWs4179LigDb1rTYAOtyCg2jWUjf7rWP0mGxQQvNrHw==}
@@ -2634,18 +2635,9 @@ packages:
     resolution: {integrity: sha512-PmIJ3BNxOzgVgnS1r/Pvyj6eZx/xUV2JCPogh0brD6smDIwjRlr1KBl9yoRX323PlfaNrBDDnfCgC9SL00OjSg==}
     engines: {node: ^22.0.0 || ^24.0.0 || >=26.0.0}
 
-  nanoevents@9.1.0:
-    resolution: {integrity: sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.11:
-    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
-    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanoid@5.1.16:
@@ -3839,11 +3831,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@novasamatech/host-api@0.8.9':
+  '@novasamatech/host-api@0.10.0':
     dependencies:
-      '@novasamatech/scale': 0.8.9
-      nanoevents: 9.1.0
-      nanoid: 5.1.11
+      '@novasamatech/scale': 0.10.0
+      nanoevents: 10.0.0
+      nanoid: 6.0.0
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
@@ -3855,19 +3847,19 @@ snapshots:
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
-  '@novasamatech/host-papp@0.8.9(esbuild@0.28.1)':
+  '@novasamatech/host-papp@0.10.0(esbuild@0.28.1)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
-      '@novasamatech/host-api': 0.8.9
-      '@novasamatech/scale': 0.8.9
-      '@novasamatech/statement-store': 0.8.9(esbuild@0.28.1)(rxjs@7.8.2)
-      '@novasamatech/storage-adapter': 0.8.9
+      '@novasamatech/host-api': 0.10.0
+      '@novasamatech/scale': 0.10.0
+      '@novasamatech/statement-store': 0.10.0(esbuild@0.28.1)(rxjs@7.8.2)
+      '@novasamatech/storage-adapter': 0.10.0
       '@polkadot-api/utils': 0.4.0
-      '@polkadot-labs/hdkd-helpers': 0.0.30
-      nanoevents: 9.1.0
-      nanoid: 5.1.11
+      '@polkadot-labs/hdkd-helpers': 0.0.31
+      nanoevents: 10.0.0
+      nanoid: 6.0.0
       neverthrow: 8.2.0
       polkadot-api: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
       rxjs: 7.8.2
@@ -3878,7 +3870,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/scale@0.8.9':
+  '@novasamatech/scale@0.10.0':
     dependencies:
       '@polkadot-api/utils': 0.4.0
       scale-ts: 1.6.1
@@ -3900,19 +3892,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/statement-store@0.8.9(esbuild@0.28.1)(rxjs@7.8.2)':
+  '@novasamatech/statement-store@0.10.0(esbuild@0.28.1)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.2.0
+      '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
-      '@novasamatech/scale': 0.8.9
+      '@novasamatech/scale': 0.10.0
       '@novasamatech/sdk-statement': 0.6.0(esbuild@0.28.1)(rxjs@7.8.2)
-      '@novasamatech/substrate-slot-sr25519-wasm': 0.8.9
+      '@novasamatech/substrate-slot-sr25519-wasm': 0.10.0
       '@polkadot-api/substrate-bindings': 0.20.3
       '@polkadot-api/substrate-client': 0.7.0
-      '@polkadot-labs/hdkd-helpers': 0.0.30
+      '@polkadot-labs/hdkd-helpers': 0.0.31
       '@polkadot-labs/schnorrkel-wasm': 0.0.9
       '@scure/sr25519': 2.2.0
-      nanoid: 5.1.11
+      nanoid: 6.0.0
       neverthrow: 8.2.0
       polkadot-api: 2.1.6(esbuild@0.28.1)(rxjs@7.8.2)
       scale-ts: 1.6.1
@@ -3923,12 +3916,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/storage-adapter@0.8.9':
+  '@novasamatech/storage-adapter@0.10.0':
     dependencies:
-      nanoevents: 9.1.0
+      nanoevents: 10.0.0
       neverthrow: 8.2.0
 
-  '@novasamatech/substrate-slot-sr25519-wasm@0.8.9': {}
+  '@novasamatech/substrate-slot-sr25519-wasm@0.10.0': {}
 
   '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.6(esbuild@0.28.1)(rxjs@7.8.2))':
     dependencies:
@@ -4136,6 +4129,14 @@ snapshots:
       '@noble/hashes': 2.2.0
       '@scure/base': 2.2.0
       '@scure/sr25519': 1.0.0
+      scale-ts: 1.6.1
+
+  '@polkadot-labs/hdkd-helpers@0.0.31':
+    dependencies:
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
+      '@scure/sr25519': 2.2.0
       scale-ts: 1.6.1
 
   '@polkadot-labs/hdkd@0.0.28':
@@ -4871,11 +4872,7 @@ snapshots:
 
   nanoevents@10.0.0: {}
 
-  nanoevents@9.1.0: {}
-
   nanoid@3.3.12: {}
-
-  nanoid@5.1.11: {}
 
   nanoid@5.1.16: {}
 

--- a/product-sdk/pnpm-workspace.yaml
+++ b/product-sdk/pnpm-workspace.yaml
@@ -20,6 +20,9 @@ catalog:
   vitest: ^3.1.4
 
 overrides:
+  # host-papp asks for `polkadot-api: ">=2"`, which resolves to 3.x on its own.
+  # Terminal pins host-papp exact for the same reason: 0.10.1+ needs PAPI 3.
+  "polkadot-api": "^2.1.6"
   "@polkadot-api/json-rpc-provider": "^0.2.0"
   # Force the patched `ws` (GHSA: memory-exhaustion DoS from tiny fragments;
   # affects >=8.0.0 <8.21.0). Pulled transitively by smoldot (`^8.8.1`, satisfied)


### PR DESCRIPTION

Related to #362

### Description

Terminal pinned `@novasamatech/host-papp` at `^0.8.9`, which on a `0.x` package admits only `<0.9.0`. host-papp 0.9.0 moved the pairing envelope to X25519 / ChaCha20-Poly1305 with 32-byte keys, and the handshake codec is fixed-width SCALE, so the old pin cannot handshake. Both shipping mobile hosts moved in mid-August 2026, so pairing has been broken in the field since then. This bumps to `0.10.0` and migrates what the new codecs change.

### Changes

- `terminal/src/testing.ts`: X25519 keys, session file `SsoSessionsV3` to `V4`. Fixes a latent 16-byte write into `rootEntropySource: Bytes(32)` that only the new length-checking `Bytes` catches.
- `terminal/src/signer.ts`: `productAccountId` is `[productId, { tag: "Index", value }]`, built once from a session-derived type. `genesisHash` goes as hex.
- `terminal/src/host-cache.ts`: the tagged dest interpolated to `[object Object]`, collapsing every SmartContract entry onto one cache key. `productDerivationSecret` becomes `ringVrfDomainEntropy`. Cache v1 to v2, so stale files drop.
- `auth/src/allocations.ts`: one line, same shape.

Not 0.10.1 or newer: they need PAPI 3 and this workspace is on 2. 0.10.0 is wire-identical to 0.10.2 for pairing, handshake and signing.

**Paired sessions are invalidated, users re-pair once.** **Pairing is restored, phone-paired signing is not**: derivation in `packages/keys` predates RFC-0022 and matches no current host, which is separate and pre-existing. Not closing #362 until that has its own issue.

### Testing

Before, at `4d81679` (pin bumped, source not migrated): 39 typecheck errors, 42 failing tests. After:

```bash
cd product-sdk && pnpm install --frozen-lockfile
pnpm build && pnpm typecheck && pnpm check
LC_ALL=en_US.UTF-8 pnpm -r --no-bail test
```

All pass, 1961 tests across 19 packages. terminal is 182/182, up from 179 for three added tests. The two `*.interop.test.ts` suites are the load-bearing ones, they read the synthesized session back through the real host-papp repositories and fail if the on-disk format drifts again. `LC_ALL` is for `packages/utils`, unrelated to this change.
