### PR TITLE
ci(docs): decouple Pages from Bulletin

### DIFF
--- a/.github/scripts/check-docs-deploy.sh
+++ b/.github/scripts/check-docs-deploy.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# docs-deploy.yml runs on release days only, so these are its regression tests.
+set -u
+
+wf="${1:-.github/workflows/docs-deploy.yml}"
+rc=0
+
+# grep exits 2 on a missing file, which reads as "no match",
+# so without this the guard passes while checking nothing.
+if [ ! -f "$wf" ]; then
+    echo "::error::$wf not found. If the deploy workflow moved, point this guard at it."
+    exit 1
+fi
+
+bulletin_step="$(awk '
+    /- name: Deploy to Bulletin Chain/ { inside = 1; next }
+    inside && /^[[:space:]]*-[[:space:]]/ { exit }
+    inside { print }
+' "$wf")"
+
+# bulletin-deploy resolves the TLD from the target environment,
+# so a literal one breaks on every other.
+if grep -nE 'bulletin-deploy .*\.(dot|paseo|test)\b' "$wf"; then
+    echo "::error file=$wf,title=Deploy domain carries a TLD::Pass the bare label. The environment decides the suffix."
+    rc=1
+fi
+
+# Unpinned, an upstream release changes this workflow with no
+# commit here. A tag such as @latest is not a pin.
+if grep -nE 'npm (install|i) (-g|--global) [^[:space:]]+' "$wf" | grep -vE '@[0-9]'; then
+    echo "::error file=$wf,title=Global install is unpinned::Pin to a version, not a tag."
+    rc=1
+fi
+
+if ! printf '%s\n' "$bulletin_step" | grep -qE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$'; then
+    echo "::error file=$wf,title=A Bulletin failure can skip the Pages deploy::Set continue-on-error: true on the Bulletin step."
+    rc=1
+fi
+
+if ! grep -qE "steps\.bulletin\.outcome == 'failure'" "$wf"; then
+    echo "::error file=$wf,title=A Bulletin failure would be silent::Keep the step that re-raises steps.bulletin.outcome."
+    rc=1
+fi
+
+exit $rc

--- a/.github/scripts/check-docs-deploy.sh
+++ b/.github/scripts/check-docs-deploy.sh
@@ -37,6 +37,11 @@ if ! printf '%s\n' "$bulletin_step" | grep -qE '^[[:space:]]*continue-on-error:[
     rc=1
 fi
 
+if ! printf '%s\n' "$bulletin_step" | grep -qE '^[[:space:]]*id:[[:space:]]*bulletin[[:space:]]*$'; then
+    echo "::error file=$wf,title=The Bulletin step lost its id::The re-raise step reads steps.bulletin.outcome, so the step must keep id: bulletin."
+    rc=1
+fi
+
 if ! grep -qE "steps\.bulletin\.outcome == 'failure'" "$wf"; then
     echo "::error file=$wf,title=A Bulletin failure would be silent::Keep the step that re-raises steps.bulletin.outcome."
     rc=1

--- a/.github/scripts/check-docs-deploy.sh
+++ b/.github/scripts/check-docs-deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# docs-deploy.yml runs on release days only, so these are its regression tests.
+# docs-deploy.yml only runs on release days, so check it here instead.
 set -u
 
 wf="${1:-.github/workflows/docs-deploy.yml}"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -114,7 +114,7 @@ jobs:
             - name: Install bulletin-deploy
               # Pinned: an upstream change would otherwise surface only on a release day.
               # No automation bumps this, so check it if a release fails here.
-              run: npm install -g bulletin-deploy@0.15.2
+              run: npm install -g bulletin-deploy@0.17.1
 
             - name: Deploy to Bulletin Chain
               id: bulletin
@@ -122,8 +122,8 @@ jobs:
               continue-on-error: true
               uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
               with:
-                  timeout_minutes: 10
-                  max_attempts: 3
+                  timeout_minutes: 30
+                  max_attempts: 2
                   command: cd docs && bulletin-deploy ./out product-sdk --env paseo-next-v2 --js-merkle
 
             - name: Rebuild static site for GitHub Pages

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -7,7 +7,7 @@ name: "docs: Deploy (Bulletin + Pages)"
 #
 # `workflow_run` is flagged by zizmor as a dangerous trigger because it is
 # attacker-controllable on PRs from forks. We are safe here because the
-# `gate` step rejects any HEAD that does not carry a fresh umbrella tag,
+# `gate` job rejects any HEAD that does not carry a fresh umbrella tag,
 # so a malicious PR run that completes successfully still won't deploy
 # unless it also produces an `@parity/product-sdk@X.Y.Z` git tag — which
 # requires write access we don't grant to forks.
@@ -27,19 +27,11 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
-    deploy:
+    gate:
         if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
         runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            # Required by `actions/deploy-pages` to publish the static site.
-            pages: write
-            # Required by `actions/deploy-pages` to mint the OIDC token GitHub
-            # Pages uses to authenticate the deployment.
-            id-token: write
-        environment:
-            name: github-pages
-            url: ${{ steps.pages-deploy.outputs.page_url }}
+        outputs:
+            skip: ${{ steps.gate.outputs.skip }}
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
@@ -67,13 +59,31 @@ jobs:
                     echo "tag=$tag" >> $GITHUB_OUTPUT
                   fi
 
-            - if: steps.gate.outputs.skip != 'true'
-              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+    deploy:
+        needs: gate
+        # An `if:` cancels the implicit success() on `needs`; a negation here runs ungated.
+        if: needs.gate.outputs.skip == 'false'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            # Required by `actions/deploy-pages` to publish the static site.
+            pages: write
+            # Required by `actions/deploy-pages` to mint the OIDC token GitHub
+            # Pages uses to authenticate the deployment.
+            id-token: write
+        environment:
+            name: github-pages
+            url: ${{ steps.pages-deploy.outputs.page_url }}
+        steps:
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  persist-credentials: false
+
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
               with:
                   version: 10
 
-            - if: steps.gate.outputs.skip != 'true'
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: "22"
                   cache: "pnpm"
@@ -82,38 +92,34 @@ jobs:
                       docs/pnpm-lock.yaml
 
             - name: Install SDK deps
-              if: steps.gate.outputs.skip != 'true'
               working-directory: product-sdk
               run: pnpm install --frozen-lockfile
 
             - name: Build SDK packages
-              if: steps.gate.outputs.skip != 'true'
               working-directory: product-sdk
               run: pnpm build
 
             - name: Install docs deps
-              if: steps.gate.outputs.skip != 'true'
               working-directory: docs
               run: pnpm install --frozen-lockfile
 
             - name: Generate API Reference docs
-              if: steps.gate.outputs.skip != 'true'
               working-directory: docs
               run: pnpm docs:generate
 
             - name: Build static site
-              if: steps.gate.outputs.skip != 'true'
               working-directory: docs
               run: pnpm build
 
             - name: Install bulletin-deploy
-              if: steps.gate.outputs.skip != 'true'
               # Pinned: an upstream change would otherwise surface only on a release day.
               # No automation bumps this, so check it if a release fails here.
               run: npm install -g bulletin-deploy@0.15.2
 
             - name: Deploy to Bulletin Chain
-              if: steps.gate.outputs.skip != 'true'
+              id: bulletin
+              # Without this a Bulletin outage skips the Pages steps below.
+              continue-on-error: true
               uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
               with:
                   timeout_minutes: 10
@@ -121,23 +127,25 @@ jobs:
                   command: cd docs && bulletin-deploy ./out product-sdk --env paseo-next-v2 --js-merkle
 
             - name: Rebuild static site for GitHub Pages
-              if: steps.gate.outputs.skip != 'true'
               working-directory: docs
               env:
                   PAGES_BASE_PATH: /${{ github.event.repository.name }}
               run: pnpm build
 
             - name: Configure GitHub Pages
-              if: steps.gate.outputs.skip != 'true'
               uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
             - name: Upload Pages artifact
-              if: steps.gate.outputs.skip != 'true'
               uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
               with:
                   path: docs/out
 
             - name: Deploy to GitHub Pages
               id: pages-deploy
-              if: steps.gate.outputs.skip != 'true'
               uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+            - name: Fail if the Bulletin deploy failed
+              if: steps.bulletin.outcome == 'failure'
+              run: |
+                  echo "::error title=Bulletin deploy failed::GitHub Pages was published. Only the Bulletin Chain copy is stale."
+                  exit 1

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -32,6 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             skip: ${{ steps.gate.outputs.skip }}
+            sha: ${{ steps.gate.outputs.sha }}
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
@@ -47,6 +48,7 @@ jobs:
               env:
                   EVENT_NAME: ${{ github.event_name }}
               run: |
+                  echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
                   if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
                     echo "skip=false" >> $GITHUB_OUTPUT
                     exit 0
@@ -77,6 +79,10 @@ jobs:
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
+                  ref: ${{ needs.gate.outputs.sha }}
+                  # nextra dates each page from its commit, so a shallow clone
+                  # drops the Last updated line from every published page.
+                  fetch-depth: 0
                   persist-credentials: false
 
             - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
@@ -147,5 +153,5 @@ jobs:
             - name: Fail if the Bulletin deploy failed
               if: steps.bulletin.outcome == 'failure'
               run: |
-                  echo "::error title=Bulletin deploy failed::GitHub Pages was published. Only the Bulletin Chain copy is stale."
+                  echo "::error title=Bulletin deploy failed::GitHub Pages published. This job is red so the github-pages environment shows a failed deployment, but only the Bulletin Chain copy is stale."
                   exit 1

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -10,6 +10,7 @@ on:
             - "docs/**"
             - ".github/workflows/docs-verify.yml"
             - ".github/workflows/docs-deploy.yml"
+            - ".github/scripts/check-docs-deploy.sh"
     pull_request:
         branches: [main]
         paths:
@@ -17,6 +18,7 @@ on:
             - "docs/**"
             - ".github/workflows/docs-verify.yml"
             - ".github/workflows/docs-deploy.yml"
+            - ".github/scripts/check-docs-deploy.sh"
 
 # Read-only build: only needs to clone the repo to verify it builds.
 permissions:
@@ -79,30 +81,5 @@ jobs:
               with:
                   persist-credentials: false
 
-            - name: Check the deploy domain and the install pin
-              run: |
-                  wf=.github/workflows/docs-deploy.yml
-                  rc=0
-
-                  # grep exits 2 on a missing file, which reads as "no match",
-                  # so without this the guard passes while checking nothing.
-                  if [ ! -f "$wf" ]; then
-                    echo "::error::$wf not found. If the deploy workflow moved, point this guard at it."
-                    exit 1
-                  fi
-
-                  # bulletin-deploy resolves the TLD from the target environment,
-                  # so a literal one breaks on every other. Only release days run it.
-                  if grep -nE 'bulletin-deploy .*\.(dot|paseo|test)\b' "$wf"; then
-                    echo "::error file=$wf,title=Deploy domain carries a TLD::Pass the bare label. The environment decides the suffix."
-                    rc=1
-                  fi
-
-                  # Unpinned, an upstream release changes this workflow with no
-                  # commit here. A tag such as @latest is not a pin.
-                  if grep -nE 'npm (install|i) (-g|--global) [^[:space:]]+' "$wf" | grep -vE '@[0-9]'; then
-                    echo "::error file=$wf,title=Global install is unpinned::Pin to a version, not a tag."
-                    rc=1
-                  fi
-
-                  exit $rc
+            - name: Check the deploy workflow
+              run: bash .github/scripts/check-docs-deploy.sh


### PR DESCRIPTION
### Description

`docs-deploy.yml` publishes to the Bulletin Chain then GitHub Pages in one job, with nothing shielding the Pages steps from a Bulletin failure. Three release deploys failed at Bulletin and published nothing, so the public site has served the 0.21.0 build since 2026-08-07 against a main at 0.27.0. This makes the two targets independent and fixes both causes.

### Changes

`.github/workflows/docs-deploy.yml`
- Bulletin step is `continue-on-error` and a final step re-raises its outcome. Pages publishes either way, the run still goes red.
- The gate moves to its own job. Twelve per-step conditions go away, a run that deploys nothing reports `skipped` instead of `success`, and the deploy checkout is pinned to the gated SHA.
- `bulletin-deploy` 0.15.2 to 0.17.1. 0.15.2 predates the 2026-09-01 DotNS ABI change and calls a `PopRules.startingPrice()` that no longer exists on `paseo-next-v2`, which is what the 09-01 and 09-03 runs failed on.
- Retry budget 3 x 10 to 2 x 30 minutes. Same ceiling, but one attempt can now finish the 66.5 MB upload that timed out on the two 08-27 runs.

`.github/scripts/check-docs-deploy.sh` (new): the guard from `docs-verify.yml`, now runnable locally, plus assertions that the two properties above cannot be undone silently.

### Testing

The deploy runs only on a release or a dispatch, so the guard is what is testable.

```bash
git show main:.github/workflows/docs-deploy.yml > /tmp/before.yml
bash .github/scripts/check-docs-deploy.sh /tmp/before.yml   # exit 1, three errors
bash .github/scripts/check-docs-deploy.sh                   # exit 0
```

Nothing under `product-sdk/` changes, so the SDK and e2e suites are path-filtered out of this PR.

Nothing here runs on push. The site updates on the next release, or now with `gh workflow run "docs: Deploy (Bulletin + Pages)" --repo paritytech/product-sdk --ref main`. Pages publishes even if Bulletin still fails.