### PR TITLE
fix(terminal): default to a people chain that resolves

### DIFF
--- a/product-sdk/packages/terminal/README.md
+++ b/product-sdk/packages/terminal/README.md
@@ -63,7 +63,7 @@ Creates a terminal adapter backed by the host-papp SDK.
 
 **Options:**
 - `appId` -- unique app identifier (used as storage namespace)
-- `endpoints?` -- statement store WebSocket endpoints (defaults to `StatementStoreNetworks.paseoNextV2`)
+- `endpoints?` -- statement store WebSocket endpoints (defaults to `StatementStoreNetworks.paseo`)
 - `hostMetadata?` -- optional host environment info
 - `storageDir?` -- override the on-disk session directory (defaults to `~/.polkadot-apps/`). Useful in tests and containerised environments.
 
@@ -77,14 +77,16 @@ Creates a terminal adapter backed by the host-papp SDK.
 
 The statement store endpoints terminal can pair against, keyed by network.
 
-| Key | Endpoint |
-| --- | --- |
-| `paseoNextV2` | `wss://paseo-people-next-system-rpc.polkadot.io` |
-| `previewnet` | `wss://previewnet.substrate.dev/people` |
+| Key | Network | Endpoint |
+| --- | --- | --- |
+| `paseo` | Paseo Next v2 | `wss://paseo-people-next-system-rpc.polkadot.io` |
+| `previewnet` | zombienet, a step ahead of paseo | whatever host-papp's `SS_PREVIEW_STAGE_ENDPOINTS` resolves to, today `wss://previewnet.substrate.dev/people` |
+
+Keyed the same way as `BULLETIN_RPCS` in `@parity/product-sdk-host`.
 
 Pairing only works when the terminal and the phone are on the **same** people chain, and the phone
-picks its chain per build flavour. The Polkadot app's nightly build uses `paseoNextV2`, which is why
-that is the default; a preview-flavour phone needs `endpoints: StatementStoreNetworks.previewnet`.
+picks its chain per build flavour. The Polkadot app's nightly build uses `paseo`, which is why that
+is the default; a preview-flavour phone needs `endpoints: StatementStoreNetworks.previewnet`.
 
 `SS_STABLE_STAGE_ENDPOINTS` is also exported. It is internal to the Parity network and does not
 answer from outside it.

--- a/product-sdk/packages/terminal/README.md
+++ b/product-sdk/packages/terminal/README.md
@@ -63,7 +63,7 @@ Creates a terminal adapter backed by the host-papp SDK.
 
 **Options:**
 - `appId` -- unique app identifier (used as storage namespace)
-- `endpoints?` -- statement store WebSocket endpoints (defaults to Paseo)
+- `endpoints?` -- statement store WebSocket endpoints (defaults to `StatementStoreNetworks.paseoNextV2`)
 - `hostMetadata?` -- optional host environment info
 - `storageDir?` -- override the on-disk session directory (defaults to `~/.polkadot-apps/`). Useful in tests and containerised environments.
 
@@ -72,6 +72,22 @@ Creates a terminal adapter backed by the host-papp SDK.
 - `sso` -- auth component (`.authenticate()`, `.abortAuthentication()`, status subscriptions)
 - `sessions` -- session manager (signing, disconnect)
 - `destroy()` -- disconnect the WebSocket and release resources. Idempotent. Drops `@novasamatech/statement-store`'s benign `Statement subscription error: Client destroyed` line, which it emits synchronously while disconnecting a live subscription — only that line; every other `console.error` passes through.
+
+### `StatementStoreNetworks`
+
+The statement store endpoints terminal can pair against, keyed by network.
+
+| Key | Endpoint |
+| --- | --- |
+| `paseoNextV2` | `wss://paseo-people-next-system-rpc.polkadot.io` |
+| `previewnet` | `wss://previewnet.substrate.dev/people` |
+
+Pairing only works when the terminal and the phone are on the **same** people chain, and the phone
+picks its chain per build flavour. The Polkadot app's nightly build uses `paseoNextV2`, which is why
+that is the default; a preview-flavour phone needs `endpoints: StatementStoreNetworks.previewnet`.
+
+`SS_STABLE_STAGE_ENDPOINTS` is also exported. It is internal to the Parity network and does not
+answer from outside it.
 
 ### `isBenignTeardownError(error): boolean`
 

--- a/product-sdk/packages/terminal/README.md
+++ b/product-sdk/packages/terminal/README.md
@@ -82,7 +82,9 @@ The statement store endpoints terminal can pair against, keyed by network.
 | `paseo` | Paseo Next v2 | `wss://paseo-people-next-system-rpc.polkadot.io` |
 | `previewnet` | zombienet, a step ahead of paseo | whatever host-papp's `SS_PREVIEW_STAGE_ENDPOINTS` resolves to, today `wss://previewnet.substrate.dev/people` |
 
-Keyed the same way as `BULLETIN_RPCS` in `@parity/product-sdk-host`.
+Keyed the same way as `BULLETIN_RPCS` in `@parity/product-sdk-host`. There is deliberately no
+`devnet` key: that people chain has a statement store, but no endpoint for it is published here, and
+no phone build pairs against it. Pass `endpoints` explicitly to reach one.
 
 Pairing only works when the terminal and the phone are on the **same** people chain, and the phone
 picks its chain per build flavour. The Polkadot app's nightly build uses `paseo`, which is why that

--- a/product-sdk/packages/terminal/manual-tests/qr-createtransaction.mjs
+++ b/product-sdk/packages/terminal/manual-tests/qr-createtransaction.mjs
@@ -64,15 +64,19 @@ const STEP_TIMEOUT_MS = 120_000;
 
 // The statement-store "people" chain that relays the pairing handshake. The CLI
 // and your phone MUST be on the same one or authenticate() will time out.
-// Select with SS_STAGE=paseoNextV2|previewnet|stable, or pass raw URLs via
+// Select with SS_STAGE=paseo|previewnet|stable, or pass raw URLs via
 // SS_ENDPOINTS.
 const SS_STAGES = {
     ...StatementStoreNetworks,
     stable: SS_STABLE_STAGE_ENDPOINTS,
 };
+const SS_STAGE = process.env.SS_STAGE ?? "paseo";
+if (!Object.hasOwn(SS_STAGES, SS_STAGE)) {
+    throw new Error(`Unknown SS_STAGE "${SS_STAGE}". Use one of: ${Object.keys(SS_STAGES).join(", ")}`);
+}
 const ENDPOINTS = process.env.SS_ENDPOINTS
     ? process.env.SS_ENDPOINTS.split(",").map((s) => s.trim())
-    : (SS_STAGES[process.env.SS_STAGE ?? "paseoNextV2"] ?? StatementStoreNetworks.paseoNextV2);
+    : SS_STAGES[SS_STAGE];
 
 const storageDir = process.env.STORAGE_DIR ?? mkdtempSync(join(tmpdir(), "terminal-ct-"));
 const isReplay = Boolean(process.env.STORAGE_DIR) && existsSync(storageDir);

--- a/product-sdk/packages/terminal/manual-tests/qr-createtransaction.mjs
+++ b/product-sdk/packages/terminal/manual-tests/qr-createtransaction.mjs
@@ -46,12 +46,12 @@ import {
     createSessionSigner,
     createTerminalAdapter,
     renderQrCode,
-    SS_STABLE_STAGE_ENDPOINTS,
-    StatementStoreNetworks,
     waitForSessions,
 } from "@parity/product-sdk-terminal";
 import { getWsProvider } from "@polkadot-api/ws-provider";
 import { Binary, createClient } from "polkadot-api";
+
+import { resolveEndpoints } from "./stages.mjs";
 
 const APP_ID = "terminal-ct-manual-test";
 // The mobile app FETCHES this URL during pairing and decodes it as
@@ -62,21 +62,8 @@ const META_URL = process.env.METADATA_URL ?? "https://example.com/metadata.json"
 const CHAIN_WS = process.env.CHAIN_WS ?? "wss://paseo-asset-hub-next-rpc.polkadot.io";
 const STEP_TIMEOUT_MS = 120_000;
 
-// The statement-store "people" chain that relays the pairing handshake. The CLI
-// and your phone MUST be on the same one or authenticate() will time out.
-// Select with SS_STAGE=paseo|previewnet|stable, or pass raw URLs via
-// SS_ENDPOINTS.
-const SS_STAGES = {
-    ...StatementStoreNetworks,
-    stable: SS_STABLE_STAGE_ENDPOINTS,
-};
-const SS_STAGE = process.env.SS_STAGE ?? "paseo";
-if (!Object.hasOwn(SS_STAGES, SS_STAGE)) {
-    throw new Error(`Unknown SS_STAGE "${SS_STAGE}". Use one of: ${Object.keys(SS_STAGES).join(", ")}`);
-}
-const ENDPOINTS = process.env.SS_ENDPOINTS
-    ? process.env.SS_ENDPOINTS.split(",").map((s) => s.trim())
-    : SS_STAGES[SS_STAGE];
+// Select with SS_STAGE=paseo|previewnet|stable, or pass raw URLs via SS_ENDPOINTS.
+const ENDPOINTS = resolveEndpoints();
 
 const storageDir = process.env.STORAGE_DIR ?? mkdtempSync(join(tmpdir(), "terminal-ct-"));
 const isReplay = Boolean(process.env.STORAGE_DIR) && existsSync(storageDir);

--- a/product-sdk/packages/terminal/manual-tests/qr-createtransaction.mjs
+++ b/product-sdk/packages/terminal/manual-tests/qr-createtransaction.mjs
@@ -46,12 +46,10 @@ import {
     createSessionSigner,
     createTerminalAdapter,
     renderQrCode,
-    SS_PASEO_STABLE_STAGE_ENDPOINTS,
     SS_STABLE_STAGE_ENDPOINTS,
+    StatementStoreNetworks,
     waitForSessions,
 } from "@parity/product-sdk-terminal";
-// Preview-stage statement store isn't re-exported by the terminal package; pull it from host-papp.
-import { SS_PREVIEW_STAGE_ENDPOINTS } from "@novasamatech/host-papp";
 import { getWsProvider } from "@polkadot-api/ws-provider";
 import { Binary, createClient } from "polkadot-api";
 
@@ -66,15 +64,15 @@ const STEP_TIMEOUT_MS = 120_000;
 
 // The statement-store "people" chain that relays the pairing handshake. The CLI
 // and your phone MUST be on the same one or authenticate() will time out.
-// Select with SS_STAGE=paseo|stable|preview, or pass raw URLs via SS_ENDPOINTS.
+// Select with SS_STAGE=paseoNextV2|previewnet|stable, or pass raw URLs via
+// SS_ENDPOINTS.
 const SS_STAGES = {
-    paseo: SS_PASEO_STABLE_STAGE_ENDPOINTS,
+    ...StatementStoreNetworks,
     stable: SS_STABLE_STAGE_ENDPOINTS,
-    preview: SS_PREVIEW_STAGE_ENDPOINTS,
 };
 const ENDPOINTS = process.env.SS_ENDPOINTS
     ? process.env.SS_ENDPOINTS.split(",").map((s) => s.trim())
-    : (SS_STAGES[process.env.SS_STAGE ?? "paseo"] ?? SS_PASEO_STABLE_STAGE_ENDPOINTS);
+    : (SS_STAGES[process.env.SS_STAGE ?? "paseoNextV2"] ?? StatementStoreNetworks.paseoNextV2);
 
 const storageDir = process.env.STORAGE_DIR ?? mkdtempSync(join(tmpdir(), "terminal-ct-"));
 const isReplay = Boolean(process.env.STORAGE_DIR) && existsSync(storageDir);

--- a/product-sdk/packages/terminal/manual-tests/qr-pair-and-sign.mjs
+++ b/product-sdk/packages/terminal/manual-tests/qr-pair-and-sign.mjs
@@ -135,7 +135,7 @@ try {
     adapter = createTerminalAdapter({
         appId: APP_ID,
         metadataUrl: META_URL,
-        endpoints: StatementStoreNetworks.paseoNextV2,
+        endpoints: StatementStoreNetworks.paseo,
         storageDir,
     });
     ok(`adapter.appId === "${adapter.appId}"`);

--- a/product-sdk/packages/terminal/manual-tests/qr-pair-and-sign.mjs
+++ b/product-sdk/packages/terminal/manual-tests/qr-pair-and-sign.mjs
@@ -79,7 +79,7 @@ import {
     createSessionSigner,
     createTerminalAdapter,
     renderQrCode,
-    SS_PASEO_STABLE_STAGE_ENDPOINTS,
+    StatementStoreNetworks,
     waitForSessions,
 } from "@parity/product-sdk-terminal";
 
@@ -135,7 +135,7 @@ try {
     adapter = createTerminalAdapter({
         appId: APP_ID,
         metadataUrl: META_URL,
-        endpoints: SS_PASEO_STABLE_STAGE_ENDPOINTS,
+        endpoints: StatementStoreNetworks.paseoNextV2,
         storageDir,
     });
     ok(`adapter.appId === "${adapter.appId}"`);

--- a/product-sdk/packages/terminal/manual-tests/qr-pair-and-sign.mjs
+++ b/product-sdk/packages/terminal/manual-tests/qr-pair-and-sign.mjs
@@ -79,13 +79,16 @@ import {
     createSessionSigner,
     createTerminalAdapter,
     renderQrCode,
-    StatementStoreNetworks,
     waitForSessions,
 } from "@parity/product-sdk-terminal";
+
+import { resolveEndpoints } from "./stages.mjs";
 
 const APP_ID = "terminal-manual-test";
 const META_URL = "https://example.com/metadata.json";
 const STEP_TIMEOUT_MS = 120_000; // 2 min per interactive step
+// Select with SS_STAGE=paseo|previewnet|stable, or pass raw URLs via SS_ENDPOINTS.
+const ENDPOINTS = resolveEndpoints();
 
 const storageDir = process.env.STORAGE_DIR ?? mkdtempSync(join(tmpdir(), "terminal-manual-"));
 const isReplay = Boolean(process.env.STORAGE_DIR) && existsSync(storageDir);
@@ -135,7 +138,7 @@ try {
     adapter = createTerminalAdapter({
         appId: APP_ID,
         metadataUrl: META_URL,
-        endpoints: StatementStoreNetworks.paseo,
+        endpoints: ENDPOINTS,
         storageDir,
     });
     ok(`adapter.appId === "${adapter.appId}"`);

--- a/product-sdk/packages/terminal/manual-tests/stages.mjs
+++ b/product-sdk/packages/terminal/manual-tests/stages.mjs
@@ -1,0 +1,29 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Statement-store endpoint selection shared by the manual scripts.
+ *
+ * The CLI and the phone must be on the same people chain or authenticate()
+ * times out after two minutes with nothing explaining why, so an unknown
+ * SS_STAGE throws rather than falling back to a chain the phone is not on.
+ */
+import { SS_STABLE_STAGE_ENDPOINTS, StatementStoreNetworks } from "@parity/product-sdk-terminal";
+
+const SS_STAGES = {
+    ...StatementStoreNetworks,
+    stable: SS_STABLE_STAGE_ENDPOINTS,
+};
+
+export const STAGE_NAMES = Object.keys(SS_STAGES);
+
+/** Endpoints from SS_ENDPOINTS if set, else the SS_STAGE preset, default `paseo`. */
+export function resolveEndpoints() {
+    if (process.env.SS_ENDPOINTS) {
+        return process.env.SS_ENDPOINTS.split(",").map((s) => s.trim());
+    }
+    const stage = process.env.SS_STAGE ?? "paseo";
+    if (!Object.hasOwn(SS_STAGES, stage)) {
+        throw new Error(`Unknown SS_STAGE "${stage}". Use one of: ${STAGE_NAMES.join(", ")}`);
+    }
+    return SS_STAGES[stage];
+}

--- a/product-sdk/packages/terminal/src/adapter.ts
+++ b/product-sdk/packages/terminal/src/adapter.ts
@@ -25,7 +25,7 @@ const log = createLogger("terminal");
 export interface TerminalAdapterOptions {
     /** Unique app identifier. Used as the storage namespace. */
     appId: string;
-    /** Statement store WebSocket endpoints. Defaults to {@link StatementStoreNetworks.paseoNextV2}. */
+    /** Statement store WebSocket endpoints. Defaults to {@link StatementStoreNetworks.paseo}. */
     endpoints?: string[];
     /** Optional host metadata for the Sign-In screen. */
     hostMetadata?: HostMetadata;
@@ -90,7 +90,7 @@ export type TerminalAdapter = PappAdapter & {
 };
 
 export function createTerminalAdapter(options: TerminalAdapterOptions): TerminalAdapter {
-    const endpoints = options.endpoints ?? StatementStoreNetworks.paseoNextV2;
+    const endpoints = options.endpoints ?? StatementStoreNetworks.paseo;
 
     const storage = createNodeStorageAdapter(options.appId, options.storageDir);
     // ws-provider 0.9 takes endpoints positionally; relies on the global

--- a/product-sdk/packages/terminal/src/adapter.ts
+++ b/product-sdk/packages/terminal/src/adapter.ts
@@ -7,13 +7,7 @@
  * transport layers, enabling QR login, attestation, and signing in
  * terminal/CLI environments.
  */
-import {
-    createPappAdapter,
-    type PappAdapter,
-    type HostMetadata,
-    SS_STABLE_STAGE_ENDPOINTS,
-    SS_PASEO_STABLE_STAGE_ENDPOINTS,
-} from "@novasamatech/host-papp";
+import { createPappAdapter, type PappAdapter, type HostMetadata } from "@novasamatech/host-papp";
 import {
     createLazyClient,
     createPapiStatementStoreAdapter,
@@ -22,6 +16,7 @@ import {
 import { createLogger } from "@parity/product-sdk-logger";
 import { getWsProvider } from "@polkadot-api/ws-provider";
 
+import { StatementStoreNetworks } from "./networks.js";
 import { createNodeStorageAdapter } from "./node-storage.js";
 
 const log = createLogger("terminal");
@@ -30,7 +25,7 @@ const log = createLogger("terminal");
 export interface TerminalAdapterOptions {
     /** Unique app identifier. Used as the storage namespace. */
     appId: string;
-    /** Statement store WebSocket endpoints. Defaults to Paseo stable endpoints. */
+    /** Statement store WebSocket endpoints. Defaults to {@link StatementStoreNetworks.paseoNextV2}. */
     endpoints?: string[];
     /** Optional host metadata for the Sign-In screen. */
     hostMetadata?: HostMetadata;
@@ -95,7 +90,7 @@ export type TerminalAdapter = PappAdapter & {
 };
 
 export function createTerminalAdapter(options: TerminalAdapterOptions): TerminalAdapter {
-    const endpoints = options.endpoints ?? SS_PASEO_STABLE_STAGE_ENDPOINTS;
+    const endpoints = options.endpoints ?? StatementStoreNetworks.paseoNextV2;
 
     const storage = createNodeStorageAdapter(options.appId, options.storageDir);
     // ws-provider 0.9 takes endpoints positionally; relies on the global
@@ -673,5 +668,3 @@ if (import.meta.vitest) {
         });
     });
 }
-
-export { SS_STABLE_STAGE_ENDPOINTS, SS_PASEO_STABLE_STAGE_ENDPOINTS };

--- a/product-sdk/packages/terminal/src/index.ts
+++ b/product-sdk/packages/terminal/src/index.ts
@@ -1,12 +1,9 @@
 // Copyright 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 // Terminal Adapter
-export {
-    createTerminalAdapter,
-    isBenignTeardownError,
-    SS_STABLE_STAGE_ENDPOINTS,
-    SS_PASEO_STABLE_STAGE_ENDPOINTS,
-} from "./adapter.js";
+export { createTerminalAdapter, isBenignTeardownError } from "./adapter.js";
+export { StatementStoreNetworks, SS_STABLE_STAGE_ENDPOINTS } from "./networks.js";
+export type { StatementStoreEnvironment } from "./networks.js";
 export type { TerminalAdapterOptions, TerminalAdapter } from "./adapter.js";
 
 // Session Signer

--- a/product-sdk/packages/terminal/src/networks.test.ts
+++ b/product-sdk/packages/terminal/src/networks.test.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Guards the statement store endpoints terminal exposes.
+ *
+ * The endpoint names were listed in both `adapter.ts` and `index.ts` and the
+ * lists drifted from the live chains (#365). These tests pin the values on the
+ * public surface and pin which one the adapter defaults to, so a repointed
+ * default fails here rather than at a consumer's runtime.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SS_PREVIEW_STAGE_ENDPOINTS } from "@novasamatech/host-papp";
+import { getWsProvider } from "@polkadot-api/ws-provider";
+import { describe, expect, test, vi } from "vitest";
+
+import { createTerminalAdapter, StatementStoreNetworks } from "./index.js";
+
+// The provider is called as a function by the PAPI raw client, so the mock has
+// to return one rather than a plain object.
+vi.mock("@polkadot-api/ws-provider", () => ({
+    getWsProvider: vi.fn(() => () => ({ send: () => {}, disconnect: () => {} })),
+}));
+
+describe("StatementStoreNetworks", () => {
+    test("paseoNextV2 names the live Paseo people chain", () => {
+        expect(StatementStoreNetworks.paseoNextV2).toEqual([
+            "wss://paseo-people-next-system-rpc.polkadot.io",
+        ]);
+    });
+
+    test("previewnet re-exposes the host-papp constant", () => {
+        expect(StatementStoreNetworks.previewnet).toEqual(SS_PREVIEW_STAGE_ENDPOINTS);
+    });
+});
+
+describe("createTerminalAdapter", () => {
+    test("defaults to paseoNextV2 when no endpoints are given", () => {
+        const storageDir = mkdtempSync(join(tmpdir(), "terminal-networks-"));
+
+        createTerminalAdapter({ appId: "networks-test", storageDir });
+
+        expect(getWsProvider).toHaveBeenCalledWith(
+            StatementStoreNetworks.paseoNextV2,
+            expect.anything(),
+        );
+    });
+});

--- a/product-sdk/packages/terminal/src/networks.test.ts
+++ b/product-sdk/packages/terminal/src/networks.test.ts
@@ -1,12 +1,8 @@
 // Copyright 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Guards the statement store endpoints terminal exposes.
- *
- * The endpoint names were listed in both `adapter.ts` and `index.ts` and the
- * lists drifted from the live chains (#365). These tests pin the values on the
- * public surface and pin which one the adapter defaults to, so a repointed
- * default fails here rather than at a consumer's runtime.
+ * The endpoint names were listed in both `adapter.ts` and `index.ts` and drifted
+ * from the live chains (#365), so these pin the values and the adapter's default.
  */
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -18,15 +14,14 @@ import { describe, expect, test, vi } from "vitest";
 
 import { createTerminalAdapter, StatementStoreNetworks } from "./index.js";
 
-// The provider is called as a function by the PAPI raw client, so the mock has
-// to return one rather than a plain object.
+// The PAPI raw client calls the provider, so the mock must return a function.
 vi.mock("@polkadot-api/ws-provider", () => ({
     getWsProvider: vi.fn(() => () => ({ send: () => {}, disconnect: () => {} })),
 }));
 
 describe("StatementStoreNetworks", () => {
-    test("paseoNextV2 names the live Paseo people chain", () => {
-        expect(StatementStoreNetworks.paseoNextV2).toEqual([
+    test("paseo names the live Paseo people chain", () => {
+        expect(StatementStoreNetworks.paseo).toEqual([
             "wss://paseo-people-next-system-rpc.polkadot.io",
         ]);
     });
@@ -37,14 +32,11 @@ describe("StatementStoreNetworks", () => {
 });
 
 describe("createTerminalAdapter", () => {
-    test("defaults to paseoNextV2 when no endpoints are given", () => {
+    test("defaults to paseo when no endpoints are given", () => {
         const storageDir = mkdtempSync(join(tmpdir(), "terminal-networks-"));
 
         createTerminalAdapter({ appId: "networks-test", storageDir });
 
-        expect(getWsProvider).toHaveBeenCalledWith(
-            StatementStoreNetworks.paseoNextV2,
-            expect.anything(),
-        );
+        expect(getWsProvider).toHaveBeenCalledWith(StatementStoreNetworks.paseo, expect.anything());
     });
 });

--- a/product-sdk/packages/terminal/src/networks.test.ts
+++ b/product-sdk/packages/terminal/src/networks.test.ts
@@ -4,14 +4,15 @@
  * The endpoint names were listed in both `adapter.ts` and `index.ts` and drifted
  * from the live chains (#365), so these pin the values and the adapter's default.
  */
-import { mkdtempSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { SS_PREVIEW_STAGE_ENDPOINTS } from "@novasamatech/host-papp";
 import { getWsProvider } from "@polkadot-api/ws-provider";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import type { TerminalAdapter } from "./index.js";
 import { createTerminalAdapter, StatementStoreNetworks } from "./index.js";
 
 // The PAPI raw client calls the provider, so the mock must return a function.
@@ -32,10 +33,20 @@ describe("StatementStoreNetworks", () => {
 });
 
 describe("createTerminalAdapter", () => {
-    test("defaults to paseo when no endpoints are given", () => {
-        const storageDir = mkdtempSync(join(tmpdir(), "terminal-networks-"));
+    let storageDir: string;
+    let adapter: TerminalAdapter | undefined;
 
-        createTerminalAdapter({ appId: "networks-test", storageDir });
+    beforeEach(async () => {
+        storageDir = await mkdtemp(join(tmpdir(), "terminal-networks-"));
+    });
+
+    afterEach(async () => {
+        await adapter?.destroy();
+        await rm(storageDir, { recursive: true, force: true });
+    });
+
+    test("defaults to paseo when no endpoints are given", () => {
+        adapter = createTerminalAdapter({ appId: "networks-test", storageDir });
 
         expect(getWsProvider).toHaveBeenCalledWith(StatementStoreNetworks.paseo, expect.anything());
     });

--- a/product-sdk/packages/terminal/src/networks.ts
+++ b/product-sdk/packages/terminal/src/networks.ts
@@ -1,29 +1,27 @@
 // Copyright 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Statement store networks terminal can pair against.
+ * Statement store networks terminal can pair against, keyed as `BULLETIN_RPCS`
+ * in `@parity/product-sdk-host`, where `paseo` is Paseo Next v2.
  *
- * Both sides of a pairing must sit on the same people chain, so the value here
- * has to match the chain the phone is on. The Polkadot app's nightly build uses
- * `paseoNextV2`, which is why it is the default.
+ * Both sides of a pairing must sit on the same people chain. The Polkadot app's
+ * nightly build uses `paseo`, which is why it is the default.
  */
 import { SS_PREVIEW_STAGE_ENDPOINTS, SS_STABLE_STAGE_ENDPOINTS } from "@novasamatech/host-papp";
 
 export const StatementStoreNetworks = {
-    // Written out because host-papp has no constant for this host: its
-    // `SS_PASEO_STABLE_STAGE_ENDPOINTS` still names the pre-rename chain.
-    paseoNextV2: ["wss://paseo-people-next-system-rpc.polkadot.io"],
+    // host-papp has no constant for this host; its `SS_PASEO_STABLE_STAGE_ENDPOINTS`
+    // still names the pre-rename chain.
+    paseo: ["wss://paseo-people-next-system-rpc.polkadot.io"],
     previewnet: SS_PREVIEW_STAGE_ENDPOINTS,
 } satisfies Record<string, string[]>;
 
 /**
- * Resolves but refuses connections from outside the Parity network, which is
- * consistent with it being internal-only rather than gone. Kept exported until
- * it has been retested on VPN (#365).
+ * Refuses connections from outside the Parity network rather than being gone.
+ * Kept exported until it has been retested on VPN (#365).
  */
 export { SS_STABLE_STAGE_ENDPOINTS };
 
-/** Network keys with built-in endpoints in {@link StatementStoreNetworks}. */
 export type StatementStoreEnvironment = keyof typeof StatementStoreNetworks;
 
 if (import.meta.vitest) {
@@ -39,8 +37,8 @@ if (import.meta.vitest) {
             }
         });
 
-        test("paseoNextV2 names the system-slot people chain", () => {
-            expect(StatementStoreNetworks.paseoNextV2).toEqual([
+        test("paseo names the system-slot people chain", () => {
+            expect(StatementStoreNetworks.paseo).toEqual([
                 "wss://paseo-people-next-system-rpc.polkadot.io",
             ]);
         });

--- a/product-sdk/packages/terminal/src/networks.ts
+++ b/product-sdk/packages/terminal/src/networks.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Statement store networks terminal can pair against.
+ *
+ * Both sides of a pairing must sit on the same people chain, so the value here
+ * has to match the chain the phone is on. The Polkadot app's nightly build uses
+ * `paseoNextV2`, which is why it is the default.
+ */
+import { SS_PREVIEW_STAGE_ENDPOINTS, SS_STABLE_STAGE_ENDPOINTS } from "@novasamatech/host-papp";
+
+export const StatementStoreNetworks = {
+    // Written out because host-papp has no constant for this host: its
+    // `SS_PASEO_STABLE_STAGE_ENDPOINTS` still names the pre-rename chain.
+    paseoNextV2: ["wss://paseo-people-next-system-rpc.polkadot.io"],
+    previewnet: SS_PREVIEW_STAGE_ENDPOINTS,
+} satisfies Record<string, string[]>;
+
+/**
+ * Resolves but refuses connections from outside the Parity network, which is
+ * consistent with it being internal-only rather than gone. Kept exported until
+ * it has been retested on VPN (#365).
+ */
+export { SS_STABLE_STAGE_ENDPOINTS };
+
+/** Network keys with built-in endpoints in {@link StatementStoreNetworks}. */
+export type StatementStoreEnvironment = keyof typeof StatementStoreNetworks;
+
+if (import.meta.vitest) {
+    const { describe, test, expect } = import.meta.vitest;
+
+    describe("StatementStoreNetworks", () => {
+        test("every network has at least one wss endpoint", () => {
+            for (const endpoints of Object.values(StatementStoreNetworks)) {
+                expect(endpoints.length).toBeGreaterThan(0);
+                for (const endpoint of endpoints) {
+                    expect(endpoint).toMatch(/^wss:\/\//);
+                }
+            }
+        });
+
+        test("paseoNextV2 names the system-slot people chain", () => {
+            expect(StatementStoreNetworks.paseoNextV2).toEqual([
+                "wss://paseo-people-next-system-rpc.polkadot.io",
+            ]);
+        });
+    });
+}

--- a/product-sdk/packages/terminal/src/networks.ts
+++ b/product-sdk/packages/terminal/src/networks.ts
@@ -22,6 +22,7 @@ export const StatementStoreNetworks = {
  */
 export { SS_STABLE_STAGE_ENDPOINTS };
 
+/** Network keys with built-in endpoints in {@link StatementStoreNetworks}. */
 export type StatementStoreEnvironment = keyof typeof StatementStoreNetworks;
 
 if (import.meta.vitest) {

--- a/product-sdk/packages/terminal/tsup.config.ts
+++ b/product-sdk/packages/terminal/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     dts: true,
     sourcemap: true,
     clean: true,
+    treeshake: true,
     target: "es2022",
     define: {
         "import.meta.vitest": "undefined",

--- a/product-sdk/pending-changesets/terminal-statement-store-endpoints.md
+++ b/product-sdk/pending-changesets/terminal-statement-store-endpoints.md
@@ -1,0 +1,36 @@
+---
+"@parity/product-sdk-terminal": minor
+---
+
+**Default to a statement store endpoint that resolves (#365).**
+
+`createTerminalAdapter({ appId })` with no `endpoints` could not reach a statement store at all. Its
+default was `SS_PASEO_STABLE_STAGE_ENDPOINTS`, whose host has no A record. The Paseo people chain it
+names is not down: it moved to the system slot and its RPC gained a `-system-` segment. host-papp
+has not followed, and that constant is unchanged from 0.6.17 through 0.10.0.
+
+The new default is `wss://paseo-people-next-system-rpc.polkadot.io`, which is the chain the Polkadot
+app's nightly build connects to, and the one this repo's own `paseo-individuality` descriptor has
+addressed all along.
+
+**New: `StatementStoreNetworks`**, replacing the flat endpoint constants.
+
+| Key | Endpoint |
+| --- | --- |
+| `paseoNextV2` | `wss://paseo-people-next-system-rpc.polkadot.io` |
+| `previewnet` | `wss://previewnet.substrate.dev/people` |
+
+`previewnet` was live before this change and was not re-exported, so reaching it meant importing
+from `@novasamatech/host-papp` directly. `StatementStoreEnvironment` is exported as its key type.
+
+**Removed: `SS_PASEO_STABLE_STAGE_ENDPOINTS`.** Minor rather than patch, because surface is removed,
+which on 0.x signals a breaking change. Nothing was reachable through it, so any caller passing it
+as `endpoints` was already unable to connect; replace it with `StatementStoreNetworks.paseoNextV2`.
+
+`SS_STABLE_STAGE_ENDPOINTS` is still exported. It resolves but refuses connections from outside the
+Parity network, which fits an internal-only host rather than a retired one, so it is kept until it
+has been retested on VPN.
+
+**Pairing needs both sides on the same chain**, and the pairing handshake does not carry one. The
+phone picks its people chain per build flavour, so a preview-flavour phone still needs
+`endpoints: StatementStoreNetworks.previewnet` passed explicitly.

--- a/product-sdk/pending-changesets/terminal-statement-store-endpoints.md
+++ b/product-sdk/pending-changesets/terminal-statement-store-endpoints.md
@@ -5,9 +5,9 @@
 **Default to a statement store endpoint that resolves (#365).**
 
 `createTerminalAdapter({ appId })` with no `endpoints` could not reach a statement store at all. Its
-default was `SS_PASEO_STABLE_STAGE_ENDPOINTS`, whose host has no A record. The Paseo people chain it
-names is not down: it moved to the system slot and its RPC gained a `-system-` segment. host-papp
-has not followed, and that constant is unchanged from 0.6.17 through 0.10.0.
+default was `SS_PASEO_STABLE_STAGE_ENDPOINTS`, whose hostname no longer exists. The Paseo people
+chain it names is not down: it moved to the system slot and its RPC gained a `-system-` segment.
+host-papp has not followed, and that constant is unchanged from 0.6.17 through 0.10.0.
 
 The new default is `wss://paseo-people-next-system-rpc.polkadot.io`, which is the chain the Polkadot
 app's nightly build connects to, and the one this repo's own `paseo-individuality` descriptor has

--- a/product-sdk/pending-changesets/terminal-statement-store-endpoints.md
+++ b/product-sdk/pending-changesets/terminal-statement-store-endpoints.md
@@ -15,9 +15,11 @@ addressed all along.
 
 **New: `StatementStoreNetworks`**, replacing the flat endpoint constants.
 
+Keys match `BULLETIN_RPCS` in `@parity/product-sdk-host`, so one network has one name across the SDK.
+
 | Key | Endpoint |
 | --- | --- |
-| `paseoNextV2` | `wss://paseo-people-next-system-rpc.polkadot.io` |
+| `paseo` | `wss://paseo-people-next-system-rpc.polkadot.io` |
 | `previewnet` | `wss://previewnet.substrate.dev/people` |
 
 `previewnet` was live before this change and was not re-exported, so reaching it meant importing
@@ -25,7 +27,7 @@ from `@novasamatech/host-papp` directly. `StatementStoreEnvironment` is exported
 
 **Removed: `SS_PASEO_STABLE_STAGE_ENDPOINTS`.** Minor rather than patch, because surface is removed,
 which on 0.x signals a breaking change. Nothing was reachable through it, so any caller passing it
-as `endpoints` was already unable to connect; replace it with `StatementStoreNetworks.paseoNextV2`.
+as `endpoints` was already unable to connect; replace it with `StatementStoreNetworks.paseo`.
 
 `SS_STABLE_STAGE_ENDPOINTS` is still exported. It resolves but refuses connections from outside the
 Parity network, which fits an internal-only host rather than a retired one, so it is kept until it

--- a/product-sdk/pending-changesets/terminal-statement-store-endpoints.md
+++ b/product-sdk/pending-changesets/terminal-statement-store-endpoints.md
@@ -33,6 +33,9 @@ as `endpoints` was already unable to connect; replace it with `StatementStoreNet
 Parity network, which fits an internal-only host rather than a retired one, so it is kept until it
 has been retested on VPN.
 
+**Smaller published bundle.** `treeshake` is now on, dropping the in-source test blocks that shipped
+as dead code. `dist/index.js` goes from 50,146 to 13,335 bytes, with every export unchanged.
+
 **Pairing needs both sides on the same chain**, and the pairing handshake does not carry one. The
 phone picks its people chain per build flavour, so a preview-flavour phone still needs
 `endpoints: StatementStoreNetworks.previewnet` passed explicitly.

--- a/product-sdk/skills/product-sdk-transactions/SKILL.md
+++ b/product-sdk/skills/product-sdk-transactions/SKILL.md
@@ -249,6 +249,7 @@ signer.
 
 ```ts
 import { createAuthClient, resolveSigner } from "@parity/product-sdk-auth";
+import { StatementStoreNetworks } from "@parity/product-sdk-terminal";
 import { submitAndWatch } from "@parity/product-sdk-tx";
 
 // 1. Bind an auth client to your product's config (inject per-product values).
@@ -256,7 +257,7 @@ const authClient = createAuthClient({
   dappId: "playground",              // scopes ~/.polkadot-apps/${dappId}_* + SSO pairing
   productId: "playground.dot",       // derives the product account
   derivationIndex: 0,                // 0 = default product account
-  peopleEndpoints: ["wss://<people-rpc>"],
+  peopleEndpoints: StatementStoreNetworks.paseo, // or .previewnet
 });
 
 // 2. Get a PolkadotSigner — dev SURI if provided, else the persisted QR session.


### PR DESCRIPTION
Closes #365

### Description

`createTerminalAdapter({ appId })` with no `endpoints` could not reach a statement store: the default named `paseo-people-next-rpc.polkadot.io`, a hostname that stopped existing when the Paseo people chain moved to the system slot. This points it at the live chain and replaces the two hand-maintained endpoint lists with one exported map.

### Changes

- New `src/networks.ts` exports `StatementStoreNetworks` (`paseo`, `previewnet`), keyed like `BULLETIN_RPCS` in `@parity/product-sdk-host`.
- Removes `SS_PASEO_STABLE_STAGE_ENDPOINTS`, the breaking part and why the changeset is a minor. Nothing was reachable through it.
- Both manual scripts share `manual-tests/stages.mjs`, and an unknown `SS_STAGE` throws instead of pairing against the wrong chain.
- `tsup.config.ts` gains `treeshake: true`: `dist/index.js` drops from 50,146 to 13,335 bytes, all 27 exports unchanged.

### Testing

Before, `dig +short paseo-people-next-rpc.polkadot.io A` returned nothing, so pairing timed out after two minutes with no explanation. After, from `packages/terminal`:

```bash
npx vitest run                                    # 14 files, 187 tests
SS_STAGE=preview node manual-tests/qr-createtransaction.mjs
# Error: Unknown SS_STAGE "preview". Use one of: paseo, previewnet, stable
```

Workspace build, typecheck and biome are clean over 352 files. A live socket from the built `StatementStoreNetworks.paseo` answers with `statement_submit`, and a nightly phone paired against it, logging `[SOCKET][CONNECTED] wss://paseo-people-next-system-rpc.polkadot.io` and `specName: next-people-paseo`.